### PR TITLE
feat: pause auto-scroll when user scrolls up during streaming

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -157,6 +157,7 @@ const App = () => {
     messagesEndRef,
     inputAreaRef,
     isUserAtBottomRef,
+    userPausedRef,
   } = useScrollBehavior({
     currentView,
     messages,
@@ -616,6 +617,7 @@ const App = () => {
     currentProviderRef,
     messagesContainerRef,
     isUserAtBottomRef,
+    userPausedRef,
     suppressNextStatusToastRef,
     streamingContentRef,
     isStreamingRef,
@@ -824,7 +826,8 @@ const App = () => {
     setLoading(true);
     setLoadingStartTime(Date.now());
 
-    // Scroll to bottom
+    // Scroll to bottom — user sent a message, so clear any scroll-pause
+    userPausedRef.current = false;
     isUserAtBottomRef.current = true;
     requestAnimationFrame(() => {
       if (messagesContainerRef.current) {

--- a/webview/src/hooks/useScrollBehavior.ts
+++ b/webview/src/hooks/useScrollBehavior.ts
@@ -17,6 +17,7 @@ interface UseScrollBehaviorReturn {
   inputAreaRef: React.RefObject<HTMLDivElement | null>;
   isUserAtBottomRef: React.MutableRefObject<boolean>;
   isAutoScrollingRef: React.MutableRefObject<boolean>;
+  userPausedRef: React.MutableRefObject<boolean>;
   scrollToBottom: () => void;
 }
 
@@ -24,6 +25,8 @@ interface UseScrollBehaviorReturn {
  * Hook for managing scroll behavior in the chat view
  * - Tracks if user is at bottom
  * - Auto-scrolls to bottom when user is at bottom and new content arrives
+ * - User can scroll up to pause auto-scroll (wheel event detection)
+ * - Auto-scroll resumes only when user scrolls back to bottom
  * - Handles view switching scroll behavior
  */
 export function useScrollBehavior({
@@ -38,6 +41,13 @@ export function useScrollBehavior({
   const inputAreaRef = useRef<HTMLDivElement | null>(null);
   const isUserAtBottomRef = useRef(true);
   const isAutoScrollingRef = useRef(false);
+
+  // Explicit scroll-pause flag. Set by wheel-up, cleared only when user
+  // manually scrolls back to the very bottom. The scroll event handler
+  // cannot override this — it prevents the race condition where handleScroll
+  // fires right after handleWheel and resets isUserAtBottomRef to true
+  // because the viewport is still within the 100px threshold.
+  const userPausedRef = useRef(false);
 
   // Scroll to bottom function
   const scrollToBottom = useCallback(() => {
@@ -66,8 +76,7 @@ export function useScrollBehavior({
     }
   }, []);
 
-  // Listen to scroll events to detect if user is at bottom
-  // If user scrolls up to view history, mark as "not at bottom" and stop auto-scrolling
+  // Listen to scroll and wheel events to detect user scroll intent
   useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
@@ -75,20 +84,47 @@ export function useScrollBehavior({
     const handleScroll = () => {
       // Skip check during auto-scrolling to prevent false detection during fast streaming
       if (isAutoScrollingRef.current) return;
+      // If user explicitly paused via wheel-up, don't let scroll handler override
+      if (userPausedRef.current) return;
       // Calculate distance from bottom
       const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
       // Consider user at bottom if within 100 pixels
       isUserAtBottomRef.current = distanceFromBottom < 100;
     };
 
+    // Wheel events are ALWAYS user-initiated and cannot be confused with
+    // programmatic scrolls. This is the primary mechanism for detecting
+    // user intent to pause or resume auto-scroll.
+    const handleWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0) {
+        // User is scrolling UP → pause auto-scroll immediately
+        userPausedRef.current = true;
+        isUserAtBottomRef.current = false;
+      } else if (e.deltaY > 0) {
+        // User is scrolling DOWN → check if they reached the bottom to unpause
+        requestAnimationFrame(() => {
+          const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+          if (distanceFromBottom < 100) {
+            userPausedRef.current = false;
+            isUserAtBottomRef.current = true;
+          }
+        });
+      }
+    };
+
     container.addEventListener('scroll', handleScroll);
-    return () => container.removeEventListener('scroll', handleScroll);
+    container.addEventListener('wheel', handleWheel, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      container.removeEventListener('wheel', handleWheel);
+    };
   }, [currentView]);
 
   // Auto-scroll: follow latest content when user is at bottom
   // Includes streaming, expanded thinking blocks, loading indicator, etc.
   useLayoutEffect(() => {
     if (currentView !== 'chat') return;
+    if (userPausedRef.current) return;
     if (!isUserAtBottomRef.current) return;
     scrollToBottom();
   }, [currentView, messages, expandedThinking, loading, streamingActive, scrollToBottom]);
@@ -110,6 +146,7 @@ export function useScrollBehavior({
     inputAreaRef,
     isUserAtBottomRef,
     isAutoScrollingRef,
+    userPausedRef,
     scrollToBottom,
   };
 }

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -69,6 +69,7 @@ export interface UseWindowCallbacksOptions {
   currentProviderRef: MutableRefObject<string>;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   isUserAtBottomRef: MutableRefObject<boolean>;
+  userPausedRef: MutableRefObject<boolean>;
   suppressNextStatusToastRef: MutableRefObject<boolean>;
 
   // Streaming refs from useStreamingMessages
@@ -138,6 +139,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     currentProviderRef,
     messagesContainerRef,
     isUserAtBottomRef,
+    userPausedRef,
     suppressNextStatusToastRef,
     streamingContentRef,
     isStreamingRef,
@@ -470,6 +472,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
         timestamp: new Date().toISOString(),
       };
       setMessages((prev) => [...prev, userMessage]);
+      userPausedRef.current = false;
       isUserAtBottomRef.current = true;
       requestAnimationFrame(() => {
         if (messagesContainerRef.current) {
@@ -486,7 +489,9 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
       useBackendStreamingRenderRef.current = false;
       autoExpandedThinkingKeysRef.current.clear();
       setStreamingActive(true);
-      isUserAtBottomRef.current = true;
+      // Don't force isUserAtBottomRef to true here — if the user scrolled up
+      // to read earlier content, auto-scroll should stay paused.
+      // The flag is already set to true when the user sends a message (addUserMessage/executeMessage).
       streamingTextSegmentsRef.current = [];
       activeTextSegmentIndexRef.current = -1;
       streamingThinkingSegmentsRef.current = [];


### PR DESCRIPTION
## Summary

Adds scroll-lock behavior to the chat view: when the user scrolls up with the mouse wheel during streaming, auto-scroll pauses immediately and stays paused until the user either scrolls back to the bottom or sends a new message.

## Problem

Previously, scrolling up during streaming was nearly impossible. The auto-scroll would "win" against the user's mouse wheel because:

1. **`onStreamStart()` forced `isUserAtBottomRef = true`** on every new stream, overriding any scroll-lock state
2. **`handleScroll` was suppressed by `isAutoScrollingRef`**, which was almost always `true` during streaming because `scrollToBottom()` fires every ~50ms (matching the streaming throttle interval)
3. **100px threshold too easy to trigger**: Even when `handleScroll` did fire, a single wheel tick often didn't move the viewport beyond the 100px bottom threshold, so the flag was immediately set back to `true`

## Solution

Introduces a `userPausedRef` flag and uses `wheel` events as the primary detection mechanism:

- **`wheel` events are always user-initiated** — they cannot be confused with programmatic `scrollToBottom()` calls, unlike `scroll` events
- **wheel-up** (`deltaY < 0`) → sets `userPausedRef = true` immediately, blocking all auto-scroll
- **wheel-down near bottom** (`deltaY > 0`, within 100px) → clears `userPausedRef`, resuming auto-scroll
- **Sending a new message** → clears `userPausedRef` (user expects to follow the new response)
- **`onStreamStart()`** no longer forces `isUserAtBottomRef = true`
- **`handleScroll`** respects `userPausedRef` and cannot override it

## Changes

- **`useScrollBehavior.ts`**: Add `userPausedRef`, `wheel` event listener, guard in `useLayoutEffect`
- **`useWindowCallbacks.ts`**: Remove forced `isUserAtBottomRef = true` in `onStreamStart`, add `userPausedRef` param, reset in `addUserMessage`
- **`App.tsx`**: Destructure and pass `userPausedRef`, reset on message send