### PR TITLE
fix: correct token calculation formula to include cache_read_input_tokens

### DIFF
--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -362,6 +362,19 @@ function truncateErrorContent(content, maxLen = 1000) {
   return content.substring(0, maxLen) + `... [truncated, total ${content.length} chars]`;
 }
 
+/**
+ * Emit [USAGE] tag for Java-side token tracking.
+ */
+function emitUsageTag(msg) {
+  if (msg.type === 'assistant' && msg.message?.usage) {
+    const { input_tokens = 0, output_tokens = 0,
+            cache_creation_input_tokens = 0, cache_read_input_tokens = 0 } = msg.message.usage;
+    console.log('[USAGE]', JSON.stringify({
+      input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens
+    }));
+  }
+}
+
 const MAX_TOOL_RESULT_CONTENT_CHARS = 20000;
 
 /**
@@ -888,6 +901,9 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
           }
         }
       }
+
+      // Emit usage data for Java-side token tracking
+      emitUsageTag(msg);
 
       // Output tool call results in real-time (tool_result in user messages)
       if (msg.type === 'user') {
@@ -1594,6 +1610,9 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
 	    	          }
 	    	        }
 	    	      }
+
+	    	      // Emit usage data for Java-side token tracking
+	    	      emitUsageTag(msg);
 
 	    	      // Output tool call results in real-time (tool_result in user messages)
 	    	      if (msg.type === 'user') {

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -4,6 +4,7 @@ import com.github.claudecodegui.CodemossSettingsService;
 import com.github.claudecodegui.provider.claude.ClaudeHistoryReader;
 import com.github.claudecodegui.provider.codex.CodexHistoryReader;
 import com.github.claudecodegui.ClaudeSession;
+import com.github.claudecodegui.session.ClaudeMessageHandler;
 import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.model.NodeDetectionResult;
 import com.github.claudecodegui.util.FontConfigService;
@@ -353,48 +354,8 @@ public class SettingsHandler extends BaseMessageHandler {
 
             // Extract the latest usage information from the current session
             List<ClaudeSession.Message> messages = session.getMessages();
-            JsonObject lastUsage = null;
-
-            for (int i = messages.size() - 1; i >= 0; i--) {
-                ClaudeSession.Message msg = messages.get(i);
-
-                if (msg.type != ClaudeSession.Message.Type.ASSISTANT || msg.raw == null) {
-                    continue;
-                }
-
-                // Check different possible structures
-                if (msg.raw.has("message")) {
-                    JsonObject message = msg.raw.getAsJsonObject("message");
-                    if (message.has("usage")) {
-                        lastUsage = message.getAsJsonObject("usage");
-                        break;
-                    }
-                }
-
-                // Check if usage is at the root level of raw
-                if (msg.raw.has("usage")) {
-                    lastUsage = msg.raw.getAsJsonObject("usage");
-                    break;
-                }
-            }
-
-            // Calculate used tokens
-            int inputTokens = lastUsage != null && lastUsage.has("input_tokens") ? lastUsage.get("input_tokens").getAsInt() : 0;
-            int cacheWriteTokens = lastUsage != null && lastUsage.has("cache_creation_input_tokens") ? lastUsage.get("cache_creation_input_tokens").getAsInt() : 0;
-            int cacheReadTokens = lastUsage != null && lastUsage.has("cache_read_input_tokens") ? lastUsage.get("cache_read_input_tokens").getAsInt() : 0;
-            int outputTokens = lastUsage != null && lastUsage.has("output_tokens") ? lastUsage.get("output_tokens").getAsInt() : 0;
-
-            // Calculate used token count based on provider
-            // Codex/OpenAI: input_tokens already includes cached_input_tokens, no need to add again
-            // Claude: input_tokens does not include cache, need to add cache_creation (cache reads don't consume new context window)
-            String currentProvider = context.getCurrentProvider();
-            int usedTokens;
-            if ("codex".equals(currentProvider)) {
-                usedTokens = inputTokens + outputTokens;
-            } else {
-                // Claude: cache reads don't consume new context window, so cacheReadTokens is excluded
-                usedTokens = inputTokens + cacheWriteTokens + outputTokens;
-            }
+            JsonObject lastUsage = ClaudeMessageHandler.findLastUsageFromSessionMessages(messages);
+            int usedTokens = ClaudeMessageHandler.extractUsedTokens(lastUsage, context.getCurrentProvider());
 
             // Send update
             sendUsageUpdate(usedTokens, newMaxTokens);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -161,6 +161,9 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         } else if (line.startsWith("[TOOL_RESULT]")) {
             String toolResultJson = line.substring("[TOOL_RESULT]".length()).trim();
             callback.onMessage("tool_result", toolResultJson);
+        } else if (line.startsWith("[USAGE]")) {
+            String usageJson = line.substring("[USAGE]".length()).trim();
+            callback.onMessage("usage", usageJson);
         } else if (line.startsWith("[MESSAGE_START]")) {
             callback.onMessage("message_start", "");
         } else if (line.startsWith("[MESSAGE_END]")) {
@@ -816,6 +819,9 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                             } else if (line.startsWith("[TOOL_RESULT]")) {
                                 String toolResultJson = line.substring("[TOOL_RESULT]".length()).trim();
                                 callback.onMessage("tool_result", toolResultJson);
+                            } else if (line.startsWith("[USAGE]")) {
+                                String usageJson = line.substring("[USAGE]".length()).trim();
+                                callback.onMessage("usage", usageJson);
                             } else if (line.startsWith("[MESSAGE_START]")) {
                                 callback.onMessage("message_start", "");
                             } else if (line.startsWith("[MESSAGE_END]")) {


### PR DESCRIPTION
The context window token formula was wrong in multiple code paths:
- Old (wrong): input_tokens + cache_creation_input_tokens + output_tokens
- New (correct): input_tokens + cache_creation_input_tokens + cache_read_input_tokens

output_tokens don't count toward context window until the next turn, while cache_read_input_tokens do occupy context window space.

Changes:
- Add [USAGE] tag pipeline: ai-bridge emits usage data, Java parses it
- Extract shared methods in ClaudeMessageHandler: calculateContextWindowTokens, extractUsedTokens, findLastUsageFromRawMessages, findLastUsageFromSessionMessages
- Fix formula in all 5 code paths: ClaudeMessageHandler.handleResult, ClaudeMessageHandler.handleUsage, ClaudeSDKToolWindow.pushUsageUpdateFromMessages, SettingsHandler.handleSetModel, ClaudeSession.extractAndDisplayTokenUsage
- Add extractAndDisplayTokenUsage for resume/history-load path
- Extract emitUsageTag helper in message-service.js to eliminate duplication

Based on claude code cli behavior.