### PR TITLE
refactor: use centralized path utilities for homedir

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -5,15 +5,16 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { homedir, platform } from 'os';
+import { platform } from 'os';
 import { execSync } from 'child_process';
+import { getClaudeDir } from '../utils/path-utils.js';
 
 /**
  * 读取 Claude Code 配置
  */
 export function loadClaudeSettings() {
   try {
-    const settingsPath = join(homedir(), '.claude', 'settings.json');
+    const settingsPath = join(getClaudeDir(), 'settings.json');
     const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
     return settings;
   } catch (error) {
@@ -62,7 +63,7 @@ function readMacKeychainCredentials() {
  */
 function readFileCredentials() {
   try {
-    const credentialsPath = join(homedir(), '.claude', '.credentials.json');
+    const credentialsPath = join(getClaudeDir(), '.credentials.json');
 
     if (!existsSync(credentialsPath)) {
       console.log('[DEBUG] No CLI session found: .credentials.json does not exist');

--- a/ai-bridge/permission-handler.js
+++ b/ai-bridge/permission-handler.js
@@ -8,6 +8,7 @@
 import { writeFileSync, readFileSync, existsSync, unlinkSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { tmpdir } from 'os';
+import { getRealHomeDir } from './utils/path-utils.js';
 
 // ========== 调试日志辅助函数 ==========
 function debugLog(tag, message, data = null) {
@@ -321,7 +322,7 @@ export async function requestPermissionFromJava(toolName, input) {
 
     // 对于某些明显的危险操作，直接拒绝
     // 获取用户主目录用于路径检查
-    const userHomeDir = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
+    const userHomeDir = getRealHomeDir();
     const dangerousPatterns = [
       '/etc/',
       '/System/',

--- a/ai-bridge/services/claude/mcp-status/config-loader.js
+++ b/ai-bridge/services/claude/mcp-status/config-loader.js
@@ -6,7 +6,7 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { homedir } from 'os';
+import { getRealHomeDir } from '../../../utils/path-utils.js';
 import { log } from './logger.js';
 
 /**
@@ -74,7 +74,7 @@ function validateConfigStructure(config) {
  * @returns {Promise<{mcpServers: Object, disabledServers: Set<string>} | null>} 解析结果，失败返回 null
  */
 async function parseMcpConfig(cwd = null) {
-  const claudeJsonPath = join(homedir(), '.claude.json');
+  const claudeJsonPath = join(getRealHomeDir(), '.claude.json');
 
   if (!existsSync(claudeJsonPath)) {
     log('info', '~/.claude.json not found');

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -7,8 +7,8 @@ import fs from 'fs';
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { homedir } from 'os';
 import { randomUUID } from 'crypto';
+import { getClaudeDir } from '../../utils/path-utils.js';
 
 /**
  * 将一条消息追加到 JSONL 历史文件
@@ -16,7 +16,7 @@ import { randomUUID } from 'crypto';
  */
 export function persistJsonlMessage(sessionId, cwd, obj) {
   try {
-    const projectsDir = join(homedir(), '.claude', 'projects');
+    const projectsDir = join(getClaudeDir(), 'projects');
     const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
     const projectHistoryDir = join(projectsDir, sanitizedCwd);
     fs.mkdirSync(projectHistoryDir, { recursive: true });
@@ -43,7 +43,7 @@ export function persistJsonlMessage(sessionId, cwd, obj) {
  */
 export function loadSessionHistory(sessionId, cwd) {
   try {
-    const projectsDir = join(homedir(), '.claude', 'projects');
+    const projectsDir = join(getClaudeDir(), 'projects');
     const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
     const sessionFile = join(projectsDir, sanitizedCwd, `${sessionId}.jsonl`);
 
@@ -92,7 +92,7 @@ export function loadSessionHistory(sessionId, cwd) {
  */
 export async function getSessionMessages(sessionId, cwd = null) {
   try {
-    const projectsDir = join(homedir(), '.claude', 'projects');
+    const projectsDir = join(getClaudeDir(), 'projects');
 
     // 转义项目路径（与 ClaudeSessionService.ts 相同逻辑）
     const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');

--- a/ai-bridge/services/codex/message-service.js
+++ b/ai-bridge/services/codex/message-service.js
@@ -19,7 +19,7 @@ import { CodexPermissionMapper } from '../../utils/permission-mapper.js';
 import { randomUUID } from 'crypto';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
+import { getRealHomeDir } from '../../utils/path-utils.js';
 
 // SDK 缓存
 let codexSdk = null;
@@ -173,7 +173,7 @@ function collectAgentsInstructions(cwd) {
   // 1. 首先读取全局指令 (~/.codex/)
   const codexHome = (process.env.CODEX_HOME && process.env.CODEX_HOME.trim())
     ? process.env.CODEX_HOME.trim()
-    : join(homedir(), '.codex');
+    : join(getRealHomeDir(), '.codex');
   const globalFile = findAgentsFileInDir(codexHome);
   if (globalFile) {
     const content = readAgentsFile(globalFile);

--- a/ai-bridge/services/favorites-service.cjs
+++ b/ai-bridge/services/favorites-service.cjs
@@ -5,10 +5,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
+const { getCodemossDir } = require('../utils/path-utils.cjs');
 
-const HOME_DIR = os.homedir();
-const FAVORITES_DIR = path.join(HOME_DIR, '.codemoss');
+const FAVORITES_DIR = getCodemossDir();
 const FAVORITES_FILE = path.join(FAVORITES_DIR, 'favorites.json');
 
 /**

--- a/ai-bridge/services/input-history-service.cjs
+++ b/ai-bridge/services/input-history-service.cjs
@@ -6,10 +6,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
+const { getCodemossDir } = require('../utils/path-utils.cjs');
 
-const HOME_DIR = os.homedir();
-const CODEMOSS_DIR = path.join(HOME_DIR, '.codemoss');
+const CODEMOSS_DIR = getCodemossDir();
 const HISTORY_FILE = path.join(CODEMOSS_DIR, 'inputHistory.json');
 
 /** 最大历史记录条数 */

--- a/ai-bridge/services/prompt-enhancer.js
+++ b/ai-bridge/services/prompt-enhancer.js
@@ -13,7 +13,7 @@
 import { loadClaudeSdk, isClaudeSdkAvailable } from '../utils/sdk-loader.js';
 import { setupApiKey, loadClaudeSettings } from '../config/api-config.js';
 import { mapModelIdToSdkName } from '../utils/model-utils.js';
-import { homedir } from 'os';
+import { getRealHomeDir } from '../utils/path-utils.js';
 
 let claudeSdk = null;
 
@@ -259,7 +259,7 @@ async function enhancePrompt(originalPrompt, systemPrompt, model, context) {
     console.log(`[PromptEnhancer] 模型映射: ${model} -> ${sdkModelName}`);
 
     // 使用用户主目录作为工作目录
-    const workingDirectory = homedir();
+    const workingDirectory = getRealHomeDir();
 
     // 构建包含上下文信息的完整提示词
     const fullPrompt = buildFullPrompt(originalPrompt, context);

--- a/ai-bridge/services/session-titles-service.cjs
+++ b/ai-bridge/services/session-titles-service.cjs
@@ -5,10 +5,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
+const { getCodemossDir } = require('../utils/path-utils.cjs');
 
-const HOME_DIR = os.homedir();
-const TITLES_DIR = path.join(HOME_DIR, '.codemoss');
+const TITLES_DIR = getCodemossDir();
 const TITLES_FILE = path.join(TITLES_DIR, 'session-titles.json');
 
 /**

--- a/ai-bridge/utils/path-utils.cjs
+++ b/ai-bridge/utils/path-utils.cjs
@@ -1,0 +1,54 @@
+/**
+ * 路径处理工具模块 (CommonJS 版本)
+ * 负责路径规范化、用户目录处理
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// 缓存真实的用户目录路径，避免重复计算
+let cachedRealHomeDir = null;
+
+/**
+ * 获取真实的用户目录路径.
+ * 解决 Windows 上用户目录被移动或使用符号链接/Junction 的问题。
+ * @returns {string} 真实的用户目录路径
+ */
+function getRealHomeDir() {
+  if (cachedRealHomeDir) {
+    return cachedRealHomeDir;
+  }
+
+  const rawHome = os.homedir();
+  try {
+    cachedRealHomeDir = fs.realpathSync(rawHome);
+  } catch {
+    console.warn('[path-utils] Failed to resolve real home path, using raw path:', rawHome);
+    cachedRealHomeDir = rawHome;
+  }
+
+  return cachedRealHomeDir;
+}
+
+/**
+ * 获取 .codemoss 配置目录路径.
+ * @returns {string} ~/.codemoss 目录路径
+ */
+function getCodemossDir() {
+  return path.join(getRealHomeDir(), '.codemoss');
+}
+
+/**
+ * 获取 .claude 配置目录路径.
+ * @returns {string} ~/.claude 目录路径
+ */
+function getClaudeDir() {
+  return path.join(getRealHomeDir(), '.claude');
+}
+
+module.exports = {
+  getRealHomeDir,
+  getCodemossDir,
+  getClaudeDir
+};


### PR DESCRIPTION
- Refactor credential paths to use a centralized utility function for resolving Claude's configuration directory.
- Replace direct homedir resolution with a centralized utility for safer path checks.
- Replace homedir with getRealHomeDir to reliably locate the user's home directory
- Replace direct homedir() calls with utility functions to centralize home and Claude directory resolution.
- Replace hard-coded home directory with centralized path utility for session storage
- Replace homedir() with getRealHomeDir() to correctly locate the global .codex directory.
- Replace hard-coded home directory with centralized utility for favorites storage
- Replace hard-coded home-dir logic with reusable utility function.
- Replace homedir with getRealHomeDir to use the correct home directory path
- Replace hardcoded home directory with utility function to locate codemoss directory
- Add CommonJS utility to resolve real home directory and config folder paths
- Add real home directory resolution to fix Windows symlink issues
- Refactor SDK path resolution to use shared path utilities and align with DependencyManager logic