### PR TITLE
fix: 修复用户消息复制按钮遮挡问题

### DIFF
--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -377,11 +377,35 @@ export const MessageItem = memo(function MessageItem({
 
   return (
     <div className={`message ${message.type}`} style={messageStyle}>
-      {/* Copy button for user and assistant messages */}
-      {(message.type === 'user' || (message.type === 'assistant' && !isMessageStreaming)) && (
+      {/* Timestamp and copy button for user messages */}
+      {message.type === 'user' && message.timestamp && (
+        <div className="message-header-row">
+          <div className="message-timestamp-header">
+            {formatTime(message.timestamp)}
+          </div>
+          <button
+            type="button"
+            className={`message-copy-btn message-copy-btn-inline ${copiedMessageIndex === messageIndex ? 'copied' : ''}`}
+            onClick={handleCopyMessage}
+            title={t('markdown.copyMessage')}
+            aria-label={t('markdown.copyMessage')}
+          >
+            <span className="copy-icon">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4 4l0 8a2 2 0 0 0 2 2l8 0a2 2 0 0 0 2 -2l0 -8a2 2 0 0 0 -2 -2l-8 0a2 2 0 0 0 -2 2zm2 0l8 0l0 8l-8 0l0 -8z" fill="currentColor" fillOpacity="0.9"/>
+                <path d="M2 2l0 8l-2 0l0 -8a2 2 0 0 1 2 -2l8 0l0 2l-8 0z" fill="currentColor" fillOpacity="0.6"/>
+              </svg>
+            </span>
+            <span className="copy-tooltip">{t('markdown.copySuccess')}</span>
+          </button>
+        </div>
+      )}
+
+      {/* Copy button for assistant messages only */}
+      {message.type === 'assistant' && !isMessageStreaming && (
         <button
           type="button"
-          className={`message-copy-btn ${message.type === 'user' ? 'message-copy-btn-user' : ''} ${copiedMessageIndex === messageIndex ? 'copied' : ''}`}
+          className={`message-copy-btn ${copiedMessageIndex === messageIndex ? 'copied' : ''}`}
           onClick={handleCopyMessage}
           title={t('markdown.copyMessage')}
           aria-label={t('markdown.copyMessage')}
@@ -394,15 +418,6 @@ export const MessageItem = memo(function MessageItem({
           </span>
           <span className="copy-tooltip">{t('markdown.copySuccess')}</span>
         </button>
-      )}
-
-      {/* Timestamp for user messages */}
-      {message.type === 'user' && message.timestamp && (
-        <div className="message-header-row">
-          <div className="message-timestamp-header">
-            {formatTime(message.timestamp)}
-          </div>
-        </div>
       )}
 
       {/* Role label for non-user/assistant messages */}

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -46,12 +46,17 @@
     white-space: pre-wrap;
 }
 
+.message-header-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 2px;
+}
+
 .message-timestamp-header {
     font-size: 11px;
     color: var(--text-tertiary);
-    margin-bottom: 2px;
     line-height: 1;
-    margin-right: 2px;
 }
 
 /* Assistant Message: Row layout for alignment */
@@ -140,27 +145,48 @@
     }
 }
 
+/* Inline copy button for user messages (in header row) */
+.message-copy-btn-inline {
+    position: relative;
+    width: 20px;
+    height: 20px;
+    opacity: 0.7;
+    visibility: visible;
+    bottom: auto;
+    right: auto;
+    padding: 2px;
+
+    .copy-icon svg {
+        width: 12px;
+        height: 12px;
+    }
+
+    &:hover {
+        opacity: 1;
+    }
+
+    .copy-tooltip {
+        top: calc(100% + 4px);
+        right: -4px;
+
+        &::after {
+            top: -4px;
+            bottom: auto;
+            right: 8px;
+            border-width: 0 4px 4px;
+            border-color: transparent transparent var(--border-secondary) transparent;
+        }
+    }
+
+    &.copied .copy-tooltip {
+        transform: translateY(2px);
+    }
+}
+
 /* Show copy button on message hover */
 .message.assistant {
     position: relative;
 
-    &:hover .message-copy-btn {
-        opacity: 0.7;
-        visibility: visible;
-    }
-
-    &:hover .message-copy-btn:hover {
-        opacity: 1;
-    }
-}
-
-/* User message copy button - positioned outside bubble on the left */
-.message-copy-btn-user {
-    right: calc(15% + 8px); /* Position outside the 85% bubble, with 8px spacing */
-}
-
-/* Show copy button on hover for user messages */
-.message.user {
     &:hover .message-copy-btn {
         opacity: 0.7;
         visibility: visible;
@@ -186,11 +212,6 @@
             width: 12px;
             height: 12px;
         }
-    }
-
-    /* User message button positioning on mobile - adjust for smaller screens */
-    .message-copy-btn-user {
-        right: 8px; /* Simplified positioning on mobile */
     }
 }
 
@@ -302,10 +323,10 @@
 .code-block-wrapper {
     position: relative;
     margin: 10px 0;
-    
+
     pre {
-        margin: 0; /* wrapper 处理了 margin */
-        padding-right: 40px; /* 仍然保留，防止内容被按钮遮挡 */
+        margin: 0;
+        padding-right: 40px;
     }
 }
 
@@ -327,7 +348,7 @@
     transition: all 0.2s;
     z-index: 10;
     opacity: 0.7;
-    
+
     &:hover {
         background: var(--bg-hover);
         color: var(--text-primary);
@@ -359,8 +380,7 @@
     pointer-events: none;
     white-space: nowrap;
     z-index: 20;
-    
-    // 小三角
+
     &::after {
         content: '';
         position: absolute;


### PR DESCRIPTION
## Summary
改为:
<img width="1666" height="366" alt="image" src="https://github.com/user-attachments/assets/172a90de-52d3-4a8d-bbd3-6b25b4055aa6" />


修复用户消息复制按钮样式遮挡问题，将复制按钮移至消息头部与时间戳并排显示，避免遮挡消息内容。

## Changes

### UI/UX 改进
- 将用户消息的复制按钮从消息气泡外侧移至消息头部区域
- 复制按钮现在与时间戳并排显示在同一行，采用内联布局
- 移除了之前复制按钮定位在气泡外侧的样式，解决了遮挡问题

### 技术实现
- 新增 `message-header-row` Flexbox 布局容器，统一管理时间戳和复制按钮
- 新增 `message-copy-btn-inline` 样式类，专门用于用户消息的内联复制按钮
- 移除了 `message-copy-btn-user` 样式类及相关定位逻辑
- 简化了 assistant 消息的复制按钮逻辑

### 文件改动
- `webview/src/components/MessageItem/MessageItem.tsx`
  - 重构用户消息的复制按钮渲染逻辑
  - 将复制按钮移至 `message-header-row` 容器内

- `webview/src/styles/less/components/message.less`
  - 添加 `.message-header-row` 样式
  - 添加 `.message-copy-btn-inline` 样式
  - 更新提示框位置和箭头样式
  - 移除旧的 `.message-copy-btn-user` 样式

## Screenshots

Before: 复制按钮定位在气泡外侧，可能遮挡内容
After: 复制按钮与时间戳并排，布局更清晰


## Related Issue

Closes #322
