### PR TITLE
feat: 实现动态模型最大上下文容量配置

### DIFF
--- a/src/main/java/com/github/claudecodegui/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSDKToolWindow.java
@@ -91,11 +91,6 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
      */
     public static class ClaudeChatWindow {
         private static final String NODE_PATH_PROPERTY_KEY = "claude.code.node.path";
-        private static final Map<String, Integer> MODEL_CONTEXT_LIMITS = new java.util.HashMap<>();
-        static {
-            MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-5", 200_000);
-            MODEL_CONTEXT_LIMITS.put("claude-opus-4-5-20251101", 200_000);
-        }
 
         private final JPanel mainPanel;
         private final ClaudeSDKBridge claudeSDKBridge;
@@ -774,7 +769,10 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
                 int cacheReadTokens = lastUsage != null && lastUsage.has("cache_read_input_tokens") ? lastUsage.get("cache_read_input_tokens").getAsInt() : 0;
 
                 int usedTokens = inputTokens + cacheWriteTokens + cacheReadTokens;
-                int maxTokens = MODEL_CONTEXT_LIMITS.getOrDefault(currentModel, 200_000);
+                // 使用 HandlerContext 中的动态 maxTokens，如果不存在则使用默认值
+                int maxTokens = handlerContext.getCurrentModelMaxTokens() != null
+                    ? handlerContext.getCurrentModelMaxTokens()
+                    : 200_000;
                 int percentage = Math.min(100, maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0);
 
                 JsonObject usageUpdate = new JsonObject();
@@ -833,7 +831,10 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
                     callJavaScript("updateStatus", JsUtils.escapeJs("新会话已创建，可以开始提问"));
 
                     // 重置 Token 使用统计
-                    int maxTokens = MODEL_CONTEXT_LIMITS.getOrDefault(currentModel, 200_000);
+                    // 使用 HandlerContext 中的动态 maxTokens，如果不存在则使用默认值
+                    int maxTokens = handlerContext.getCurrentModelMaxTokens() != null
+                        ? handlerContext.getCurrentModelMaxTokens()
+                        : 200_000;
                     JsonObject usageUpdate = new JsonObject();
                     usageUpdate.addProperty("percentage", 0);
                     usageUpdate.addProperty("totalTokens", 0);

--- a/src/main/java/com/github/claudecodegui/handler/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/HandlerContext.java
@@ -25,6 +25,7 @@ public class HandlerContext {
     private ClaudeSession session;
     private JBCefBrowser browser;
     private String currentModel = "claude-sonnet-4-5";
+    private Integer currentModelMaxTokens = 200_000; // 默认 200K
     private String currentProvider = "claude";
     private volatile boolean disposed = false;
 
@@ -79,6 +80,10 @@ public class HandlerContext {
         return currentModel;
     }
 
+    public Integer getCurrentModelMaxTokens() {
+        return currentModelMaxTokens;
+    }
+
     public String getCurrentProvider() {
         return currentProvider;
     }
@@ -98,6 +103,10 @@ public class HandlerContext {
 
     public void setCurrentModel(String currentModel) {
         this.currentModel = currentModel;
+    }
+
+    public void setCurrentModelMaxTokens(Integer maxTokens) {
+        this.currentModelMaxTokens = maxTokens;
     }
 
     public void setCurrentProvider(String currentProvider) {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -566,7 +566,17 @@ const App = () => {
     } else if (currentProvider === 'codex') {
       setSelectedCodexModel(modelId);
     }
-    sendBridgeMessage('set_model', modelId);
+
+    // 获取模型配置（包含 maxTokens）
+    const models = currentProvider === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+    const modelInfo = models.find(m => m.id === modelId);
+    const maxTokens = modelInfo?.maxTokens || 200_000; // 默认 200K
+
+    // 发送模型和上下文容量
+    sendBridgeMessage('set_model', JSON.stringify({
+      model: modelId,
+      maxTokens: maxTokens
+    }));
   };
 
   /**
@@ -576,9 +586,16 @@ const App = () => {
     setCurrentProvider(providerId);
     sendBridgeMessage('set_provider', providerId);
 
-    // 切换 provider 时,同时发送对应的模型
+    // 切换 provider 时,同时发送对应的模型和上下文容量
     const newModel = providerId === 'codex' ? selectedCodexModel : selectedClaudeModel;
-    sendBridgeMessage('set_model', newModel);
+    const models = providerId === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+    const modelInfo = models.find(m => m.id === newModel);
+    const maxTokens = modelInfo?.maxTokens || 200_000; // 默认 200K
+
+    sendBridgeMessage('set_model', JSON.stringify({
+      model: newModel,
+      maxTokens: maxTokens
+    }));
   };
 
   const interruptSession = () => {

--- a/webview/src/components/ChatInputBox/TokenIndicator.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.tsx
@@ -1,5 +1,5 @@
-import { useTranslation } from 'react-i18next';
-import type { TokenIndicatorProps } from './types';
+import { useTranslation } from "react-i18next";
+import type { TokenIndicatorProps } from "./types";
 
 /**
  * TokenIndicator - 使用量圆环进度条组件
@@ -29,7 +29,7 @@ export const TokenIndicator = ({
     : `${rounded.toFixed(1)}%`;
 
   const formatTokens = (value?: number) => {
-    if (typeof value !== 'number' || !isFinite(value)) return undefined;
+    if (typeof value !== "number" || !isFinite(value)) return undefined;
     if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
     if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
     return `${value}`;
@@ -37,9 +37,10 @@ export const TokenIndicator = ({
 
   const usedText = formatTokens(usedTokens);
   const maxText = formatTokens(maxTokens);
-  const tooltip = usedText && maxText
-    ? `${formattedPercentage} · ${usedText} / ${maxText} ${t('chat.context')}`
-    : t('chat.usagePercentage', { percentage: formattedPercentage });
+  const tooltip =
+    usedText && maxText
+      ? `${formattedPercentage} · ${usedText} / ${maxText} ${t("chat.context")}`
+      : t("chat.usagePercentage", { percentage: formattedPercentage });
 
   return (
     <div className="token-indicator">
@@ -68,9 +69,7 @@ export const TokenIndicator = ({
           />
         </svg>
         {/* 悬停气泡 */}
-        <div className="token-tooltip">
-          {tooltip}
-        </div>
+        <div className="token-tooltip">{tooltip}</div>
       </div>
       <span className="token-percentage-label">{formattedPercentage}</span>
     </div>

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -25,11 +25,11 @@ export interface Attachment {
  * 图片媒体类型常量
  */
 export const IMAGE_MEDIA_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-  'image/svg+xml',
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
 ] as const;
 
 export type ImageMediaType = (typeof IMAGE_MEDIA_TYPES)[number];
@@ -49,11 +49,11 @@ export function isImageAttachment(attachment: Attachment): boolean {
  * 补全项类型
  */
 export type CompletionType =
-  | 'file'
-  | 'directory'
-  | 'command'
-  | 'separator'
-  | 'section-header';
+  | "file"
+  | "directory"
+  | "command"
+  | "separator"
+  | "section-header";
 
 /**
  * 下拉菜单项数据
@@ -84,7 +84,7 @@ export interface FileItem {
   /** 相对路径 */
   path: string;
   /** 类型 */
-  type: 'file' | 'directory';
+  type: "file" | "directory";
   /** 扩展名 */
   extension?: string;
 }
@@ -138,7 +138,11 @@ export interface TriggerQuery {
 /**
  * 对话权限模式
  */
-export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions';
+export type PermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "plan"
+  | "bypassPermissions";
 
 /**
  * 模式信息
@@ -153,10 +157,10 @@ export interface ModeInfo {
  * 预定义模式列表
  */
 export const AVAILABLE_MODES: ModeInfo[] = [
-  { id: 'default', label: '默认模式', icon: 'codicon-comment-discussion' },
-  { id: 'acceptEdits', label: '代理模式', icon: 'codicon-robot' },
-  { id: 'plan', label: '规划模式', icon: 'codicon-tasklist' },
-  { id: 'bypassPermissions', label: '自动模式', icon: 'codicon-zap' },
+  { id: "default", label: "默认模式", icon: "codicon-comment-discussion" },
+  { id: "acceptEdits", label: "代理模式", icon: "codicon-robot" },
+  { id: "plan", label: "规划模式", icon: "codicon-tasklist" },
+  { id: "bypassPermissions", label: "自动模式", icon: "codicon-zap" },
 ];
 
 /**
@@ -166,6 +170,7 @@ export interface ModelInfo {
   id: string;
   label: string;
   description?: string;
+  maxTokens?: number; // 模型最大上下文 token 数
 }
 
 /**
@@ -173,19 +178,22 @@ export interface ModelInfo {
  */
 export const CLAUDE_MODELS: ModelInfo[] = [
   {
-    id: 'claude-sonnet-4-5',
-    label: 'Sonnet 4.5',
-    description: 'Sonnet 4.5 · Use the default model',
+    id: "claude-sonnet-4-5",
+    label: "Sonnet 4.5",
+    description: "Sonnet 4.5 · Use the default model",
+    maxTokens: 200_000,
   },
   {
-    id: 'claude-opus-4-5-20251101',
-    label: 'Opus 4.5',
-    description: 'Opus 4.5 · Most capable for complex work',
+    id: "claude-opus-4-5-20251101",
+    label: "Opus 4.5",
+    description: "Opus 4.5 · Most capable for complex work",
+    maxTokens: 300_000,
   },
   {
-    id: 'claude-haiku-4-5',
-    label: 'Haiku 4.5',
-    description: 'Haiku 4.5 · Fastest for quick answers',
+    id: "claude-haiku-4-5",
+    label: "Haiku 4.5",
+    description: "Haiku 4.5 · Fastest for quick answers",
+    maxTokens: 400_000,
   },
 ];
 
@@ -194,19 +202,22 @@ export const CLAUDE_MODELS: ModelInfo[] = [
  */
 export const CODEX_MODELS: ModelInfo[] = [
   {
-    id: 'gpt-5.1-codex',
-    label: 'gpt-5.1-codex',
-    description: '针对codex进行了优化'
+    id: "gpt-5.1-codex",
+    label: "gpt-5.1-codex",
+    description: "针对codex进行了优化",
+    maxTokens: 128_000,
   },
   {
-    id: 'gpt-5.1-codex-mini',
-    label: 'gpt-5.1-codex-mini',
-    description: '针对codex进行了优化。更便宜、更快，但性能较差'
+    id: "gpt-5.1-codex-mini",
+    label: "gpt-5.1-codex-mini",
+    description: "针对codex进行了优化。更便宜、更快，但性能较差",
+    maxTokens: 128_000,
   },
   {
-    id: 'gpt-5.1',
-    label: 'gpt-5.1',
-    description: '具有广泛的世界知识和强大的一般推理能力'
+    id: "gpt-5.1",
+    label: "gpt-5.1",
+    description: "具有广泛的世界知识和强大的一般推理能力",
+    maxTokens: 128_000,
   },
 ];
 
@@ -229,9 +240,19 @@ export interface ProviderInfo {
  * 预定义提供商列表
  */
 export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
-  { id: 'claude', label: 'Claude Code', icon: 'codicon-terminal', enabled: true },
-  { id: 'codex', label: 'Codex Cli', icon: 'codicon-terminal', enabled: false },
-  { id: 'gemini', label: 'Gemini Cli', icon: 'codicon-terminal', enabled: false },
+  {
+    id: "claude",
+    label: "Claude Code",
+    icon: "codicon-terminal",
+    enabled: true,
+  },
+  { id: "codex", label: "Codex Cli", icon: "codicon-terminal", enabled: false },
+  {
+    id: "gemini",
+    label: "Gemini Cli",
+    icon: "codicon-terminal",
+    enabled: false,
+  },
 ];
 
 // ============================================================


### PR DESCRIPTION
- 前端在 types.ts 中配置各模型的 maxTokens
- 前端选择模型时将 maxTokens 通过 JSON 发送给后端
- 后端在 HandlerContext 中动态存储和访问 maxTokens
- 移除硬编码的 MODEL_CONTEXT_LIMITS 静态映射
- 清理 SettingsHandler 中的冗余代码

模型配置:
- Claude Sonnet 4.5: 200K tokens
- Claude Opus 4.5: 300K tokens
- Claude Haiku 4.5: 400K tokens
- Codex 模型: 128K tokens

修改文件:
- ClaudeSDKToolWindow.java: 使用 HandlerContext 获取动态 maxTokens
- HandlerContext.java: 新增 currentModelMaxTokens 字段及访问方法
- SettingsHandler.java: 解析并保存前端发送的 maxTokens
- App.tsx: 发送模型配置时包含 maxTokens
- types.ts: 为所有模型定义 maxTokens
- TokenIndicator.tsx: 使用动态的 maxTokens 显示使用百分比