### PR TITLE
fix: disable spellcheck and prevent character loss in contenteditable input

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -780,6 +780,7 @@ export const ChatInputBox = forwardRef<ChatInputBoxHandle, ChatInputBoxProps>(
             ref={editableRef}
             className="input-editable"
             contentEditable={!disabled}
+            spellCheck={false}
             data-placeholder={placeholder}
             data-completion-suffix={inlineCompletion.suffix || ''}
             onInput={(e) => {

--- a/webview/src/components/ChatInputBox/hooks/useControlledValueSync.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useControlledValueSync.test.ts
@@ -82,4 +82,33 @@ describe('useControlledValueSync', () => {
 
     expect(editable.innerText).toBe('old');
   });
+
+  it('does not sync while editable element has focus', () => {
+    const editable = createEditable();
+    editable.setAttribute('contenteditable', 'true');
+    editable.innerText = 'typing in progress';
+    editable.focus();
+    const setHasContent = vi.fn();
+    const adjustHeight = vi.fn();
+    const invalidateCache = vi.fn();
+    const isComposingRef = { current: false };
+    const isExternalUpdateRef = { current: false };
+
+    renderHook(() =>
+      useControlledValueSync({
+        value: 'stale value from parent',
+        editableRef: { current: editable },
+        isComposingRef,
+        isExternalUpdateRef,
+        getTextContent: () => editable.innerText,
+        setHasContent,
+        adjustHeight,
+        invalidateCache,
+      })
+    );
+
+    // Should NOT overwrite — DOM is source of truth while user is typing
+    expect(editable.innerText).toBe('typing in progress');
+    expect(setHasContent).not.toHaveBeenCalled();
+  });
 });

--- a/webview/src/components/ChatInputBox/hooks/useControlledValueSync.ts
+++ b/webview/src/components/ChatInputBox/hooks/useControlledValueSync.ts
@@ -18,7 +18,12 @@ export interface UseControlledValueSyncOptions {
  * Only updates when:
  * - `value` is provided (controlled mode)
  * - Not currently in IME composition
+ * - The editable element does NOT have focus (user is not actively typing)
  * - External value differs from current DOM content
+ *
+ * When the element has focus, the DOM is the source of truth and the `value` prop
+ * may lag behind due to debounced onInput callbacks. Overwriting innerText while
+ * the user types causes characters to disappear.
  */
 export function useControlledValueSync({
   value,
@@ -34,6 +39,11 @@ export function useControlledValueSync({
     if (value === undefined) return;
     if (!editableRef.current) return;
     if (isComposingRef.current) return;
+
+    // Skip sync while the user is actively typing.
+    // The DOM content is ahead of the `value` prop due to debounced onInput,
+    // so overwriting innerText here would lose the most recent keystrokes.
+    if (document.activeElement === editableRef.current) return;
 
     invalidateCache();
     const currentText = getTextContent();


### PR DESCRIPTION
## Summary

Fixes two bugs in the `ChatInputBox` contenteditable input:

1. **Spellcheck cannot be disabled or changed from English** — The JCEF browser defaults to English spellcheck with no API to configure the language, making it unusable for non-English users. Other contenteditable elements in the plugin (e.g. `McpServerDialog`) already set `spellCheck="false"`.

2. **Characters disappear while typing** — `useControlledValueSync` overwrites `innerText` with the `value` prop whenever they differ. Because `onInput` is debounced (100ms via `DEBOUNCE_TIMING.ON_INPUT_CALLBACK_MS`), the `value` prop lags behind the DOM during active typing. When the sync fires mid-typing, it replaces the DOM content with the stale `value`, losing the most recent keystroke(s).

## Changes

- **`ChatInputBox.tsx`**: Add `spellCheck={false}` to contenteditable div
- **`useControlledValueSync.ts`**: Skip value sync while element has focus (DOM is source of truth during active typing)
- **`useControlledValueSync.test.ts`**: Add test for focus-skip behavior

## How to reproduce (before fix)

**Bug 1:** Open any chat input in JCEF — text is underlined with English spellcheck, no way to disable or change language.

**Bug 2:** Type rapidly in the input box. Characters intermittently disappear, especially noticeable when the parent component re-renders with a stale `value` prop.

## Root cause analysis (Bug 2)

```
1. User types "a"  → handleInput fires → debouncedOnInput schedules setDraftInput("a") in 100ms
2. User types "b"  → DOM now has "ab" → debounce resets, schedules setDraftInput("ab") in 100ms
3. setDraftInput("ab") fires → React re-renders → value prop = "ab"
4. useControlledValueSync sees currentText ("abc") !== value ("ab") → overwrites innerText with "ab"
   → character "c" (typed between step 2 and 4) is lost
```

The fix skips the sync when `document.activeElement === editableRef.current`, since the DOM is ahead of the prop during active typing.