### PR TITLE
✨ feat(auth): 添加对 AWS Bedrock 的支持

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -47,6 +47,10 @@ export function setupApiKey() {
     apiKey = settings.env.ANTHROPIC_API_KEY;
     authType = 'api_key';  // x-api-key 认证
     apiKeySource = 'settings.json (ANTHROPIC_API_KEY)';
+  } else if (settings?.env?.CLAUDE_CODE_USE_BEDROCK === '1' || settings?.env?.CLAUDE_CODE_USE_BEDROCK === 1 || settings?.env?.CLAUDE_CODE_USE_BEDROCK === 'true' || settings?.env?.CLAUDE_CODE_USE_BEDROCK === true) {
+    apiKey = settings?.env?.CLAUDE_CODE_USE_BEDROCK;
+    authType = 'aws_bedrock';  // aws_bedrock 认证
+    apiKeySource = 'settings.json (AWS_BEDROCK)';
   }
 
   if (settings?.env?.ANTHROPIC_BASE_URL) {
@@ -64,6 +68,9 @@ export function setupApiKey() {
     process.env.ANTHROPIC_AUTH_TOKEN = apiKey;
     // 清除 ANTHROPIC_API_KEY 避免混淆
     delete process.env.ANTHROPIC_API_KEY;
+  } else if (authType === 'aws_bedrock') {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
   } else {
     process.env.ANTHROPIC_API_KEY = apiKey;
     // 清除 ANTHROPIC_AUTH_TOKEN 避免混淆

--- a/ai-bridge/package.json
+++ b/ai-bridge/package.json
@@ -4,6 +4,7 @@
   "description": "Unified bridge for Claude and Codex SDKs from Java",
   "type": "module",
   "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "^0.26.0",
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
     "@anthropic-ai/sdk": "^0.25.0",
     "sql.js": "^1.12.0",

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -5,6 +5,7 @@
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import Anthropic from '@anthropic-ai/sdk';
+import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
 import { randomUUID } from 'crypto';
 
 import { setupApiKey, isCustomBaseUrl, loadClaudeSettings } from '../../config/api-config.js';
@@ -28,14 +29,14 @@ import { loadAttachments, buildContentBlocks } from './attachment-service.js';
 			    const rawError = error?.message || String(error);
 			    const errorName = error?.name || 'Error';
 			    const errorStack = error?.stack || null;
-	
+
 			    // 之前这里对 AbortError / "Claude Code process aborted by user" 做了超时提示
 			    // 现在统一走错误处理逻辑，但仍然在 details 中记录是否为超时/中断类错误，方便排查
 			    const isAbortError =
 			      errorName === 'AbortError' ||
 			      rawError.includes('Claude Code process aborted by user') ||
 			      rawError.includes('The operation was aborted');
-	
+
 		    const settings = loadClaudeSettings();
 	    const env = settings?.env || {};
 
@@ -77,11 +78,11 @@ import { loadAttachments, buildContentBlocks } from './attachment-service.js';
 		    } else {
 		      baseUrlSource = '默认值（https://api.anthropic.com）';
 		    }
-		
+
 		    const heading = isAbortError
 		      ? 'Claude Code 运行被中断（可能是响应超时或用户取消）：'
 		      : 'Claude Code 出现错误：';
-		
+
 		    const userMessage = [
 	      heading,
 	      `- 错误信息: ${rawError}`,
@@ -281,19 +282,19 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     }
 
 	    console.log('[DEBUG] Query started, waiting for messages...');
-	
+
 	    // 调用 query 函数
 	    const result = query({
 	      prompt: message,
 	      options
 	    });
-	
+
 		// 设置 60 秒超时，超时后通过 AbortController 取消查询（已发现严重问题，暂时注释掉自动超时逻辑）
 		// timeoutId = setTimeout(() => {
 		//   console.log('[DEBUG] Query timeout after 60 seconds, aborting...');
 		//   abortController.abort();
 		// }, 60000);
-	
+
 	    console.log('[DEBUG] Starting message loop...');
 
     let currentSessionId = resumeSessionId;
@@ -390,7 +391,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
 	      success: true,
 	      sessionId: currentSessionId
 	    }));
-	
+
 	  } catch (error) {
 	    const payload = buildConfigErrorPayload(error);
 	    console.error('[SEND_ERROR]', JSON.stringify(payload));
@@ -426,6 +427,9 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
       // 优先使用 Bearer（ANTHROPIC_AUTH_TOKEN），避免继续发送 x-api-key
       delete process.env.ANTHROPIC_API_KEY;
       process.env.ANTHROPIC_AUTH_TOKEN = apiKey;
+    } else if (authType === 'aws_bedrock') {
+        console.log('[DEBUG] Using AWS_BEDROCK authentication (AWS_BEDROCK)');
+        client = new AnthropicBedrock();
     } else {
       console.log('[DEBUG] Using API Key authentication (ANTHROPIC_API_KEY)');
       // 使用 apiKey 参数（x-api-key 认证）
@@ -796,7 +800,7 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
 	      options.resume = resumeSessionId;
 	      console.log('[RESUMING]', resumeSessionId);
 	    }
-	
+
 		    const result = query({
 		      prompt: inputStream,
 		      options
@@ -807,7 +811,7 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
 	    //   console.log('[DEBUG] Query with attachments timeout after 30 seconds, aborting...');
 	    //   abortController.abort();
 	    // }, 30000);
-	
+
 		    let currentSessionId = resumeSessionId;
 
 		    try {


### PR DESCRIPTION
- 【新增】添加 `@anthropic-ai/bedrock-sdk` 依赖以支持 AWS Bedrock。
- 【更新】在 `api-config.js` 中增加 `aws_bedrock` 认证类型，通过环境变量 `CLAUDE_CODE_USE_BEDROCK` 启用。
- 【更新】在 `message-service.js` 中，当认证类型为 `aws_bedrock` 时，实例化 `AnthropicBedrock` 客户端。

完成自定义 haiku sonnet 模型的多轮对话测试
完成与其他非 aws bedrock 供应商一轮对话中切换的测试