### PR TITLE
chore: Configure Rider 2025.3.2 with terminal plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,11 @@ dependencies {
         } else if (targetIde == 'PY') {
             pycharmProfessional('2024.3')
             bundledPlugin('Pythonid')
+        } else if (targetIde == 'RD') {
+            // Rider 2025.3.2
+            rider('2025.3.2')
+            // Enable Terminal Plugin support
+            bundledPlugin('org.jetbrains.plugins.terminal')
         } else {
             intellijIdeaCommunity('2024.3.1')
             bundledPlugin('com.intellij.java')
@@ -101,8 +106,15 @@ dependencies {
 sourceSets {
     main {
         java {
-            if (project.findProperty('targetIde') == 'PC' || project.findProperty('targetIde') == 'PY') {
+            def targetIde = project.findProperty('targetIde') ?: 'IC'
+            // PyCharm: exclude Java context collector
+            if (targetIde == 'PC' || targetIde == 'PY') {
                 exclude '**/JavaContextCollector.java'
+            }
+            // Rider: exclude both Java and Python context collectors (no PSI support)
+            if (targetIde == 'RD') {
+                exclude '**/JavaContextCollector.java'
+                exclude '**/PythonContextCollector.java'
             }
         }
     }


### PR DESCRIPTION
- Configure Rider IDE environment with version 2025.3.2 and terminal plugin, excluding Java and Python context collectors.