### PR TITLE
feat: add AI-powered prompt suggestion (predicted next input)

### DIFF
--- a/ai-bridge/services/prompt-suggestion.js
+++ b/ai-bridge/services/prompt-suggestion.js
@@ -1,0 +1,270 @@
+/**
+ * Prompt Suggestion Service.
+ * Predicts what the user might type next based on recent conversation context.
+ * Uses a low-cost API call (Haiku / low effort) to generate short suggestions.
+ *
+ * Input (stdin JSON):
+ * - recentMessages: Array of { role: 'user'|'assistant', content: string }
+ * - model: Optional model ID override
+ *
+ * Output (stdout):
+ * - [PROMPT_SUGGESTION]<text> on success
+ * - [PROMPT_SUGGESTION] (empty) when suggestion is filtered out
+ * - [PROMPT_SUGGESTION_ERROR]<message> on failure
+ */
+
+import { loadClaudeSdk, isClaudeSdkAvailable } from '../utils/sdk-loader.js';
+import { setupApiKey } from '../config/api-config.js';
+import { getRealHomeDir } from '../utils/path-utils.js';
+
+let claudeSdk = null;
+
+async function ensureClaudeSdk() {
+  if (!claudeSdk) {
+    if (!isClaudeSdkAvailable()) {
+      const error = new Error('Claude Code SDK not installed. Please install via Settings > Dependencies.');
+      error.code = 'SDK_NOT_INSTALLED';
+      throw error;
+    }
+    claudeSdk = await loadClaudeSdk();
+  }
+  return claudeSdk;
+}
+
+// The suggestion generation prompt — adapted from Claude CLI's prompt
+const SUGGESTION_PROMPT = `You predict what the user would type next. Output ONLY the short phrase, nothing else.
+
+Rules:
+- 2-12 words (or 2-30 CJK characters)
+- Single line, no newlines
+- No explanation, no reasoning, no quotes
+- Match the user's language (Chinese/English/etc.)
+- No evaluative phrases (thanks, looks good, 谢谢, 很好)
+- No AI-voice (Let me, I'll, 让我, 我来)
+- Empty response if unsure
+
+Examples:
+"fix bug and run tests" + bug fixed → run the tests
+代码写完 → 提交代码
+Task done → commit this
+Asked to continue → yes`;
+
+// Action words that are acceptable as single-word suggestions
+const SINGLE_WORD_ACTIONS = new Set([
+  'yes', 'yeah', 'yep', 'yea', 'yup', 'sure', 'ok', 'okay',
+  'push', 'commit', 'deploy', 'stop', 'continue', 'check', 'no',
+]);
+
+/**
+ * Check if a suggestion should be filtered out.
+ * Returns a reason string if invalid, or null if valid.
+ * @param {string} text - The suggestion text
+ * @returns {string|null} Filter reason or null
+ */
+function getFilterReason(text) {
+  if (!text) return 'empty';
+
+  const lower = text.toLowerCase();
+  const trimmed = text.trim();
+  // CJK characters count as individual "words" for length checks
+  const cjkChars = (trimmed.match(/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []).length;
+  const hasCJK = cjkChars > 0;
+  const wordCount = hasCJK
+    ? cjkChars + trimmed.split(/\s+/).filter(w => !/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(w)).length
+    : trimmed.split(/\s+/).length;
+
+  // Exact match filters
+  if (lower === 'done') return 'done';
+  if (lower === 'nothing found' || lower === 'nothing found.' ||
+      lower.startsWith('nothing to suggest') || lower.startsWith('no suggestion')) {
+    return 'meta_text';
+  }
+
+  // Error messages
+  if (lower.startsWith('api error:') || lower.startsWith('prompt is too long') ||
+      lower.startsWith('request timed out') || lower.startsWith('invalid api key') ||
+      lower.startsWith('image was too large')) {
+    return 'error_message';
+  }
+
+  // Prefixed labels (e.g., "Note: ...", "Warning: ...")
+  if (/^\w+:\s/.test(text)) return 'prefixed_label';
+
+  // Too few words (unless it's an action word)
+  if (wordCount < 2) {
+    if (text.startsWith('/')) return null; // Slash commands are fine
+    if (!SINGLE_WORD_ACTIONS.has(lower)) return 'too_few_words';
+  }
+
+  // Too many words or too long (CJK chars are denser, allow more "words")
+  const maxWords = hasCJK ? 30 : 12;
+  if (wordCount > maxWords) return 'too_many_words';
+  if (text.length >= 100) return 'too_long';
+
+  // Multiple sentences (including CJK punctuation)
+  if (/[.!?]\s+[A-Z]/.test(text)) return 'multiple_sentences';
+  if (/[。！？][^"'）》」】)]*[\u4e00-\u9fff\u3400-\u4dbf]/.test(text)) return 'multiple_sentences';
+
+  // Has formatting (newlines, markdown bold)
+  if (/\n|\*\*/.test(text)) return 'has_formatting';
+
+  // Evaluative language (English and CJK)
+  if (/thanks|thank you|looks good|sounds good|that works|that worked|that's all|nice|great|perfect|makes sense|awesome|excellent/i.test(lower)) {
+    return 'evaluative';
+  }
+  if (/^(谢谢|感谢|不错|很好|太好了|完美|好的|没问题|可以了|就这样|辛苦了)/.test(text)) {
+    return 'evaluative';
+  }
+
+  // Claude-voice patterns (English and CJK)
+  if (/^(let me|i'll|i've|i'm|i can|i would|i think|i notice|here's|here is|here are|that's|this is|this will|you can|you should|you could|sure,|of course|certainly)/i.test(text)) {
+    return 'claude_voice';
+  }
+  if (/^(让我|我来|我会|我可以|我认为|我注意到|我觉得|我建议|这是|这个|这将|你可以|你应该|当然|好的，)/.test(text)) {
+    return 'claude_voice';
+  }
+
+  return null;
+}
+
+/**
+ * Format recent messages into a conversation context string.
+ * @param {Array<{role: string, content: string}>} messages
+ * @returns {string}
+ */
+function formatConversationContext(messages) {
+  if (!messages || messages.length === 0) {
+    return '';
+  }
+
+  return messages
+    .map(msg => {
+      const role = msg.role === 'user' ? 'User' : 'Assistant';
+      // Truncate long messages to save tokens
+      const content = msg.content.length > 500
+        ? msg.content.slice(0, 500) + '...'
+        : msg.content;
+      return `${role}: ${content}`;
+    })
+    .join('\n\n');
+}
+
+/**
+ * Read input from stdin.
+ */
+async function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => {
+      resolve(data);
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
+ * Generate a prompt suggestion based on recent conversation.
+ * @param {Array<{role: string, content: string}>} recentMessages
+ * @param {string|null} model - Optional model override
+ * @returns {Promise<string|null>} Suggestion text or null
+ */
+async function generateSuggestion(recentMessages, model) {
+  const sdk = await ensureClaudeSdk();
+  const { query } = sdk;
+
+  // Set up API key
+  process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
+  setupApiKey();
+
+  const workingDirectory = getRealHomeDir();
+
+  // Build the full prompt with conversation context
+  const conversationContext = formatConversationContext(recentMessages);
+  const fullPrompt = conversationContext
+    ? `Here is the recent conversation:\n\n${conversationContext}\n\nWhat would the user type next?`
+    : 'What would the user type next?';
+
+  const options = {
+    cwd: workingDirectory,
+    permissionMode: 'bypassPermissions',
+    model: 'haiku',
+    maxTurns: 1,
+    systemPrompt: SUGGESTION_PROMPT,
+    settingSources: ['user', 'project', 'local'],
+  };
+
+  console.log('[PromptSuggestion] Calling Claude SDK for suggestion...');
+
+  const result = query({
+    prompt: fullPrompt,
+    options,
+  });
+
+  let responseText = '';
+  for await (const msg of result) {
+    if (msg.type === 'assistant') {
+      const content = msg.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'text') {
+            responseText += block.text;
+          }
+        }
+      } else if (typeof content === 'string') {
+        responseText += content;
+      }
+    }
+  }
+
+  const suggestion = responseText.trim();
+  if (!suggestion) return null;
+
+  const filterReason = getFilterReason(suggestion);
+  if (filterReason) {
+    console.log(`[PromptSuggestion] Suggestion filtered: reason="${filterReason}", text="${suggestion}"`);
+    return null;
+  }
+
+  return suggestion;
+}
+
+/**
+ * Main entry point.
+ */
+async function main() {
+  try {
+    const input = await readStdin();
+    const data = JSON.parse(input);
+
+    const { recentMessages, model } = data;
+
+    if (!recentMessages || recentMessages.length === 0) {
+      console.log('[PROMPT_SUGGESTION]');
+      process.exit(0);
+    }
+
+    console.log(`[PromptSuggestion] Generating suggestion from ${recentMessages.length} recent messages`);
+
+    const suggestion = await generateSuggestion(recentMessages, model || null);
+
+    if (suggestion) {
+      // Encode newlines to prevent Java's readLine() from splitting
+      const encoded = suggestion.replace(/\n/g, '{{NEWLINE}}');
+      console.log(`[PROMPT_SUGGESTION]${encoded}`);
+    } else {
+      console.log('[PROMPT_SUGGESTION]');
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error('[PromptSuggestion] Error:', error.message);
+    console.log(`[PROMPT_SUGGESTION_ERROR]${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/main/java/com/github/claudecodegui/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/CodemossSettingsService.java
@@ -277,6 +277,10 @@ public class CodemossSettingsService {
         return claudeSettingsManager.getAlwaysThinkingEnabled();
     }
 
+    public boolean isPromptSuggestionEnabled() throws IOException {
+        return claudeSettingsManager.isPromptSuggestionEnabled();
+    }
+
     public void setAlwaysThinkingEnabledInClaudeSettings(boolean enabled) throws IOException {
         claudeSettingsManager.setAlwaysThinkingEnabled(enabled);
     }

--- a/src/main/java/com/github/claudecodegui/handler/PromptSuggestionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PromptSuggestionHandler.java
@@ -1,0 +1,235 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.ClaudeSession;
+import com.github.claudecodegui.bridge.EnvironmentConfigurator;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Prompt suggestion handler.
+ * Generates next-input predictions by calling the AI service after each response completes.
+ * Extracts recent messages from the current session state to build context.
+ */
+public class PromptSuggestionHandler extends BaseMessageHandler {
+
+    private static final Logger LOG = Logger.getInstance(PromptSuggestionHandler.class);
+    private final Gson gson = new Gson();
+    private final EnvironmentConfigurator envConfigurator = new EnvironmentConfigurator();
+
+    // Maximum number of recent message pairs to include (user + assistant)
+    private static final int MAX_RECENT_PAIRS = 3;
+    // Timeout for the Node.js process (seconds)
+    private static final int PROCESS_TIMEOUT_SECONDS = 30;
+
+    private static final String[] SUPPORTED_TYPES = {
+        "request_prompt_suggestion"
+    };
+
+    public PromptSuggestionHandler(HandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if ("request_prompt_suggestion".equals(type)) {
+            handleRequestSuggestion();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Handle a suggestion request.
+     * Extracts recent messages from session state and spawns Node.js to generate suggestion.
+     */
+    private void handleRequestSuggestion() {
+        if (!isEnabledInSettings()) {
+            LOG.info("[PromptSuggestion] Disabled via settings.json");
+            return;
+        }
+
+        LOG.info("[PromptSuggestion] Request received, starting async generation");
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                String payload = buildPayloadFromSession();
+                if (payload == null) {
+                    LOG.info("[PromptSuggestion] No messages in session, skipping");
+                    return;
+                }
+                LOG.info("[PromptSuggestion] Payload built (" + payload.length() + " chars), calling service...");
+                LOG.debug("[PromptSuggestion] Payload: " + payload);
+
+                String suggestion = callPromptSuggestionService(payload);
+                if (suggestion != null && !suggestion.isEmpty()) {
+                    LOG.info("[PromptSuggestion] Got suggestion: " + suggestion);
+                    sendSuggestionToFrontend(suggestion);
+                } else {
+                    LOG.info("[PromptSuggestion] No suggestion generated");
+                }
+            } catch (Exception e) {
+                LOG.warn("[PromptSuggestion] Failed: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    /**
+     * Build the JSON payload for the Node.js service from session messages.
+     * Extracts the last N user-assistant message pairs.
+     */
+    private String buildPayloadFromSession() {
+        ClaudeSession session = context.getSession();
+        if (session == null) return null;
+
+        List<ClaudeSession.Message> allMessages = session.getMessages();
+        if (allMessages == null || allMessages.isEmpty()) return null;
+
+        // Extract recent user/assistant messages, skip tool_result placeholders and empty content
+        List<ClaudeSession.Message> relevantMessages = new ArrayList<>();
+        for (ClaudeSession.Message msg : allMessages) {
+            if (msg.type != ClaudeSession.Message.Type.USER &&
+                msg.type != ClaudeSession.Message.Type.ASSISTANT) continue;
+            String c = msg.content != null ? msg.content.trim() : "";
+            if (c.isEmpty() || "[tool_result]".equals(c)) continue;
+            relevantMessages.add(msg);
+        }
+
+        // Take the last (MAX_RECENT_PAIRS * 2) messages
+        int startIdx = Math.max(0, relevantMessages.size() - MAX_RECENT_PAIRS * 2);
+        JsonArray recentArray = new JsonArray();
+        for (int i = startIdx; i < relevantMessages.size(); i++) {
+            ClaudeSession.Message msg = relevantMessages.get(i);
+            JsonObject msgObj = new JsonObject();
+            msgObj.addProperty("role", msg.type == ClaudeSession.Message.Type.USER ? "user" : "assistant");
+            // Truncate very long messages
+            String content = msg.content != null ? msg.content : "";
+            if (content.length() > 1000) {
+                content = content.substring(0, 1000) + "...";
+            }
+            msgObj.addProperty("content", content);
+            recentArray.add(msgObj);
+        }
+
+        if (recentArray.isEmpty()) return null;
+
+        JsonObject payload = new JsonObject();
+        payload.add("recentMessages", recentArray);
+        return gson.toJson(payload);
+    }
+
+    /**
+     * Call the Node.js prompt-suggestion service.
+     */
+    private String callPromptSuggestionService(String stdinPayload) {
+        try {
+            String nodeExecutable = context.getClaudeSDKBridge().getNodeExecutable();
+            if (nodeExecutable == null) {
+                LOG.error("[PromptSuggestion] Node.js not configured");
+                return null;
+            }
+
+            File bridgeDir = context.getClaudeSDKBridge().getSdkTestDir();
+            if (bridgeDir == null || !bridgeDir.exists()) {
+                LOG.error("[PromptSuggestion] AI Bridge directory not found");
+                return null;
+            }
+
+            File scriptFile = new File(bridgeDir, "services/prompt-suggestion.js");
+            if (!scriptFile.exists()) {
+                LOG.error("[PromptSuggestion] Script not found: " + scriptFile.getAbsolutePath());
+                return null;
+            }
+
+            List<String> command = new ArrayList<>();
+            command.add(nodeExecutable);
+            command.add(scriptFile.getAbsolutePath());
+
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.directory(bridgeDir);
+            pb.redirectErrorStream(true);
+
+            envConfigurator.updateProcessEnvironment(pb, nodeExecutable);
+
+            LOG.info("[PromptSuggestion] Starting: " + String.join(" ", command));
+            Process process = pb.start();
+
+            // Send the recent messages payload via stdin
+            try (OutputStreamWriter writer = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8)) {
+                writer.write(stdinPayload);
+                writer.flush();
+            }
+
+            // Read output and look for the [PROMPT_SUGGESTION] tag
+            StringBuilder suggestion = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("[PROMPT_SUGGESTION]")) {
+                        String text = line.substring("[PROMPT_SUGGESTION]".length()).trim();
+                        text = text.replace("{{NEWLINE}}", "\n");
+                        suggestion.append(text);
+                    } else if (line.startsWith("[PROMPT_SUGGESTION_ERROR]")) {
+                        LOG.warn("[PromptSuggestion] Service error: " + line.substring("[PROMPT_SUGGESTION_ERROR]".length()));
+                    } else {
+                        LOG.debug("[PromptSuggestion] stdout: " + line);
+                    }
+                }
+            }
+
+            boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                LOG.warn("[PromptSuggestion] Process timed out after " + PROCESS_TIMEOUT_SECONDS + "s");
+                process.destroyForcibly();
+                return null;
+            }
+
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                LOG.warn("[PromptSuggestion] Process exited with code " + exitCode);
+            }
+
+            return suggestion.toString();
+
+        } catch (Exception e) {
+            LOG.error("[PromptSuggestion] Service call failed: " + e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Send the suggestion to the frontend via JS callback.
+     */
+    private void sendSuggestionToFrontend(String suggestion) {
+        callJavaScript("window.onPromptSuggestion", escapeJs(suggestion));
+    }
+
+    /**
+     * Check if prompt suggestion is enabled in ~/.claude/settings.json.
+     * Claude CLI stores this as top-level "promptSuggestionEnabled" field.
+     * Default is true (enabled); only explicitly false disables it.
+     */
+    private boolean isEnabledInSettings() {
+        try {
+            return context.getSettingsService().isPromptSuggestionEnabled();
+        } catch (Exception e) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
@@ -240,6 +240,21 @@ public class ClaudeSettingsManager {
     }
 
     /**
+     * Check if prompt suggestion is enabled (default: true).
+     */
+    public boolean isPromptSuggestionEnabled() throws IOException {
+        JsonObject settings = readClaudeSettings();
+        if (settings.has("promptSuggestionEnabled") && !settings.get("promptSuggestionEnabled").isJsonNull()) {
+            try {
+                return settings.get("promptSuggestionEnabled").getAsBoolean();
+            } catch (Exception e) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Apply provider configuration to Claude settings.json.
      * Uses an incremental merge strategy:
      * - User-customized fields are preserved

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -16,6 +16,7 @@ import com.github.claudecodegui.handler.MessageDispatcher;
 import com.github.claudecodegui.handler.PermissionHandler;
 import com.github.claudecodegui.handler.PromptEnhancerHandler;
 import com.github.claudecodegui.handler.PromptHandler;
+import com.github.claudecodegui.handler.PromptSuggestionHandler;
 import com.github.claudecodegui.handler.ProviderHandler;
 import com.github.claudecodegui.handler.RewindHandler;
 import com.github.claudecodegui.handler.SessionHandler;
@@ -255,6 +256,7 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(new FileExportHandler(handlerContext));
         messageDispatcher.registerHandler(new DiffHandler(handlerContext));
         messageDispatcher.registerHandler(new PromptEnhancerHandler(handlerContext));
+        messageDispatcher.registerHandler(new PromptSuggestionHandler(handlerContext));
         messageDispatcher.registerHandler(new AgentHandler(handlerContext));
         messageDispatcher.registerHandler(new PromptHandler(handlerContext));
         messageDispatcher.registerHandler(new TabHandler(handlerContext));

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -39,6 +39,7 @@ import {
   useSpaceKeyListener,
   useResizableChatInputBox,
   useInlineHistoryCompletion,
+  usePromptSuggestion,
 } from './hooks/index.js';
 import {
   commandToDropdownItem,
@@ -335,6 +336,9 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
       minQueryLength: 2,
     });
 
+    // Prompt suggestion hook (AI-predicted next input)
+    const promptSuggestion = usePromptSuggestion();
+
     // Tooltip hook
     const { tooltip, handleMouseOver, handleMouseLeave } = useTooltip();
 
@@ -456,6 +460,11 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
           inlineCompletion.clear();
         }
 
+        // Clear prompt suggestion when user starts typing
+        if (!isEmpty) {
+          promptSuggestion.clearSuggestion();
+        }
+
         // Notify parent component (use debounced version to reduce re-renders)
         // If determined empty (only zero-width characters), pass empty string to parent
         debouncedOnInput(isEmpty ? '' : text);
@@ -475,6 +484,7 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
         agentCompletion,
         promptCompletion,
         inlineCompletion,
+        promptSuggestion,
       ]
     );
 
@@ -500,6 +510,26 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
       handleInput();
       return true;
     }, [inlineCompletion, handleInput]);
+
+    /**
+     * Apply prompt suggestion (Tab key when input is empty)
+     */
+    const applyPromptSuggestion = useCallback(() => {
+      const text = promptSuggestion.acceptSuggestion();
+      if (!text || !editableRef.current) return false;
+
+      editableRef.current.innerText = text;
+
+      const range = document.createRange();
+      const selection = window.getSelection();
+      range.selectNodeContents(editableRef.current);
+      range.collapse(false);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      handleInput();
+      return true;
+    }, [promptSuggestion, handleInput]);
 
     // IME composition hook
     const {
@@ -599,9 +629,12 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
       handleMacCursorMovement,
       handleHistoryKeyDown,
       // Inline completion: Tab key applies suggestion
-      inlineCompletion: inlineCompletion.hasSuggestion ? {
-        applySuggestion: applyInlineCompletion,
-      } : undefined,
+      // Priority: prompt suggestion (empty input) > history completion (non-empty input)
+      inlineCompletion: promptSuggestion.suggestion
+        ? { applySuggestion: applyPromptSuggestion }
+        : inlineCompletion.hasSuggestion
+          ? { applySuggestion: applyInlineCompletion }
+          : undefined,
       completionSelectedRef,
       submittedOnEnterRef,
       handleSubmit,
@@ -720,6 +753,22 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
 
     useSpaceKeyListener({ editableRef, onKeyDown: handleKeyDownForTagRendering });
 
+    // Prompt suggestion: bump epoch when AI response starts, request suggestion when it ends
+    // Use refs to avoid unstable promptSuggestion object in deps (would cause missed transitions)
+    const promptSuggestionRef = useRef(promptSuggestion);
+    promptSuggestionRef.current = promptSuggestion;
+    const prevIsLoadingRef = useRef(isLoading);
+    useEffect(() => {
+      const wasLoading = prevIsLoadingRef.current;
+      prevIsLoadingRef.current = isLoading;
+
+      if (isLoading && !wasLoading) {
+        promptSuggestionRef.current.bumpEpoch();
+      } else if (!isLoading && wasLoading) {
+        promptSuggestionRef.current.requestSuggestion();
+      }
+    }, [isLoading]);
+
     const {
       isResizing: isResizingInputBox,
       containerStyle,
@@ -781,7 +830,7 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
             className="input-editable"
             contentEditable={!disabled}
             data-placeholder={placeholder}
-            data-completion-suffix={inlineCompletion.suffix || ''}
+            data-completion-suffix={promptSuggestion.suggestion || inlineCompletion.suffix || ''}
             onInput={(e) => {
               // Pass native event isComposing state, more accurate than React state
               // Can correctly capture input before compositionStart

--- a/webview/src/components/ChatInputBox/hooks/index.ts
+++ b/webview/src/components/ChatInputBox/hooks/index.ts
@@ -27,3 +27,4 @@ export { useChatInputImperativeHandle } from './useChatInputImperativeHandle.js'
 export { useSpaceKeyListener } from './useSpaceKeyListener.js';
 export { useResizableChatInputBox, computeResize } from './useResizableChatInputBox.js';
 export { useInlineHistoryCompletion } from './useInlineHistoryCompletion.js';
+export { usePromptSuggestion } from './usePromptSuggestion.js';

--- a/webview/src/components/ChatInputBox/hooks/usePromptSuggestion.ts
+++ b/webview/src/components/ChatInputBox/hooks/usePromptSuggestion.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { sendToJava } from '../../../utils/bridge.js';
+
+export interface UsePromptSuggestionReturn {
+  /** The current suggestion text (empty string when none) */
+  suggestion: string;
+  /** Accept the current suggestion — returns the text or null */
+  acceptSuggestion: () => string | null;
+  /** Clear the current suggestion */
+  clearSuggestion: () => void;
+  /** Increment the epoch (call on message send or AI response start) */
+  bumpEpoch: () => void;
+  /** Request a new suggestion from Java backend */
+  requestSuggestion: () => void;
+}
+
+/**
+ * Manages AI-generated prompt suggestions displayed as ghost text
+ * when the input box is empty.
+ *
+ * - Receives suggestions from Java backend via window.onPromptSuggestion
+ * - Tracks a request epoch to discard stale suggestions
+ * - Enabled/disabled state is controlled by Claude Code's own config (Java layer)
+ */
+export function usePromptSuggestion(): UsePromptSuggestionReturn {
+  const [suggestion, setSuggestion] = useState('');
+
+  // Epoch counter to detect stale suggestions
+  const epochRef = useRef(0);
+  // The epoch at which the most recent request was sent
+  const requestEpochRef = useRef(0);
+
+  // Register the window callback for receiving suggestions from Java
+  useEffect(() => {
+    const handler = (text: string) => {
+      // Only accept if the epoch hasn't changed since the request
+      if (epochRef.current !== requestEpochRef.current) {
+        return;
+      }
+      setSuggestion(text || '');
+    };
+
+    (window as any).onPromptSuggestion = handler;
+
+    return () => {
+      if ((window as any).onPromptSuggestion === handler) {
+        (window as any).onPromptSuggestion = undefined;
+      }
+    };
+  }, []);
+
+  const acceptSuggestion = useCallback((): string | null => {
+    if (!suggestion) return null;
+    const text = suggestion;
+    setSuggestion('');
+    return text;
+  }, [suggestion]);
+
+  const clearSuggestion = useCallback(() => {
+    setSuggestion('');
+  }, []);
+
+  const bumpEpoch = useCallback(() => {
+    epochRef.current += 1;
+    setSuggestion('');
+  }, []);
+
+  const requestSuggestion = useCallback(() => {
+    // Record the current epoch for this request
+    requestEpochRef.current = epochRef.current;
+    // Java layer extracts recent messages from session state
+    sendToJava('request_prompt_suggestion', '');
+  }, []);
+
+  return {
+    suggestion,
+    acceptSuggestion,
+    clearSuggestion,
+    bumpEpoch,
+    requestSuggestion,
+  };
+}

--- a/webview/src/components/ChatInputBox/styles.css
+++ b/webview/src/components/ChatInputBox/styles.css
@@ -701,6 +701,11 @@
   pointer-events: none;
 }
 
+/* Hide placeholder when a non-empty prompt suggestion is shown */
+.input-editable:empty[data-completion-suffix]:not([data-completion-suffix=""])::before {
+  display: none;
+}
+
 .input-editable:focus {
   outline: none;
 }


### PR DESCRIPTION
Implement Claude CLI-style prompt suggestions that predict what the user might type next after an AI response completes. Suggestions appear as ghost text in the empty input box and can be accepted with Tab.

Three-layer implementation:
- Frontend: usePromptSuggestion hook with epoch-based stale detection, ghost text via CSS ::after pseudo-element, Tab key acceptance
- Java: PromptSuggestionHandler extracts recent conversation context from session state, spawns Node.js service with 30s timeout
- Node.js: prompt-suggestion.js calls Claude SDK (haiku/low effort) with filtering rules for quality control (CJK-aware word counting, Claude-voice detection, evaluative language filtering)

Key details:
- Skip [tool_result] placeholder messages in context payload
- Hide placeholder text when suggestion is displayed via CSS :not()
- Use ref pattern to avoid unstable useEffect dependencies
- Priority: prompt suggestion > inline history completion for Tab key