### PR TITLE
fix(webview): 修复文件引用、会话管理和滚动相关问题

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -274,6 +274,7 @@ export const ChatInputBox = ({
       const fullMatch = match[0];
       const filePath = match[1];
       const matchIndex = match.index || 0;
+
       // 添加匹配前的文本
       if (matchIndex > lastIndex) {
         const textBefore = currentText.substring(lastIndex, matchIndex);
@@ -286,6 +287,20 @@ export const ChatInputBox = ({
 
       // 获取纯文件名（不含行号，用于获取 ICON）
       const pureFileName = pureFilePath.split(/[/\\]/).pop() || pureFilePath;
+
+      // 验证路径是否为有效引用（必须在 pathMappingRef 中存在）
+      // 只有用户从下拉列表中选择的文件才会被记录到 pathMappingRef
+      const isValidReference =
+        pathMappingRef.current.has(pureFilePath) ||
+        pathMappingRef.current.has(pureFileName) ||
+        pathMappingRef.current.has(filePath);
+
+      // 如果不是有效引用，保留原始文本，不渲染为标签
+      if (!isValidReference) {
+        newHTML += fullMatch;
+        lastIndex = matchIndex + fullMatch.length;
+        return;
+      }
 
       // 获取显示文件名（包含行号，用于显示）
       const displayFileName = filePath.split(/[/\\]/).pop() || filePath;
@@ -305,7 +320,6 @@ export const ChatInputBox = ({
       const escapedPath = escapeHtmlAttr(filePath);
 
       // 尝试从路径映射中获取完整路径（用于 tooltip 显示）
-      // 优先级：pureFilePath -> pureFileName -> 原路径（去掉行号进行查找）
       const fullPath =
         pathMappingRef.current.get(pureFilePath) ||
         pathMappingRef.current.get(pureFileName) ||
@@ -313,8 +327,6 @@ export const ChatInputBox = ({
       const escapedFullPath = escapeHtmlAttr(fullPath);
 
       // 创建文件标签 HTML
-      // data-file-path: 存储原始路径（用于提取文本时还原）
-      // data-tooltip: 存储完整路径（用于悬停显示）
       newHTML += `<span class="file-tag has-tooltip" contenteditable="false" data-file-path="${escapedPath}" data-tooltip="${escapedFullPath}">`;
       newHTML += `<span class="file-tag-icon">${iconSvg}</span>`;
       newHTML += `<span class="file-tag-text">${displayFileName}</span>`;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -263,7 +263,8 @@
     "deleteSuccess": "Deleted successfully",
     "operationFailed": "Operation failed",
     "copySuccess": "{{label}} copied to clipboard",
-    "copyFailed": "Copy failed"
+    "copyFailed": "Copy failed",
+    "newSessionCreated": "New session created"
   },
   "config": {
     "clickToCopy": "Click to copy",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -263,7 +263,8 @@
     "deleteSuccess": "删除成功",
     "operationFailed": "操作失败",
     "copySuccess": "{{label}}已复制到剪切板",
-    "copyFailed": "复制失败"
+    "copyFailed": "复制失败",
+    "newSessionCreated": "新会话已创建"
   },
   "config": {
     "clickToCopy": "点击复制",


### PR DESCRIPTION
1. 修复文件引用标签显示不存在文件夹的问题
   - 验证路径是否在 pathMappingRef 中存在
   - 只有从下拉列表选择的文件才渲染为标签

2. 修复删除当前会话后 toast 重复显示问题
   - 添加 suppressNextStatusToastRef 标志位
   - 删除当前会话时抑制后端 createNewSession 触发的 toast

3. 修复历史页面返回后发送消息不显示问题
   - 修正会话有效性检查逻辑
   - currentSessionId 为 null 表示新会话，是合法状态

4. 修复发送消息后页面不自动滚动问题
   - handleSubmit 中强制滚动到底部
   - 重置 isUserAtBottomRef 确保后续消息持续触发滚动