### PR TITLE
feat: add new models support and fix model version passing

### DIFF
--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -60,7 +60,7 @@ import { getMcpServersStatus, loadMcpServersConfig, getMcpServerTools as getMcpS
 
 import { setupApiKey, isCustomBaseUrl, loadClaudeSettings } from '../../config/api-config.js';
 import { selectWorkingDirectory, getRealHomeDir, getClaudeDir } from '../../utils/path-utils.js';
-import { mapModelIdToSdkName } from '../../utils/model-utils.js';
+import { mapModelIdToSdkName, setModelEnvironmentVariables } from '../../utils/model-utils.js';
 import { AsyncStream } from '../../utils/async-stream.js';
 import { canUseTool, requestPlanApproval } from '../../permission-handler.js';
 import { persistJsonlMessage, loadSessionHistory } from './session-service.js';
@@ -499,6 +499,11 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     // 将模型 ID 映射为 SDK 期望的名称
     const sdkModelName = mapModelIdToSdkName(model);
     console.log('[DEBUG] Model mapping:', model, '->', sdkModelName);
+
+    // 🔧 FIX: 设置模型环境变量，让 SDK 知道具体使用哪个版本
+    // 例如：用户选择 claude-opus-4-6 时，需要设置 ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6
+    // 否则 SDK 只知道使用 'opus'，但不知道是 4.5 还是 4.6
+    setModelEnvironmentVariables(model);
 
 	    // Build systemPrompt.append content (for adding opened files context and agent prompt)
 	    // 使用统一的提示词管理模块构建 IDE 上下文提示词（包括智能体提示词）
@@ -1218,6 +1223,8 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     };
 
     const sdkModelName = mapModelIdToSdkName(model);
+    // 🔧 FIX: 设置模型环境变量，让 SDK 知道具体使用哪个版本
+    setModelEnvironmentVariables(model);
     // 不再查找系统 CLI，使用 SDK 内置 cli.js
     console.log('[DEBUG] (withAttachments) Using SDK built-in Claude CLI (cli.js)');
 

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -1,6 +1,6 @@
 /**
  * 模型工具模块
- * 负责模型 ID 映射
+ * 负责模型 ID 映射和环境变量设置
  */
 
 /**
@@ -25,6 +25,34 @@ export function mapModelIdToSdkName(modelId) {
     return 'haiku';
   } else {
     return 'sonnet';
+  }
+}
+
+/**
+ * 根据完整模型 ID 设置 SDK 环境变量
+ * Claude SDK 使用短名称（opus/sonnet/haiku）作为模型选择器，
+ * 具体版本由 ANTHROPIC_DEFAULT_*_MODEL 环境变量指定
+ *
+ * @param {string} modelId - 完整的模型 ID（如 'claude-opus-4-6'）
+ */
+export function setModelEnvironmentVariables(modelId) {
+  if (!modelId || typeof modelId !== 'string') {
+    return;
+  }
+
+  const lowerModel = modelId.toLowerCase();
+
+  // 根据模型类型设置对应的环境变量
+  // 这样 SDK 就能知道具体使用哪个版本
+  if (lowerModel.includes('opus')) {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = modelId;
+    console.log('[MODEL_ENV] Set ANTHROPIC_DEFAULT_OPUS_MODEL =', modelId);
+  } else if (lowerModel.includes('haiku')) {
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = modelId;
+    console.log('[MODEL_ENV] Set ANTHROPIC_DEFAULT_HAIKU_MODEL =', modelId);
+  } else if (lowerModel.includes('sonnet')) {
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = modelId;
+    console.log('[MODEL_ENV] Set ANTHROPIC_DEFAULT_SONNET_MODEL =', modelId);
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ checkstyle {
 }
 
 group = 'com.github.idea-claude-code-gui'
-version = '0.1.7'
+version = '0.1.7-fix'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -21,8 +21,11 @@ const DEFAULT_MODEL_MAP: Record<string, ModelInfo> = AVAILABLE_MODELS.reduce(
 
 const MODEL_LABEL_KEYS: Record<string, string> = {
   'claude-sonnet-4-5': 'models.claude.sonnet45.label',
+  'claude-opus-4-6': 'models.claude.opus46.label',
   'claude-opus-4-5-20251101': 'models.claude.opus45.label',
   'claude-haiku-4-5': 'models.claude.haiku45.label',
+  'gpt-5.3-codex': 'models.codex.gpt53codex.label',
+  'gpt-5.3': 'models.codex.gpt53.label',
   'gpt-5.2-codex': 'models.codex.gpt52codex.label',
   'gpt-5.1-codex-max': 'models.codex.gpt51codexMax.label',
   'gpt-5.1-codex-mini': 'models.codex.gpt51codexMini.label',
@@ -31,8 +34,11 @@ const MODEL_LABEL_KEYS: Record<string, string> = {
 
 const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   'claude-sonnet-4-5': 'models.claude.sonnet45.description',
+  'claude-opus-4-6': 'models.claude.opus46.description',
   'claude-opus-4-5-20251101': 'models.claude.opus45.description',
   'claude-haiku-4-5': 'models.claude.haiku45.description',
+  'gpt-5.3-codex': 'models.codex.gpt53codex.description',
+  'gpt-5.3': 'models.codex.gpt53.description',
   'gpt-5.2-codex': 'models.codex.gpt52codex.description',
   'gpt-5.1-codex-max': 'models.codex.gpt51codexMax.description',
   'gpt-5.1-codex-mini': 'models.codex.gpt51codexMini.description',

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -244,6 +244,11 @@ export const CLAUDE_MODELS: ModelInfo[] = [
     description: 'Sonnet 4.5 · Use the default model',
   },
   {
+    id: 'claude-opus-4-6',
+    label: 'Opus 4.6',
+    description: 'Opus 4.6 · Latest and most capable',
+  },
+  {
     id: 'claude-opus-4-5-20251101',
     label: 'Opus 4.5',
     description: 'Opus 4.5 · Most capable for complex work',
@@ -260,9 +265,24 @@ export const CLAUDE_MODELS: ModelInfo[] = [
  */
 export const CODEX_MODELS: ModelInfo[] = [
   {
+    id: 'gpt-5.3-codex',
+    label: 'gpt-5.3-codex',
+    description: 'Latest frontier agentic coding model with enhanced capabilities.',
+  },
+  {
+    id: 'gpt-5.3',
+    label: 'gpt-5.3',
+    description: 'Latest frontier model with significant improvements.',
+  },
+  {
     id: 'gpt-5.2-codex',
     label: 'gpt-5.2-codex',
     description: 'Latest frontier agentic coding model.',
+  },
+  {
+    id: 'gpt-5.2',
+    label: 'gpt-5.2',
+    description: 'Latest frontier model with improvements across knowledge.',
   },
   {
     id: 'gpt-5.1-codex-max',
@@ -273,11 +293,6 @@ export const CODEX_MODELS: ModelInfo[] = [
     id: 'gpt-5.1-codex-mini',
     label: 'gpt-5.1-codex-mini',
     description: 'Optimized for codex. Cheaper, faster, but less capable.',
-  },
-  {
-    id: 'gpt-5.2',
-    label: 'gpt-5.2',
-    description: 'Latest frontier model with improvements across knowledge.',
   },
 ];
 

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -892,6 +892,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · Use the default model"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · Latest and most capable"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · Most capable for complex work"
@@ -902,6 +906,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "Latest frontier agentic coding model with enhanced capabilities."
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "Latest frontier model with significant improvements."
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "Latest frontier agentic coding model."

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -727,6 +727,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · Modelo recomendado por defecto"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · El más reciente y capaz"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · Más capaz para trabajos complejos"
@@ -737,6 +741,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "Último modelo de codificación agéntico con capacidades mejoradas."
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "Último modelo de frontera con mejoras significativas."
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "Último modelo de codificación agéntico de frontera."

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -727,6 +727,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · Modèle recommandé par défaut"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · Le plus récent et le plus performant"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · Le plus performant pour les tâches complexes"
@@ -737,6 +741,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "Dernier modèle de codage agentique avec des capacités améliorées."
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "Dernier modèle de pointe avec des améliorations significatives."
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "Dernier modèle de codage agentique de pointe."

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -724,6 +724,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · डिफ़ॉल्ट अनुशंसित मॉडल"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · नवीनतम और सबसे सक्षम"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · जटिल कार्यों के लिए सबसे सक्षम"
@@ -734,6 +738,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "नवीनतम फ्रंटियर एजेंटिक कोडिंग मॉडल, उन्नत क्षमताओं के साथ।"
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "नवीनतम फ्रंटियर मॉडल, महत्वपूर्ण सुधारों के साथ।"
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "नवीनतम फ्रंटियर एजेंटिक कोडिंग मॉडल।"

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -746,6 +746,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · デフォルトモデルを使用"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · 最新かつ最も優れたモデル"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · 複雑な作業に最も有能"
@@ -756,6 +760,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "最新の最先端エージェントコーディングモデル（機能強化版）"
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "最新の最先端モデル、大幅な性能向上"
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "最新の最先端エージェントコーディングモデル"

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -732,6 +732,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 4.5 · 預設推薦模型"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · 最新最強大的模型"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 4.5 · 處理複雜任務最強性能"
@@ -742,6 +746,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "最新前沿智慧編程模型，能力全面增強"
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "最新前沿模型，性能顯著提升"
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "最新前沿智慧編程模型"

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -893,6 +893,10 @@
         "label": "Sonnet 4.5",
         "description": "Sonnet 默认推荐模型"
       },
+      "opus46": {
+        "label": "Opus 4.6",
+        "description": "Opus 4.6 · 最新最强大的模型"
+      },
       "opus45": {
         "label": "Opus 4.5",
         "description": "Opus 复杂任务最强性能"
@@ -903,6 +907,14 @@
       }
     },
     "codex": {
+      "gpt53codex": {
+        "label": "gpt-5.3-codex",
+        "description": "最新前沿智能编程模型，能力全面增强"
+      },
+      "gpt53": {
+        "label": "gpt-5.3",
+        "description": "最新前沿模型，性能显著提升"
+      },
       "gpt52codex": {
         "label": "gpt-5.2-codex",
         "description": "最新前沿智能编程模型"


### PR DESCRIPTION
- Add setModelEnvironmentVariables() to set ANTHROPIC_DEFAULT_*_MODEL env vars so SDK knows the exact model version to use
- Add Claude Opus 4.6 model support
- Add GPT-5.3 and GPT-5.3-codex model support
- Add i18n translations for new models in all locales
- Bump version to 0.1.7-fix