### PR TITLE
fix(mcp): correct tool icon sizing and alignment in MCP settings

### DIFF
--- a/webview/src/components/mcp/McpSettingsSection.tsx
+++ b/webview/src/components/mcp/McpSettingsSection.tsx
@@ -486,7 +486,7 @@ export function McpSettingsSection({ currentProvider = 'claude' }: McpSettingsSe
         >
           <div className="tooltip-header">
             <span className="tooltip-icon">
-              <span className="codicon">{getToolIcon(hoveredTool.tool.name)}</span>
+              <span className={`codicon tool-icon ${getToolIcon(hoveredTool.tool.name)}`}></span>
             </span>
             <span className="tooltip-name">{hoveredTool.tool.name}</span>
           </div>

--- a/webview/src/components/mcp/ServerToolsPanel.tsx
+++ b/webview/src/components/mcp/ServerToolsPanel.tsx
@@ -101,7 +101,7 @@ export function ServerToolsPanel({
                       onToolHover(null);
                     }}
                   >
-                    <span className="codicon tool-icon">{getToolIcon(tool.name)}</span>
+                    <span className={`codicon tool-icon ${getToolIcon(tool.name)}`}></span>
                     <div className="tool-info">
                       <span className="tool-name-text">{tool.name}</span>
                     </div>

--- a/webview/src/styles/less/components/mcp.less
+++ b/webview/src/styles/less/components/mcp.less
@@ -1750,7 +1750,7 @@
 .sidebar-tool-item {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     padding: 8px 12px;
     border-radius: 6px;
     cursor: pointer;
@@ -1781,20 +1781,20 @@
 
 .tool-icon {
     flex-shrink: 0;
-    width: auto;
-    min-width: 200px;
-    height: 22px;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
-    background: var(--bg-tertiary);
     color: var(--accent-primary);
-    font-size: 13px;
+    font-size: 14px;
+    line-height: 1;
+}
+
+.sidebar-tool-item:hover .tool-icon {
+    color: var(--accent-primary-hover);
 }
 
 .sidebar-tool-item.active .tool-icon {
-    background: rgba(255, 255, 255, 0.2);
+    color: var(--text-white);
 }
 
 .tool-info {
@@ -2103,17 +2103,15 @@
 }
 
 .mcp-tool-tooltip .tooltip-icon {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: auto;
-    min-width: 200px;
-    height: 24px;
-    border-radius: 4px;
-    background: var(--bg-tertiary);
-    color: var(--accent-primary);
-    font-size: 14px;
     flex-shrink: 0;
+}
+
+.mcp-tool-tooltip .tooltip-icon .tool-icon {
+    color: var(--accent-primary);
+    font-size: 16px;
 }
 
 .mcp-tool-tooltip .tooltip-name {


### PR DESCRIPTION
- Fix tool icon width from 200px to proper size
- Restore blue accent color for icons
- Fix vertical alignment in tooltip and sidebar
- Simplify icon styles for better consistency

Fixes #315 