### PR TITLE
fix: quote npm package specs to preserve semver operators on Windows

### DIFF
--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -315,6 +315,7 @@ public class DependencyManager {
                 List<String> command = NpmPermissionHelper.buildInstallCommandWithFallback(
                     npmPath, normalizedSdkDir, packages, attempt
                 );
+                log.accept("Command: " + String.join(" ", command));
 
                 ProcessBuilder pb = new ProcessBuilder(command);
                 pb.directory(sdkDir.toFile());

--- a/src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java
+++ b/src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java
@@ -229,7 +229,15 @@ public class NpmPermissionHelper {
             LOG.info("[NpmPermissionHelper] Adding --force flag for retry attempt " + retryAttempt);
         }
 
-        command.addAll(packages);
+        // Wrap packages containing special characters in quotes to prevent shell interpretation
+        for (String pkg : packages) {
+            if (pkg.contains("^") || pkg.contains("~") || pkg.contains(">") || pkg.contains("<")) {
+                command.add("\"" + pkg + "\"");
+            } else {
+                command.add(pkg);
+            }
+        }
+
         return command;
     }
 


### PR DESCRIPTION
Windows cmd.exe was interpreting ^ as escape character, causing npm to install exact versions instead of version ranges. Now wrapping package specs containing semver operators (^~><) in quotes across all platforms.

Also added command logging for better debugging.

Fixes #225