### PR TITLE
feat: 添加任务完成提示音功能 (#392)

### DIFF
--- a/src/main/java/com/github/claudecodegui/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/CodemossSettingsService.java
@@ -625,6 +625,91 @@ public class CodemossSettingsService {
         return promptManager.getPrompt(id);
     }
 
+    // ==================== Sound Notification Management ====================
+
+    /**
+     * Get whether sound notification is enabled.
+     * @return whether sound notification is enabled, default is false
+     */
+    public boolean getSoundNotificationEnabled() throws IOException {
+        JsonObject config = readConfig();
+
+        if (!config.has("soundNotification")) {
+            return false;
+        }
+
+        JsonObject soundConfig = config.getAsJsonObject("soundNotification");
+        if (soundConfig.has("enabled")) {
+            return soundConfig.get("enabled").getAsBoolean();
+        }
+
+        return false;
+    }
+
+    /**
+     * Set whether sound notification is enabled.
+     * @param enabled whether to enable
+     */
+    public void setSoundNotificationEnabled(boolean enabled) throws IOException {
+        JsonObject config = readConfig();
+
+        JsonObject soundConfig;
+        if (config.has("soundNotification")) {
+            soundConfig = config.getAsJsonObject("soundNotification");
+        } else {
+            soundConfig = new JsonObject();
+            config.add("soundNotification", soundConfig);
+        }
+
+        soundConfig.addProperty("enabled", enabled);
+        writeConfig(config);
+        LOG.info("[CodemossSettings] Set sound notification enabled: " + enabled);
+    }
+
+    /**
+     * Get custom sound file path.
+     * @return custom sound path, null means use default sound
+     */
+    public String getCustomSoundPath() throws IOException {
+        JsonObject config = readConfig();
+
+        if (!config.has("soundNotification")) {
+            return null;
+        }
+
+        JsonObject soundConfig = config.getAsJsonObject("soundNotification");
+        if (soundConfig.has("customSoundPath") && !soundConfig.get("customSoundPath").isJsonNull()) {
+            return soundConfig.get("customSoundPath").getAsString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Set custom sound file path.
+     * @param path file path, null means use default sound
+     */
+    public void setCustomSoundPath(String path) throws IOException {
+        JsonObject config = readConfig();
+
+        JsonObject soundConfig;
+        if (config.has("soundNotification")) {
+            soundConfig = config.getAsJsonObject("soundNotification");
+        } else {
+            soundConfig = new JsonObject();
+            config.add("soundNotification", soundConfig);
+        }
+
+        if (path == null || path.isEmpty()) {
+            soundConfig.remove("customSoundPath");
+        } else {
+            soundConfig.addProperty("customSoundPath", path);
+        }
+
+        writeConfig(config);
+        LOG.info("[CodemossSettings] Set custom sound path: " + path);
+    }
+
     // ==================== Codex Provider Management ====================
 
     public List<JsonObject> getCodexProviders() throws IOException {

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -9,6 +9,7 @@ import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.model.NodeDetectionResult;
 import com.github.claudecodegui.util.FontConfigService;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
+import com.github.claudecodegui.util.SoundNotificationService;
 import com.github.claudecodegui.util.ThemeConfigService;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -67,7 +68,13 @@ public class SettingsHandler extends BaseMessageHandler {
         "get_input_history",
         "record_input_history",
         "delete_input_history_item",
-        "clear_input_history"
+        "clear_input_history",
+        // 提示音配置
+        "get_sound_notification_config",
+        "set_sound_notification_enabled",
+        "set_custom_sound_path",
+        "test_sound",
+        "browse_sound_file"
     };
 
     private static final Map<String, Integer> MODEL_CONTEXT_LIMITS = new HashMap<>();
@@ -191,6 +198,22 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "clear_input_history":
                 handleClearInputHistory();
+                return true;
+            // 提示音配置
+            case "get_sound_notification_config":
+                handleGetSoundNotificationConfig();
+                return true;
+            case "set_sound_notification_enabled":
+                handleSetSoundNotificationEnabled(content);
+                return true;
+            case "set_custom_sound_path":
+                handleSetCustomSoundPath(content);
+                return true;
+            case "test_sound":
+                handleTestSound(content);
+                return true;
+            case "browse_sound_file":
+                handleBrowseSoundFile();
                 return true;
             default:
                 return false;
@@ -1481,5 +1504,180 @@ public class SettingsHandler extends BaseMessageHandler {
 
         String[] lines = output.toString().split("\n");
         return lines.length > 0 ? lines[lines.length - 1] : "{}";
+    }
+
+    // ==================== 提示音配置管理 ====================
+
+    /**
+     * 获取提示音配置
+     */
+    private void handleGetSoundNotificationConfig() {
+        try {
+            CodemossSettingsService settingsService = new CodemossSettingsService();
+            boolean enabled = settingsService.getSoundNotificationEnabled();
+            String customPath = settingsService.getCustomSoundPath();
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                JsonObject response = new JsonObject();
+                response.addProperty("enabled", enabled);
+                response.addProperty("customSoundPath", customPath != null ? customPath : "");
+                callJavaScript("window.updateSoundNotificationConfig", escapeJs(new Gson().toJson(response)));
+            });
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Failed to get sound notification config: " + e.getMessage(), e);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                JsonObject response = new JsonObject();
+                response.addProperty("enabled", false);
+                response.addProperty("customSoundPath", "");
+                callJavaScript("window.updateSoundNotificationConfig", escapeJs(new Gson().toJson(response)));
+            });
+        }
+    }
+
+    /**
+     * 设置提示音启用状态
+     */
+    private void handleSetSoundNotificationEnabled(String content) {
+        try {
+            Gson gson = new Gson();
+            JsonObject json = gson.fromJson(content, JsonObject.class);
+            boolean enabled = json != null && json.has("enabled") && json.get("enabled").getAsBoolean();
+
+            CodemossSettingsService settingsService = new CodemossSettingsService();
+            settingsService.setSoundNotificationEnabled(enabled);
+
+            LOG.info("[SettingsHandler] Set sound notification enabled: " + enabled);
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                JsonObject response = new JsonObject();
+                response.addProperty("enabled", enabled);
+                try {
+                    response.addProperty("customSoundPath", settingsService.getCustomSoundPath() != null ? settingsService.getCustomSoundPath() : "");
+                } catch (Exception e) {
+                    response.addProperty("customSoundPath", "");
+                }
+                callJavaScript("window.updateSoundNotificationConfig", escapeJs(gson.toJson(response)));
+            });
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Failed to set sound notification enabled: " + e.getMessage(), e);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                callJavaScript("window.showError", escapeJs("保存提示音配置失败: " + e.getMessage()));
+            });
+        }
+    }
+
+    /**
+     * 设置自定义提示音路径
+     */
+    private void handleSetCustomSoundPath(String content) {
+        try {
+            Gson gson = new Gson();
+            JsonObject json = gson.fromJson(content, JsonObject.class);
+            String path = json != null && json.has("path") && !json.get("path").isJsonNull()
+                ? json.get("path").getAsString() : null;
+
+            // 验证文件
+            if (path != null && !path.isEmpty()) {
+                SoundNotificationService.ValidationResult validation =
+                    SoundNotificationService.getInstance().validateSoundFile(path);
+
+                if (!validation.isValid()) {
+                    final String errorMsg = validation.getErrorMessage();
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        callJavaScript("window.showError", escapeJs("无效的音频文件: " + errorMsg));
+                    });
+                    return;
+                }
+            }
+
+            CodemossSettingsService settingsService = new CodemossSettingsService();
+            settingsService.setCustomSoundPath(path);
+
+            LOG.info("[SettingsHandler] Set custom sound path: " + path);
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                JsonObject response = new JsonObject();
+                try {
+                    response.addProperty("enabled", settingsService.getSoundNotificationEnabled());
+                } catch (Exception e) {
+                    response.addProperty("enabled", false);
+                }
+                response.addProperty("customSoundPath", path != null ? path : "");
+                callJavaScript("window.updateSoundNotificationConfig", escapeJs(gson.toJson(response)));
+                callJavaScript("window.showSuccessI18n", escapeJs("settings.basic.soundNotification.customSoundSaved"));
+            });
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Failed to set custom sound path: " + e.getMessage(), e);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                callJavaScript("window.showError", escapeJs("保存自定义提示音失败: " + e.getMessage()));
+            });
+        }
+    }
+
+    /**
+     * 测试播放提示音
+     */
+    private void handleTestSound(String content) {
+        try {
+            String path = null;
+            if (content != null && !content.isEmpty()) {
+                Gson gson = new Gson();
+                JsonObject json = gson.fromJson(content, JsonObject.class);
+                path = json != null && json.has("path") && !json.get("path").isJsonNull()
+                    ? json.get("path").getAsString() : null;
+            }
+
+            LOG.info("[SettingsHandler] Testing sound: " + (path != null ? path : "default"));
+            SoundNotificationService.getInstance().testPlaySound(path);
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Failed to test sound: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 打开文件选择器选择音频文件
+     */
+    private void handleBrowseSoundFile() {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                    new com.intellij.openapi.fileChooser.FileChooserDescriptor(
+                        true, false, false, false, false, false
+                    )
+                    .withFileFilter(file -> {
+                        String ext = file.getExtension();
+                        return ext != null && (
+                            ext.equalsIgnoreCase("wav") ||
+                            ext.equalsIgnoreCase("mp3") ||
+                            ext.equalsIgnoreCase("aiff")
+                        );
+                    })
+                    .withTitle("选择提示音文件")
+                    .withDescription("选择 WAV、MP3 或 AIFF 格式的音频文件");
+
+                com.intellij.openapi.fileChooser.FileChooser.chooseFile(
+                    descriptor,
+                    context.getProject(),
+                    null,
+                    file -> {
+                        if (file != null) {
+                            String path = file.getPath();
+                            JsonObject response = new JsonObject();
+                            try {
+                                CodemossSettingsService settingsService = new CodemossSettingsService();
+                                response.addProperty("enabled", settingsService.getSoundNotificationEnabled());
+                            } catch (Exception e) {
+                                response.addProperty("enabled", false);
+                            }
+                            response.addProperty("customSoundPath", path);
+                            callJavaScript("window.updateSoundNotificationConfig",
+                                escapeJs(new Gson().toJson(response)));
+                        }
+                    }
+                );
+            } catch (Exception e) {
+                LOG.error("[SettingsHandler] Failed to open file chooser: " + e.getMessage(), e);
+            }
+        });
     }
 }

--- a/src/main/java/com/github/claudecodegui/notifications/ClaudeNotifier.java
+++ b/src/main/java/com/github/claudecodegui/notifications/ClaudeNotifier.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.notifications;
 
 import com.github.claudecodegui.ClaudeCodeGuiBundle;
+import com.github.claudecodegui.util.SoundNotificationService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -24,6 +25,9 @@ public class ClaudeNotifier {
 
     public static void showSuccess(@NotNull Project project, String message) {
         show(project, "Claude ✓", message, 5000);
+
+        // 播放任务完成提示音
+        SoundNotificationService.getInstance().playTaskCompleteSound();
     }
 
     public static void showError(@NotNull Project project, String message) {

--- a/src/main/java/com/github/claudecodegui/util/SoundNotificationService.java
+++ b/src/main/java/com/github/claudecodegui/util/SoundNotificationService.java
@@ -1,0 +1,271 @@
+package com.github.claudecodegui.util;
+
+import com.github.claudecodegui.CodemossSettingsService;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+
+import javax.sound.sampled.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 声音通知服务
+ * 负责在任务完成时播放提示音
+ */
+public class SoundNotificationService {
+
+    private static final Logger LOG = Logger.getInstance(SoundNotificationService.class);
+    private static final String DEFAULT_SOUND_PATH = "/sounds/task-complete.wav";
+
+    // 单例模式
+    private static volatile SoundNotificationService instance;
+
+    private SoundNotificationService() {
+    }
+
+    public static SoundNotificationService getInstance() {
+        if (instance == null) {
+            synchronized (SoundNotificationService.class) {
+                if (instance == null) {
+                    instance = new SoundNotificationService();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * 播放任务完成提示音
+     */
+    public void playTaskCompleteSound() {
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                CodemossSettingsService settings = new CodemossSettingsService();
+
+                // 检查是否启用提示音
+                if (!settings.getSoundNotificationEnabled()) {
+                    LOG.debug("[SoundNotification] Sound notification is disabled");
+                    return;
+                }
+
+                String customSoundPath = settings.getCustomSoundPath();
+
+                if (customSoundPath != null && !customSoundPath.isEmpty()) {
+                    // 播放自定义音频
+                    LOG.info("[SoundNotification] Playing custom sound: " + customSoundPath);
+                    playFromFile(new File(customSoundPath));
+                } else {
+                    // 播放默认音频
+                    LOG.info("[SoundNotification] Playing default sound");
+                    playFromResource(DEFAULT_SOUND_PATH);
+                }
+            } catch (Exception e) {
+                LOG.warn("[SoundNotification] Failed to play notification sound: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    /**
+     * 测试播放提示音（用于设置预览）
+     *
+     * @param soundPath 声音文件路径，为空则使用默认声音
+     */
+    public void testPlaySound(String soundPath) {
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                if (soundPath == null || soundPath.isEmpty()) {
+                    LOG.info("[SoundNotification] Testing default sound");
+                    playFromResource(DEFAULT_SOUND_PATH);
+                } else {
+                    LOG.info("[SoundNotification] Testing custom sound: " + soundPath);
+                    playFromFile(new File(soundPath));
+                }
+            } catch (Exception e) {
+                LOG.warn("[SoundNotification] Failed to play test sound: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    /**
+     * 从资源文件播放音频
+     */
+    private void playFromResource(String resourcePath) throws Exception {
+        try (InputStream rawStream = getClass().getResourceAsStream(resourcePath)) {
+            if (rawStream == null) {
+                LOG.info("[SoundNotification] Sound resource not found, using system beep as fallback");
+                playSystemBeep();
+                return;
+            }
+
+            // 使用 BufferedInputStream 包装，因为 AudioSystem 需要 mark/reset 支持
+            try (BufferedInputStream bufferedStream = new BufferedInputStream(rawStream);
+                 AudioInputStream audioIn = AudioSystem.getAudioInputStream(bufferedStream)) {
+                playAudioStream(audioIn);
+            }
+        }
+    }
+
+    /**
+     * 播放系统默认提示音（作为回退方案）
+     */
+    private void playSystemBeep() {
+        try {
+            java.awt.Toolkit.getDefaultToolkit().beep();
+        } catch (Exception e) {
+            LOG.debug("[SoundNotification] System beep failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 从文件播放音频
+     */
+    private void playFromFile(File file) throws Exception {
+        if (!file.exists() || !file.canRead()) {
+            LOG.warn("[SoundNotification] Sound file not found or not readable: " + file.getAbsolutePath());
+            return;
+        }
+
+        String fileName = file.getName().toLowerCase();
+
+        // MP3 格式使用系统命令播放
+        if (fileName.endsWith(".mp3")) {
+            playWithSystemCommand(file);
+            return;
+        }
+
+        // WAV 和 AIFF 格式使用 Java 标准库播放
+        try (AudioInputStream audioIn = AudioSystem.getAudioInputStream(file)) {
+            playAudioStream(audioIn);
+        }
+    }
+
+    /**
+     * 使用系统命令播放音频文件（支持 MP3）
+     */
+    private void playWithSystemCommand(File file) {
+        try {
+            String os = System.getProperty("os.name").toLowerCase();
+            ProcessBuilder pb;
+
+            if (os.contains("mac")) {
+                // macOS 使用 afplay
+                pb = new ProcessBuilder("afplay", file.getAbsolutePath());
+            } else if (os.contains("win")) {
+                // Windows 使用 PowerShell 播放
+                pb = new ProcessBuilder("powershell", "-c",
+                    "(New-Object Media.SoundPlayer '" + file.getAbsolutePath() + "').PlaySync()");
+            } else {
+                // Linux 尝试使用 aplay 或 paplay
+                pb = new ProcessBuilder("aplay", file.getAbsolutePath());
+            }
+
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            // 等待播放完成，最多 30 秒
+            boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                LOG.warn("[SoundNotification] Sound playback timed out");
+            }
+        } catch (Exception e) {
+            LOG.warn("[SoundNotification] Failed to play with system command: " + e.getMessage());
+            // 回退到系统 beep
+            playSystemBeep();
+        }
+    }
+
+    /**
+     * 播放音频流
+     */
+    private void playAudioStream(AudioInputStream audioIn) throws Exception {
+        Clip clip = AudioSystem.getClip();
+        clip.open(audioIn);
+        clip.start();
+
+        // 等待播放完成后关闭
+        clip.addLineListener(event -> {
+            if (event.getType() == LineEvent.Type.STOP) {
+                clip.close();
+            }
+        });
+
+        // 等待播放完成（最多等待 10 秒）
+        int maxWaitMs = 10000;
+        int waitedMs = 0;
+        while (clip.isRunning() && waitedMs < maxWaitMs) {
+            Thread.sleep(100);
+            waitedMs += 100;
+        }
+
+        // 确保资源被释放
+        if (clip.isOpen()) {
+            clip.close();
+        }
+    }
+
+    /**
+     * 验证音频文件是否可用
+     *
+     * @param filePath 文件路径
+     * @return 验证结果，包含成功状态和错误信息
+     */
+    public ValidationResult validateSoundFile(String filePath) {
+        if (filePath == null || filePath.isEmpty()) {
+            return new ValidationResult(true, null); // 空路径表示使用默认声音
+        }
+
+        File file = new File(filePath);
+
+        if (!file.exists()) {
+            return new ValidationResult(false, "文件不存在");
+        }
+
+        if (!file.canRead()) {
+            return new ValidationResult(false, "文件无法读取");
+        }
+
+        // 验证文件格式
+        String lowerPath = filePath.toLowerCase();
+        if (!lowerPath.endsWith(".wav") && !lowerPath.endsWith(".mp3") && !lowerPath.endsWith(".aiff")) {
+            return new ValidationResult(false, "仅支持 WAV、MP3、AIFF 格式");
+        }
+
+        // MP3 格式需要使用系统命令播放，跳过 AudioSystem 验证
+        if (lowerPath.endsWith(".mp3")) {
+            return new ValidationResult(true, null);
+        }
+
+        // 对于 WAV 和 AIFF 格式，尝试加载文件验证格式
+        try (AudioInputStream audioIn = AudioSystem.getAudioInputStream(file)) {
+            return new ValidationResult(true, null);
+        } catch (UnsupportedAudioFileException e) {
+            return new ValidationResult(false, "不支持的音频格式");
+        } catch (Exception e) {
+            return new ValidationResult(false, "无法读取音频文件: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 验证结果
+     */
+    public static class ValidationResult {
+        private final boolean valid;
+        private final String errorMessage;
+
+        public ValidationResult(boolean valid, String errorMessage) {
+            this.valid = valid;
+            this.errorMessage = errorMessage;
+        }
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}

--- a/webview/src/components/AlertDialog.tsx
+++ b/webview/src/components/AlertDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export type AlertType = 'error' | 'warning' | 'info' | 'success';
 
@@ -16,9 +17,11 @@ const AlertDialog = ({
   type = 'info',
   title,
   message,
-  confirmText = '确定',
+  confirmText,
   onClose,
 }: AlertDialogProps) => {
+  const { t } = useTranslation();
+  const buttonText = confirmText || t('common.confirm');
   useEffect(() => {
     if (isOpen) {
       const handleEscape = (e: KeyboardEvent) => {
@@ -64,19 +67,19 @@ const AlertDialog = ({
   return (
     <div className="confirm-dialog-overlay" onClick={onClose}>
       <div className="confirm-dialog alert-dialog" onClick={(e) => e.stopPropagation()}>
-        <div className="confirm-dialog-header">
+        <div className="confirm-dialog-header" style={{ display: 'flex', alignItems: 'center' }}>
           <span
             className={`codicon ${getIconClass()}`}
-            style={{ color: getIconColor(), marginRight: '8px', fontSize: '16px' }}
+            style={{ color: getIconColor(), marginRight: '8px', fontSize: '16px', lineHeight: 1 }}
           />
-          <h3 className="confirm-dialog-title">{title}</h3>
+          <h3 className="confirm-dialog-title" style={{ margin: 0, lineHeight: 1.2 }}>{title}</h3>
         </div>
         <div className="confirm-dialog-body">
           <p className="confirm-dialog-message" style={{ whiteSpace: 'pre-wrap' }}>{message}</p>
         </div>
         <div className="confirm-dialog-footer" style={{ justifyContent: 'center' }}>
           <button className="confirm-dialog-button confirm-button" onClick={onClose} autoFocus>
-            {confirmText}
+            {buttonText}
           </button>
         </div>
       </div>

--- a/webview/src/components/settings/BasicConfigSection/index.tsx
+++ b/webview/src/components/settings/BasicConfigSection/index.tsx
@@ -90,6 +90,14 @@ interface BasicConfigSectionProps {
   // Diff expanded by default configuration
   diffExpandedByDefault?: boolean;
   onDiffExpandedByDefaultChange?: (enabled: boolean) => void;
+  // Sound notification configuration
+  soundNotificationEnabled?: boolean;
+  onSoundNotificationEnabledChange?: (enabled: boolean) => void;
+  customSoundPath?: string;
+  onCustomSoundPathChange?: (path: string) => void;
+  onSaveCustomSoundPath?: () => void;
+  onTestSound?: () => void;
+  onBrowseSound?: () => void;
 }
 
 const BasicConfigSection = ({
@@ -123,6 +131,14 @@ const BasicConfigSection = ({
   // Diff expanded by default configuration
   diffExpandedByDefault = false,
   onDiffExpandedByDefaultChange = () => {},
+  // Sound notification configuration
+  soundNotificationEnabled = false,
+  onSoundNotificationEnabledChange = () => {},
+  customSoundPath = '',
+  onCustomSoundPathChange = () => {},
+  onSaveCustomSoundPath = () => {},
+  onTestSound = () => {},
+  onBrowseSound = () => {},
 }: BasicConfigSectionProps) => {
   const { t, i18n } = useTranslation();
   const colorInputRef = useRef<HTMLInputElement>(null);
@@ -585,6 +601,75 @@ const BasicConfigSection = ({
             <div className={styles.themeCardDesc}>{t('settings.basic.sendShortcut.cmdEnterDesc')}</div>
           </div>
         </div>
+      </div>
+
+      {/* 任务完成提示音配置 */}
+      <div className={styles.streamingSection}>
+        <div className={styles.fieldHeader}>
+          <span className="codicon codicon-unmute" />
+          <span className={styles.fieldLabel}>{t('settings.basic.soundNotification.label')}</span>
+        </div>
+        <label className={styles.toggleWrapper}>
+          <input
+            type="checkbox"
+            className={styles.toggleInput}
+            checked={soundNotificationEnabled}
+            onChange={(e) => onSoundNotificationEnabledChange(e.target.checked)}
+          />
+          <span className={styles.toggleSlider} />
+          <span className={styles.toggleLabel}>
+            {soundNotificationEnabled
+              ? t('settings.basic.soundNotification.enabled')
+              : t('settings.basic.soundNotification.disabled')}
+          </span>
+        </label>
+        <small className={styles.formHint}>
+          <span className="codicon codicon-info" />
+          <span>{t('settings.basic.soundNotification.hint')}</span>
+        </small>
+
+        {/* 自定义提示音（仅在启用提示音时显示） */}
+        {soundNotificationEnabled && (
+          <div className={styles.customSoundSection}>
+            <div className={styles.fieldHeader}>
+              <span className="codicon codicon-file-media" />
+              <span className={styles.fieldLabel}>{t('settings.basic.soundNotification.customSound')}</span>
+            </div>
+            <div className={styles.nodePathInputWrapper}>
+              <input
+                type="text"
+                className={styles.nodePathInput}
+                placeholder={t('settings.basic.soundNotification.customSoundPlaceholder')}
+                value={customSoundPath}
+                onChange={(e) => onCustomSoundPathChange(e.target.value)}
+              />
+              <button
+                className={styles.saveBtn}
+                onClick={onBrowseSound}
+                title={t('settings.basic.soundNotification.browse')}
+              >
+                <span className="codicon codicon-folder-opened" />
+              </button>
+              <button
+                className={styles.saveBtn}
+                onClick={onTestSound}
+                title={t('settings.basic.soundNotification.testSound')}
+              >
+                <span className="codicon codicon-play" />
+              </button>
+              <button
+                className={styles.saveBtn}
+                onClick={onSaveCustomSoundPath}
+              >
+                {t('common.save')}
+              </button>
+            </div>
+            <small className={styles.formHint}>
+              <span className="codicon codicon-info" />
+              <span>{t('settings.basic.soundNotification.customSoundHint')}</span>
+            </small>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/webview/src/components/settings/BasicConfigSection/style.module.less
+++ b/webview/src/components/settings/BasicConfigSection/style.module.less
@@ -584,6 +584,13 @@
   margin-bottom: 24px;
 }
 
+/* 自定义提示音区域 */
+.customSoundSection {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-secondary);
+}
+
 /* 响应式适配 */
 @media (max-width: 480px) {
   .sectionTitle {

--- a/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
+++ b/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
@@ -35,6 +35,9 @@ export interface SettingsWindowCallbacksDeps {
   setLoading: (loading: boolean) => void;
   setCodexLoading: (loading: boolean) => void;
   setCodexConfigLoading: (loading: boolean) => void;
+  // Sound notification setters
+  setSoundNotificationEnabled?: (enabled: boolean) => void;
+  setCustomSoundPath?: (path: string) => void;
 
   // Hook functions
   updateProviders: (providers: ProviderConfig[]) => void;
@@ -218,6 +221,21 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       }
     };
 
+    // Sound notification config callback
+    window.updateSoundNotificationConfig = (jsonStr: string) => {
+      try {
+        const data = JSON.parse(jsonStr);
+        if (data.enabled !== undefined && deps.setSoundNotificationEnabled) {
+          deps.setSoundNotificationEnabled(data.enabled);
+        }
+        if (data.customSoundPath !== undefined && deps.setCustomSoundPath) {
+          deps.setCustomSoundPath(data.customSoundPath);
+        }
+      } catch (error) {
+        console.error('[SettingsView] Failed to parse sound notification config:', error);
+      }
+    };
+
     // Agent callbacks
     const previousUpdateAgents = window.updateAgents;
     window.updateAgents = (jsonStr: string) => {
@@ -304,6 +322,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
     sendToJava('get_editor_font_config:');
     sendToJava('get_streaming_enabled:');
     sendToJava('get_commit_prompt:');
+    sendToJava('get_sound_notification_config:');
 
     return () => {
       deps.cleanupAgentsTimeout();
@@ -326,6 +345,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
         window.updateSendShortcut = previousUpdateSendShortcut;
       }
       window.updateCommitPrompt = undefined;
+      window.updateSoundNotificationConfig = undefined;
       window.updateAgents = previousUpdateAgents;
       window.agentOperationResult = undefined;
       window.updatePrompts = previousUpdatePrompts;

--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -292,6 +292,10 @@ const SettingsView = ({
     }
   });
 
+  // 提示音配置
+  const [soundNotificationEnabled, setSoundNotificationEnabled] = useState<boolean>(false);
+  const [customSoundPath, setCustomSoundPath] = useState<string>('');
+
   const handleTabChange = (tab: SettingsTab) => {
     if (isCodexMode && disabledTabs.includes(tab)) {
       addToast(t('settings.codexFeatureUnavailable'), 'warning');
@@ -307,7 +311,7 @@ const SettingsView = ({
   };
 
   const closeAlert = () => {
-    setAlertDialog({ ...alertDialog, isOpen: false });
+    setAlertDialog(prev => ({ ...prev, isOpen: false }));
   };
 
   // Register window callbacks for Java bridge communication
@@ -348,6 +352,8 @@ const SettingsView = ({
     addToast,
     onStreamingEnabledChangeProp,
     onSendShortcutChangeProp,
+    setSoundNotificationEnabled,
+    setCustomSoundPath,
   });
 
   // Listen for window resize events
@@ -500,6 +506,35 @@ const SettingsView = ({
     }
   };
 
+  // Sound notification toggle change handler
+  const handleSoundNotificationEnabledChange = (enabled: boolean) => {
+    setSoundNotificationEnabled(enabled);
+    const payload = { enabled };
+    sendToJava(`set_sound_notification_enabled:${JSON.stringify(payload)}`);
+  };
+
+  // Custom sound path change handler
+  const handleCustomSoundPathChange = (path: string) => {
+    setCustomSoundPath(path);
+  };
+
+  // Save custom sound path
+  const handleSaveCustomSoundPath = () => {
+    const payload = { path: customSoundPath };
+    sendToJava(`set_custom_sound_path:${JSON.stringify(payload)}`);
+  };
+
+  // Test sound
+  const handleTestSound = () => {
+    const payload = { path: customSoundPath };
+    sendToJava(`test_sound:${JSON.stringify(payload)}`);
+  };
+
+  // Browse sound file
+  const handleBrowseSound = () => {
+    sendToJava('browse_sound_file:');
+  };
+
   // Commit AI prompt save handler
   const handleSaveCommitPrompt = () => {
     setSavingCommitPrompt(true);
@@ -638,6 +673,13 @@ const SettingsView = ({
               onChatBgColorChange={setChatBgColor}
               diffExpandedByDefault={diffExpandedByDefault}
               onDiffExpandedByDefaultChange={setDiffExpandedByDefault}
+              soundNotificationEnabled={soundNotificationEnabled}
+              onSoundNotificationEnabledChange={handleSoundNotificationEnabledChange}
+              customSoundPath={customSoundPath}
+              onCustomSoundPathChange={handleCustomSoundPathChange}
+              onSaveCustomSoundPath={handleSaveCustomSoundPath}
+              onTestSound={handleTestSound}
+              onBrowseSound={handleBrowseSound}
             />
           </div>
 

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -236,6 +236,11 @@ interface Window {
   updateCommitPrompt?: (json: string) => void;
 
   /**
+   * Update sound notification configuration
+   */
+  updateSoundNotificationConfig?: (json: string) => void;
+
+  /**
    * Update current Claude config
    */
   updateCurrentClaudeConfig?: (json: string) => void;
@@ -264,6 +269,11 @@ interface Window {
    * Show success message
    */
   showSuccess?: (message: string) => void;
+
+  /**
+   * Show success message with i18n key
+   */
+  showSuccessI18n?: (i18nKey: string) => void;
 
   /**
    * Update skills list

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -170,6 +170,19 @@
         "custom": "Custom",
         "reset": "Reset",
         "hint": "Customize the chat area background color. Leave empty to follow the theme default."
+      },
+      "soundNotification": {
+        "label": "Task Completion Sound",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "hint": "When enabled, a notification sound will play when AI completes a task, so you'll know even when away from the screen.",
+        "customSound": "Custom Sound",
+        "customSoundPlaceholder": "Leave empty for default sound",
+        "customSoundHint": "Supports WAV, MP3, AIFF formats",
+        "testSound": "Test",
+        "browse": "Browse",
+        "useDefault": "Use Default",
+        "customSoundSaved": "Custom sound saved"
       }
     },
     "providers": "Provider Management",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -170,6 +170,19 @@
         "custom": "自定义",
         "reset": "恢复默认",
         "hint": "自定义聊天区域的背景颜色，留空则跟随主题默认颜色"
+      },
+      "soundNotification": {
+        "label": "任务完成提示音",
+        "enabled": "已开启",
+        "disabled": "已关闭",
+        "hint": "开启后，AI 完成任务时会播放提示音，方便您离开屏幕时也能知道任务已完成。",
+        "customSound": "自定义提示音",
+        "customSoundPlaceholder": "留空使用默认提示音",
+        "customSoundHint": "支持 WAV、MP3、AIFF 格式",
+        "testSound": "试听",
+        "browse": "浏览",
+        "useDefault": "使用默认",
+        "customSoundSaved": "自定义提示音已保存"
       }
     },
     "providers": "供应商管理",


### PR DESCRIPTION
## 概述

### 样式
<img width="747" height="260" alt="image" src="https://github.com/user-attachments/assets/a427a18b-d420-4165-8eee-5cace0fb6f74" />

- 添加任务完成提示音功能，AI 回复结束后可自动播放提示音
- 支持自定义提示音文件（WAV、MP3、AIFF 格式）
- 在设置页面添加提示音开关和自定义音频选择

- 新增 AI 任务完成时的声音提醒功能
- 用户可在设置中开启/关闭提示音
- 支持自定义提示音文件（WAV、MP3、AIFF 格式）
- 与现有功能（提示词库、聊天背景色、差异默认展开）完成合并

## 变更内容

### 后端 (Java)
- `CodemossSettingsService.java`: 新增提示音配置管理方法
- `SettingsHandler.java`: 添加 SoundNotificationService 导入
- `ClaudeNotifier.java`: 集成提示音服务
- `SoundNotificationService.java`: 新增提示音播放服务类

### 前端 (React/TypeScript)
- `BasicConfigSection/index.tsx`: 新增提示音 UI 控件
- `settings/index.tsx`: 新增提示音相关处理函数
- `useSettingsWindowCallbacks.ts`: 新增提示音状态管理
- `global.d.ts`: 新增 window 回调类型定义

### 国际化
- `en.json`: 新增提示音设置英文翻译
- `zh.json`: 新增提示音设置中文翻译

## 测试计划

- [x] 在设置中开启提示音
- [x] 验证 AI 任务完成时播放提示音
- [x] 测试自定义提示音文件选择
- [x] 测试"试听"按钮功能
- [x] 验证设置在会话间持久保存
- [x] 测试关闭提示音功能

Closes #392
