### PR TITLE
fix: pass proxy env vars from settings.json to Node.js process

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -190,6 +190,15 @@ export function setupApiKey() {
         process.env.ANTHROPIC_BASE_URL = baseUrl;
       }
 
+      // CLI session 路径也需要注入代理环境变量
+      const PROXY_VARS = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
+      for (const varName of PROXY_VARS) {
+        if (settings?.env?.[varName] && !process.env[varName]) {
+          process.env[varName] = settings.env[varName];
+          console.log(`[DEBUG] Set ${varName} from settings.json`);
+        }
+      }
+
       console.log('[DEBUG] Auth type:', authType);
       return { apiKey: null, baseUrl, authType, apiKeySource, baseUrlSource };
     } else {
@@ -218,6 +227,17 @@ export function setupApiKey() {
 
   if (baseUrl) {
     process.env.ANTHROPIC_BASE_URL = baseUrl;
+  }
+
+  // 从 settings.json 注入代理环境变量到 process.env
+  // IDE 通过桌面启动器启动时不会继承 shell 中的代理配置，
+  // 因此需要从 settings.json 显式读取并设置
+  const PROXY_ENV_VARS = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
+  for (const varName of PROXY_ENV_VARS) {
+    if (settings?.env?.[varName] && !process.env[varName]) {
+      process.env[varName] = settings.env[varName];
+      console.log(`[DEBUG] Set ${varName} from settings.json`);
+    }
   }
 
   console.log('[DEBUG] Auth type:', authType);


### PR DESCRIPTION
## Summary

- Fix proxy not working when IDE is launched from desktop launcher (not terminal)
- Read `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (and lowercase variants) from `~/.claude/settings.json` `env` field and inject into `process.env`
- Covers both API key auth path and CLI session auth path in `setupApiKey()`

## Problem

When Android Studio (or other JetBrains IDEs) is launched from desktop launcher, shell environment variables like `HTTP_PROXY`/`HTTPS_PROXY` are **not inherited**. The Claude Agent SDK supports these variables for network proxy, but they never reach the Node.js subprocess because:

1. IDE process doesn't inherit shell env vars (`.bashrc`/`.zshrc`)
2. `EnvironmentConfigurator.java` doesn't forward proxy vars
3. `setupApiKey()` only sets auth-related vars, not proxy vars

## Solution

In `setupApiKey()`, after setting auth/baseUrl vars, also read proxy env vars from `settings.json` and inject them into `process.env`. This is done for both code paths (API key auth and CLI session auth).

## Usage

Users can configure proxy in `~/.claude/settings.json`:

```json
{
  "env": {
    "HTTP_PROXY": "http://127.0.0.1:7890",
    "HTTPS_PROXY": "http://127.0.0.1:7890",
    "NO_PROXY": "localhost,127.0.0.1"
  }
}
```

## Test plan

- [x] Set proxy in `~/.claude/settings.json` env field
- [x] Launch IDE from desktop launcher (not terminal)
- [x] Verify plugin can connect to Claude API through proxy
- [x] Verify proxy vars appear in Node.js debug logs (`[DEBUG] Set HTTP_PROXY from settings.json`)
- [x] Verify existing behavior without proxy config is unchanged