### PR TITLE
fix: use <br> elements for newlines in pasted text to fix ArrowUp navigation

### DIFF
--- a/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
+++ b/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createTextFragment } from '../utils/selectionUtils.js';
 
 interface UseGlobalCallbacksOptions {
   editableRef: React.RefObject<HTMLDivElement | null>;
@@ -167,25 +168,32 @@ export function useGlobalCallbacks({
         // Cursor inside input box, insert at cursor position
         const range = selection.getRangeAt(0);
         range.deleteContents();
-        const textNode = document.createTextNode(selectionInfo + ' ');
-        range.insertNode(textNode);
+        // Use <br> elements for newlines to ensure proper ArrowUp/Down cursor navigation
+        const fragment = createTextFragment(selectionInfo + ' ');
+        const lastChild = fragment.lastChild;
+        range.insertNode(fragment);
 
-        // Move cursor after inserted text
-        range.setStartAfter(textNode);
+        // Move cursor after inserted content
+        if (lastChild) {
+          range.setStartAfter(lastChild);
+        }
         range.collapse(true);
         selection.removeAllRanges();
         selection.addRange(range);
       } else {
         // Cursor not inside input box, append to end
-        const textNode = document.createTextNode(selectionInfo + ' ');
-        editableRef.current.appendChild(textNode);
+        const fragment = createTextFragment(selectionInfo + ' ');
+        const lastChild = fragment.lastChild;
+        editableRef.current.appendChild(fragment);
 
         // Move cursor to end
-        const range = document.createRange();
-        range.setStartAfter(textNode);
-        range.collapse(true);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
+        if (lastChild) {
+          const range = document.createRange();
+          range.setStartAfter(lastChild);
+          range.collapse(true);
+          selection?.removeAllRanges();
+          selection?.addRange(range);
+        }
       }
 
       // Trigger state update

--- a/webview/src/components/ChatInputBox/utils/index.ts
+++ b/webview/src/components/ChatInputBox/utils/index.ts
@@ -1,4 +1,4 @@
 export { debounce, type DebouncedFunction } from './debounce.js';
 export { escapeHtmlAttr } from './htmlEscape.js';
 export { generateId } from './generateId.js';
-export { insertTextAtCursor, deleteSelection, deleteToPosition } from './selectionUtils.js';
+export { insertTextAtCursor, createTextFragment, deleteSelection, deleteToPosition } from './selectionUtils.js';

--- a/webview/src/components/ChatInputBox/utils/selectionUtils.ts
+++ b/webview/src/components/ChatInputBox/utils/selectionUtils.ts
@@ -29,9 +29,12 @@ export function insertTextAtCursor(text: string, element?: HTMLElement | null): 
     return false;
   }
 
-  // For large text, use fast Range API method (sacrifices undo for performance)
-  // execCommand('insertText') is extremely slow for large text (6+ seconds for 50KB)
-  if (text.length > TEXT_LENGTH_THRESHOLDS.LARGE_TEXT_INSERTION) {
+  // For large or multiline text, use fast Range API method with <br> elements.
+  // - Large text: execCommand('insertText') is extremely slow (6+ seconds for 50KB)
+  // - Multiline text: execCommand creates a single TextNode with \n, which breaks
+  //   ArrowUp cursor navigation in Chromium's contentEditable. Using <br> elements
+  //   gives the browser proper line boundaries for vertical cursor movement.
+  if (text.length > TEXT_LENGTH_THRESHOLDS.LARGE_TEXT_INSERTION || text.includes('\n')) {
     return insertTextFast(text, element, selection, range);
   }
 
@@ -49,8 +52,28 @@ export function insertTextAtCursor(text: string, element?: HTMLElement | null): 
 }
 
 /**
+ * Create a DocumentFragment from text, converting \n to <br> elements.
+ * This ensures proper DOM structure for contentEditable cursor navigation.
+ * A single TextNode with \n breaks ArrowUp navigation in Chromium.
+ */
+export function createTextFragment(text: string): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0) {
+      fragment.appendChild(document.createElement('br'));
+    }
+    if (lines[i]) {
+      fragment.appendChild(document.createTextNode(lines[i]));
+    }
+  }
+  return fragment;
+}
+
+/**
  * Fast text insertion using Range API
  * Much faster than execCommand for large text, but doesn't support native undo
+ * Uses <br> elements for newlines to ensure proper cursor navigation
  */
 function insertTextFast(
   text: string,
@@ -63,12 +86,15 @@ function insertTextFast(
     range.deleteContents();
   }
 
-  // Create and insert text node
-  const textNode = document.createTextNode(text);
-  range.insertNode(textNode);
+  // Create fragment with <br> for newlines (instead of single TextNode with \n)
+  const fragment = createTextFragment(text);
+  const lastChild = fragment.lastChild;
+  range.insertNode(fragment);
 
-  // Move cursor to after inserted text
-  range.setStartAfter(textNode);
+  // Move cursor to after inserted content
+  if (lastChild) {
+    range.setStartAfter(lastChild);
+  }
   range.collapse(true);
   selection.removeAllRanges();
   selection.addRange(range);


### PR DESCRIPTION
## Summary

- ArrowUp cursor navigation breaks after pasting multiline text into the chat input
- Root cause: `insertTextAtCursor` and `insertCodeSnippetAtCursor` create a single TextNode containing `\n` characters. Chromium's contentEditable cannot perform vertical cursor movement within a monolithic TextNode — it needs separate nodes separated by `<br>` elements.
- Add `createTextFragment()` helper that converts text with `\n` into a DocumentFragment with proper `<br>` elements between TextNodes
- Apply the same fix to `useGlobalCallbacks.ts` (code snippet insertion)

## Files changed

- `selectionUtils.ts` — new `createTextFragment()`, updated `insertTextAtCursor` and `insertTextFast` to use `<br>` instead of `\n` in TextNodes
- `useGlobalCallbacks.ts` — `insertCodeSnippetAtCursor` uses `createTextFragment`
- `utils/index.ts` — export `createTextFragment`

## How to reproduce

1. Open chat, type some text, press Enter to send
2. Paste multiline text (e.g. a code block from clipboard) into the input
3. Press ArrowUp repeatedly — cursor gets stuck or doesn't move line by line

## Test plan

- [ ] Paste multiline text, verify ArrowUp/ArrowDown navigate line by line
- [ ] Paste single-line text, verify normal behavior
- [ ] Type text with Shift+Enter, verify ArrowUp still works
- [ ] Insert code snippet via button, verify ArrowUp works
- [ ] Verify `useTextContent` still reads content correctly (it already handles `<br>` as `\n`)