### PR TITLE
feat(history):增加时间展示

### DIFF
--- a/webview/src/components/settings/OtherSettingsSection/index.tsx
+++ b/webview/src/components/settings/OtherSettingsSection/index.tsx
@@ -62,6 +62,31 @@ interface EditorState {
   item?: HistoryItem;
 }
 
+/**
+ * Format timestamp to relative time string
+ */
+const formatRelativeTime = (timestamp: string | undefined, t: (key: string) => string): string => {
+  if (!timestamp) {
+    return '';
+  }
+  const seconds = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
+  const units: [number, string][] = [
+    [31536000, t('settings.other.historyCompletion.timeAgo.yearsAgo')],
+    [2592000, t('settings.other.historyCompletion.timeAgo.monthsAgo')],
+    [86400, t('settings.other.historyCompletion.timeAgo.daysAgo')],
+    [3600, t('settings.other.historyCompletion.timeAgo.hoursAgo')],
+    [60, t('settings.other.historyCompletion.timeAgo.minutesAgo')],
+  ];
+
+  for (const [unitSeconds, label] of units) {
+    const interval = Math.floor(seconds / unitSeconds);
+    if (interval >= 1) {
+      return `${interval} ${label}`;
+    }
+  }
+  return t('settings.other.historyCompletion.timeAgo.justNow');
+};
+
 const OtherSettingsSection = ({
   historyCompletionEnabled,
   onHistoryCompletionEnabledChange,
@@ -252,6 +277,11 @@ const OtherSettingsSection = ({
                         <span className={styles.historyText} title={item.text}>
                           {item.text}
                         </span>
+                        {item.timestamp && (
+                          <span className={styles.historyTimestamp} title={new Date(item.timestamp).toLocaleString()}>
+                            {formatRelativeTime(item.timestamp, t)}
+                          </span>
+                        )}
                         <div className={styles.itemActions}>
                           <button
                             type="button"

--- a/webview/src/components/settings/OtherSettingsSection/style.module.less
+++ b/webview/src/components/settings/OtherSettingsSection/style.module.less
@@ -209,6 +209,14 @@
   white-space: nowrap;
 }
 
+.historyTimestamp {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-right: 8px;
+}
+
 .itemActions {
   display: flex;
   align-items: center;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -238,6 +238,14 @@
           "contentPlaceholder": "Enter history record content...",
           "importanceLabel": "Importance",
           "importanceHint": "Higher importance means higher priority in auto-completion"
+        },
+        "timeAgo": {
+          "yearsAgo": "years ago",
+          "monthsAgo": "months ago",
+          "daysAgo": "days ago",
+          "hoursAgo": "hours ago",
+          "minutesAgo": "minutes ago",
+          "justNow": "just now"
         }
       }
     },

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -202,6 +202,14 @@
           "contentPlaceholder": "Ingresa el contenido del registro...",
           "importanceLabel": "Importancia",
           "importanceHint": "Mayor importancia significa mayor prioridad en el autocompletado"
+        },
+        "timeAgo": {
+          "yearsAgo": "años",
+          "monthsAgo": "meses",
+          "daysAgo": "días",
+          "hoursAgo": "horas",
+          "minutesAgo": "minutos",
+          "justNow": "ahora mismo"
         }
       }
     },

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -202,6 +202,14 @@
           "contentPlaceholder": "Entrez le contenu de l'enregistrement...",
           "importanceLabel": "Importance",
           "importanceHint": "Une importance plus élevée signifie une priorité plus élevée dans l'auto-complétion"
+        },
+        "timeAgo": {
+          "yearsAgo": "ans",
+          "monthsAgo": "mois",
+          "daysAgo": "jours",
+          "hoursAgo": "heures",
+          "minutesAgo": "minutes",
+          "justNow": "à l'instant"
         }
       }
     },

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -200,6 +200,14 @@
           "contentPlaceholder": "इतिहास रिकॉर्ड सामग्री दर्ज करें...",
           "importanceLabel": "महत्व",
           "importanceHint": "उच्च महत्व का अर्थ है स्वतः पूर्ण में उच्च प्राथमिकता"
+        },
+        "timeAgo": {
+          "yearsAgo": "साल पहले",
+          "monthsAgo": "महीने पहले",
+          "daysAgo": "दिन पहले",
+          "hoursAgo": "घंटे पहले",
+          "minutesAgo": "मिनट पहले",
+          "justNow": "अभी"
         }
       }
     },

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -207,6 +207,14 @@
           "contentPlaceholder": "履歴記録の内容を入力...",
           "importanceLabel": "重要度",
           "importanceHint": "重要度が高いほど、自動補完で優先されます"
+        },
+        "timeAgo": {
+          "yearsAgo": "年前",
+          "monthsAgo": "ヶ月前",
+          "daysAgo": "日前",
+          "hoursAgo": "時間前",
+          "minutesAgo": "分前",
+          "justNow": "たった今"
         }
       }
     },

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -202,6 +202,14 @@
           "contentPlaceholder": "輸入歷史記錄內容...",
           "importanceLabel": "重要度",
           "importanceHint": "重要度越高，自動補全時越靠前"
+        },
+        "timeAgo": {
+          "yearsAgo": "年前",
+          "monthsAgo": "個月前",
+          "daysAgo": "天前",
+          "hoursAgo": "小時前",
+          "minutesAgo": "分鐘前",
+          "justNow": "剛剛"
         }
       }
     },

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -238,6 +238,14 @@
           "contentPlaceholder": "输入历史记录内容...",
           "importanceLabel": "重要度",
           "importanceHint": "重要度越高，自动补全时越靠前"
+        },
+        "timeAgo": {
+          "yearsAgo": "年前",
+          "monthsAgo": "个月前",
+          "daysAgo": "天前",
+          "hoursAgo": "小时前",
+          "minutesAgo": "分钟前",
+          "justNow": "刚刚"
         }
       }
     },


### PR DESCRIPTION
## 概要
- 为历史记录项添加时间戳追踪功能
- 在设置页面显示相对时间（如"3天前"、"刚刚"）
- 添加所有语言的 i18n 支持（en, zh, zh-TW, ja, es, fr, hi）

Closes #416

## 变更内容
- `useInputHistory.ts`: 添加时间戳存储/加载逻辑
- `OtherSettingsSection`: 使用 `formatRelativeTime` 函数显示相对时间
- `style.module.less`: 添加 `.historyTimestamp` 样式
- i18n locales: 添加 `timeAgo` 翻译键

## 测试计划
- [x] 验证使用历史记录补全时时间戳被正确保存
- [x] 验证设置页面中相对时间显示正确
- [x] 验证不同语言环境下翻译正常工作


## 样式

<img width="732" height="401" alt="image" src="https://github.com/user-attachments/assets/9b7968f0-7753-4527-81c2-14fbd307c1b9" />
