### PR TITLE
fix(webview): resolve paste-then-send race condition in chat input

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -482,6 +482,7 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
 
     const handleSubmit = useSubmitHandler({
       getTextContent,
+      invalidateCache,
       attachments,
       isLoading,
       sdkStatusLoading,
@@ -578,6 +579,7 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
       fileCompletion,
       commandCompletion,
       handleInput,
+      flushInput: debouncedOnInput.flush,
     });
 
     const { handleAddAttachment, handleRemoveAttachment } = useAttachmentHandlers({

--- a/webview/src/components/ChatInputBox/hooks/useResizableChatInputBox.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useResizableChatInputBox.test.ts
@@ -2,38 +2,38 @@ import { describe, expect, it } from 'vitest';
 import { computeResize } from './useResizableChatInputBox.js';
 
 describe('useResizableChatInputBox/computeResize', () => {
-  it('resizes width on east handle and clamps to bounds', () => {
-    const bounds = { minWidthPx: 320, maxWidthPx: 500, minWrapperHeightPx: 96, maxWrapperHeightPx: 400 };
-    const start = { startX: 0, startY: 0, startWidthPx: 400, startWrapperHeightPx: 200 };
+  it('keeps current height when no vertical drag', () => {
+    const bounds = { minWrapperHeightPx: 96, maxWrapperHeightPx: 400 };
+    const start = { startY: 0, startWrapperHeightPx: 200 };
 
-    expect(computeResize(start, { x: 50, y: 0 }, 'e', bounds)).toEqual({
-      widthPx: 450,
+    expect(computeResize(start, { y: 0 }, bounds)).toEqual({
       wrapperHeightPx: 200,
     });
-
-    // clamp
-    expect(computeResize(start, { x: 200, y: 0 }, 'e', bounds).widthPx).toBe(500);
-    expect(computeResize(start, { x: -200, y: 0 }, 'e', bounds).widthPx).toBe(320);
   });
 
   it('resizes height on north handle (drag up increases) and clamps to bounds', () => {
-    const bounds = { minWidthPx: 320, maxWidthPx: 900, minWrapperHeightPx: 96, maxWrapperHeightPx: 240 };
-    const start = { startX: 0, startY: 100, startWidthPx: 600, startWrapperHeightPx: 120 };
+    const bounds = { minWrapperHeightPx: 96, maxWrapperHeightPx: 240 };
+    const start = { startY: 100, startWrapperHeightPx: 120 };
 
-    // drag up (y smaller) => height increases
-    expect(computeResize(start, { x: 0, y: 50 }, 'n', bounds).wrapperHeightPx).toBe(170);
+    // drag to y=50 => dy = 50 - 100 = -50 => height = 120 - (-50) = 170
+    expect(computeResize(start, { y: 50 }, bounds).wrapperHeightPx).toBe(170);
 
-    // clamp
-    expect(computeResize(start, { x: 0, y: 0 }, 'n', bounds).wrapperHeightPx).toBe(220);
-    expect(computeResize(start, { x: 0, y: 500 }, 'n', bounds).wrapperHeightPx).toBe(96);
+    // drag to y=0 => dy = 0 - 100 = -100 => height = 120 + 100 = 220
+    expect(computeResize(start, { y: 0 }, bounds).wrapperHeightPx).toBe(220);
+
+    // clamp to max: drag to y=-200 => dy = -300 => height = 420, clamped to 240
+    expect(computeResize(start, { y: -200 }, bounds).wrapperHeightPx).toBe(240);
+
+    // clamp to min: drag to y=500 => dy = 400 => height = -280, clamped to 96
+    expect(computeResize(start, { y: 500 }, bounds).wrapperHeightPx).toBe(96);
   });
 
-  it('resizes both on north-east handle', () => {
-    const bounds = { minWidthPx: 320, maxWidthPx: 900, minWrapperHeightPx: 96, maxWrapperHeightPx: 520 };
-    const start = { startX: 10, startY: 10, startWidthPx: 500, startWrapperHeightPx: 200 };
+  it('clamps height within bounds for large drag', () => {
+    const bounds = { minWrapperHeightPx: 96, maxWrapperHeightPx: 520 };
+    const start = { startY: 10, startWrapperHeightPx: 200 };
 
-    const next = computeResize(start, { x: 60, y: -40 }, 'ne', bounds);
-    expect(next).toEqual({ widthPx: 550, wrapperHeightPx: 250 });
+    // drag up by 50 => dy = -40 - 10 = -50 => height = 200 + 50 = 250
+    const next = computeResize(start, { y: -40 }, bounds);
+    expect(next).toEqual({ wrapperHeightPx: 250 });
   });
 });
-

--- a/webview/src/components/ChatInputBox/hooks/useSubmitHandler.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useSubmitHandler.test.ts
@@ -16,12 +16,14 @@ describe('useSubmitHandler', () => {
     const { result } = renderHook(() =>
       useSubmitHandler({
         getTextContent: () => '',
+        invalidateCache: vi.fn(),
         attachments: [],
         isLoading: false,
         sdkStatusLoading: false,
         sdkInstalled: true,
         currentProvider: 'claude',
         clearInput,
+        cancelPendingInput: vi.fn(),
         externalAttachments: undefined,
         setInternalAttachments: vi.fn(),
         fileCompletion: { close },
@@ -47,12 +49,14 @@ describe('useSubmitHandler', () => {
     const { result } = renderHook(() =>
       useSubmitHandler({
         getTextContent: () => 'hello',
+        invalidateCache: vi.fn(),
         attachments: [],
         isLoading: false,
         sdkStatusLoading: true,
         sdkInstalled: true,
         currentProvider: 'claude',
         clearInput,
+        cancelPendingInput: vi.fn(),
         externalAttachments: undefined,
         setInternalAttachments: vi.fn(),
         fileCompletion: { close },
@@ -77,12 +81,14 @@ describe('useSubmitHandler', () => {
     const { result } = renderHook(() =>
       useSubmitHandler({
         getTextContent: () => 'hello',
+        invalidateCache: vi.fn(),
         attachments: [],
         isLoading: false,
         sdkStatusLoading: false,
         sdkInstalled: false,
         currentProvider: 'codex',
         clearInput: vi.fn(),
+        cancelPendingInput: vi.fn(),
         externalAttachments: undefined,
         setInternalAttachments: vi.fn(),
         fileCompletion: { close: vi.fn() },
@@ -107,16 +113,19 @@ describe('useSubmitHandler', () => {
     const recordInputHistory = vi.fn();
     const close = vi.fn();
     const onSubmit = vi.fn();
+    const invalidateCache = vi.fn();
 
     const { result } = renderHook(() =>
       useSubmitHandler({
         getTextContent: () => 'hello',
+        invalidateCache,
         attachments: [createAttachment('a1')],
         isLoading: false,
         sdkStatusLoading: false,
         sdkInstalled: true,
         currentProvider: 'claude',
         clearInput,
+        cancelPendingInput: vi.fn(),
         externalAttachments: undefined,
         setInternalAttachments: vi.fn(),
         fileCompletion: { close },
@@ -129,6 +138,7 @@ describe('useSubmitHandler', () => {
     );
 
     result.current();
+    expect(invalidateCache).toHaveBeenCalled();
     expect(close).toHaveBeenCalledTimes(3);
     expect(recordInputHistory).toHaveBeenCalledWith('hello');
     expect(clearInput).toHaveBeenCalled();

--- a/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
+++ b/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
@@ -16,6 +16,8 @@ export interface UseSubmitHandlerOptions {
   clearInput: () => void;
   /** Cancel any pending debounced input callbacks to prevent stale values from refilling the input */
   cancelPendingInput: () => void;
+  /** Invalidate text content cache to force fresh DOM read on submit */
+  invalidateCache: () => void;
   externalAttachments: Attachment[] | undefined;
   setInternalAttachments: Dispatch<SetStateAction<Attachment[]>>;
   fileCompletion: CompletionLike;
@@ -45,6 +47,7 @@ export function useSubmitHandler({
   currentProvider,
   clearInput,
   cancelPendingInput,
+  invalidateCache,
   externalAttachments,
   setInternalAttachments,
   fileCompletion,
@@ -57,6 +60,8 @@ export function useSubmitHandler({
   t,
 }: UseSubmitHandlerOptions) {
   return useCallback(() => {
+    // Force fresh DOM read to avoid stale cache (e.g., after paste)
+    invalidateCache();
     const content = getTextContent();
     const cleanContent = content.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
 
@@ -104,6 +109,7 @@ export function useSubmitHandler({
     }, 10);
   }, [
     getTextContent,
+    invalidateCache,
     attachments,
     isLoading,
     sdkStatusLoading,

--- a/webview/src/components/ChatInputBox/utils/debounce.ts
+++ b/webview/src/components/ChatInputBox/utils/debounce.ts
@@ -1,10 +1,12 @@
 /**
- * Debounced function interface with cancel capability
+ * Debounced function interface with cancel and flush capabilities
  */
 export interface DebouncedFunction<Args extends unknown[]> {
   (...args: Args): void;
   /** Cancel any pending execution */
   cancel: () => void;
+  /** Immediately execute any pending callback with the last-provided arguments */
+  flush: () => void;
 }
 
 /**
@@ -16,18 +18,27 @@ export interface DebouncedFunction<Args extends unknown[]> {
  * const debouncedFn = debounce(myFn, 300);
  * debouncedFn('arg1');
  * debouncedFn.cancel(); // Cancel pending execution (e.g., on unmount)
+ * debouncedFn.flush();  // Immediately execute pending callback
  */
 export function debounce<Args extends unknown[]>(
   func: (...args: Args) => void,
   wait: number
 ): DebouncedFunction<Args> {
   let timeout: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Args | null = null;
+  let lastThis: unknown = null;
 
   const debouncedFn = function (this: unknown, ...args: Args) {
+    lastArgs = args;
+    lastThis = this;
     if (timeout) clearTimeout(timeout);
     timeout = setTimeout(() => {
       timeout = null;
-      func.apply(this, args);
+      const a = lastArgs;
+      const ctx = lastThis;
+      lastArgs = null;
+      lastThis = null;
+      func.apply(ctx, a!);
     }, wait);
   } as DebouncedFunction<Args>;
 
@@ -35,6 +46,20 @@ export function debounce<Args extends unknown[]>(
     if (timeout) {
       clearTimeout(timeout);
       timeout = null;
+    }
+    lastArgs = null;
+    lastThis = null;
+  };
+
+  debouncedFn.flush = () => {
+    if (timeout && lastArgs) {
+      clearTimeout(timeout);
+      timeout = null;
+      const args = lastArgs;
+      const ctx = lastThis;
+      lastArgs = null;
+      lastThis = null;
+      func.apply(ctx, args);
     }
   };
 


### PR DESCRIPTION
When users paste text and immediately press Enter, the debounced onInput callback hasn't fired yet, causing the parent component to receive stale or empty content.

- Add flush() method to debounce utility for immediate execution of pending callbacks, using unified lastArgs/lastThis tracking for both timeout and flush code paths
- Call invalidateCache() before getTextContent() in submit handler to force fresh DOM read
- Call flushInput() after paste to immediately sync parent state
- Simplify computeResize to height-only (remove unused width logic)
- Update tests with invalidateCache assertions and new parameters

Fixes #408 