### PR TITLE
fix: 修复删除会话功能并补充国际化翻译，实现前端焦点恢复机制，解决输入框光标丢失问题

### DIFF
--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -63,6 +63,11 @@ interface Window {
   addToast?: (message: string, type: 'success' | 'error' | 'warning' | 'info') => void;
 
   /**
+   * Delete session failed callback (called from backend)
+   */
+  onDeleteSessionFailed?: () => void;
+
+  /**
    * Usage statistics update callback
    */
   onUsageUpdate?: (json: string) => void;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -220,6 +220,7 @@
     "confirmDelete": "Confirm Delete",
     "deleteMessage": "Are you sure you want to delete this session? This action cannot be undone.",
     "deleteSession": "Delete this session",
+    "deleteFailed": "Failed to delete session",
     "exportSession": "Export session",
     "exportSuccess": "Session exported",
     "exportFailed": "Export failed",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -220,6 +220,7 @@
     "confirmDelete": "Confirmar eliminación",
     "deleteMessage": "��Estás seguro de que quieres eliminar esta sesión? Esta acción no se puede deshacer.",
     "deleteSession": "Eliminar esta sesión",
+    "deleteFailed": "Error al eliminar sesión",
     "exportSession": "Exportar sesión",
     "exportSuccess": "Sesión exportada",
     "exportFailed": "Falló la exportación",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -220,6 +220,7 @@
     "confirmDelete": "Confirmer la suppression",
     "deleteMessage": "Êtes-vous sûr de vouloir supprimer cette session ? Cette action ne peut pas être annulée.",
     "deleteSession": "Supprimer cette session",
+    "deleteFailed": "Échec de la suppression de session",
     "exportSession": "Exporter la session",
     "exportSuccess": "Session exportée",
     "exportFailed": "Échec de l'exportation",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -220,6 +220,7 @@
     "confirmDelete": "हटाने की पुष्टि करें",
     "deleteMessage": "क्या आप इस सत्र को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।",
     "deleteSession": "इस सत्र को हटाएं",
+    "deleteFailed": "सत्र हटाने में विफल",
     "exportSession": "सत्र निर्यात करें",
     "exportSuccess": "सत्र निर्यात किया गया",
     "exportFailed": "निर्यात विफल",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -220,6 +220,7 @@
     "confirmDelete": "確認刪除",
     "deleteMessage": "確定要刪除這個會話嗎?此操作無法撤銷。",
     "deleteSession": "刪除此會話",
+    "deleteFailed": "刪除會話失敗",
     "exportSession": "匯出會話",
     "exportSuccess": "會話已匯出",
     "exportFailed": "匯出失敗",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -220,6 +220,7 @@
     "confirmDelete": "确认删除",
     "deleteMessage": "确定要删除这个会话吗?此操作无法撤销。",
     "deleteSession": "删除此会话",
+    "deleteFailed": "删除会话失败",
     "exportSession": "导出会话",
     "exportSuccess": "会话已导出",
     "exportFailed": "导出失败",


### PR DESCRIPTION
1. 修复删除进行中会话的问题
   - 添加会话删除回调机制
   - 删除当前会话时先中断请求并创建新会话
   - 防止删除后会话重新出现

2. 补充多语言翻译
   - 补充 zh-TW、es、fr、hi 语言文件中缺失的 65 个翻译 key
   - 主要涉及 workingDirectory 和 providers 相关配置
  
3. 解决输入框光标丢失问题
  - 添加全局焦点恢复函数 window.restoreInputFocus
  - 在权限弹窗、确认对话框关闭后自动恢复焦点
  - 在页面切换返回聊天视图时自动恢复焦点
  - 添加 TypeScript 类型定义