### PR TITLE
fix: unlock Codex SDK version constraint to allow auto-update

### DIFF
--- a/src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java
+++ b/src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java
@@ -23,7 +23,7 @@ public enum SdkDefinition {
         "codex-sdk",
         "Codex SDK",
         "@openai/codex-sdk",
-        "^0.80.0",
+        "latest",
         Collections.emptyList(),
         "Codex AI 提供商所需。"
     );


### PR DESCRIPTION
## Summary
- Codex SDK 版本约束从 `^0.80.0` 改为 `latest`，解决版本锁定无法自动更新的问题

Closes #300

## Changes

`src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java`

```diff
 CODEX_SDK(
     "codex-sdk",
     "Codex SDK",
     "@openai/codex-sdk",
-    "^0.80.0",
+    "latest",
     Collections.emptyList(),
     "Codex AI 提供商所需。"
 );
