### PR TITLE
fix: improve ai-bridge extraction waiting mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ cd webview
 npm install
 ```
 
-### 2. Install claude-bridge Dependencies
+### 2. Install ai-bridge Dependencies
 
 ```bash
-cd claude-bridge
+cd ai-bridge
 npm install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,10 +83,10 @@ cd webview
 npm install
 ```
 
-### 2.安装claude-bridge依赖
+### 2.安装ai-bridge依赖
 
 ```bash
-cd claude-bridge
+cd ai-bridge
 npm install
 ```
 


### PR DESCRIPTION
- Use shared BridgeDirectoryResolver instance for proper extraction state detection
- Add waiting logic for background extraction (up to 60s timeout)
- Update documentation to reflect claude-bridge renamed to ai-bridge
- Adjust version to 0.1.5-beta3-fix2