### PR TITLE
fix: only show Windows path constraints on Windows platform

### DIFF
--- a/ai-bridge/services/quickfix-prompts.js
+++ b/ai-bridge/services/quickfix-prompts.js
@@ -17,14 +17,16 @@ function buildEnhancedIDEContextPrompt(openedFiles, agentPrompt = null) {
         prompt += '\n---\n';
     }
 
-    // Windows path format constraint
-    prompt += '\n\n## CRITICAL: File Path Format Requirement\n\n';
-    prompt += '**IMPORTANT**: There\'s a file modification bug in Claude Code. The workaround is: always use complete absolute Windows paths with drive letters and backslashes for ALL file operations.\n\n';
-    prompt += '**Examples**:\n';
-    prompt += '- ✅ Correct: `C:\\Users\\username\\project\\src\\file.js`\n';
-    prompt += '- ❌ Wrong: `/c/Users/username/project/src/file.js`\n';
-    prompt += '- ❌ Wrong: `./src/file.js` (relative paths)\n\n';
-    prompt += '---\n\n';
+    // Windows path format constraint - only on Windows
+    if (process.platform === 'win32') {
+        prompt += '\n\n## CRITICAL: File Path Format Requirement\n\n';
+        prompt += '**IMPORTANT**: There\'s a file modification bug in Claude Code. The workaround is: always use complete absolute Windows paths with drive letters and backslashes for ALL file operations.\n\n';
+        prompt += '**Examples**:\n';
+        prompt += '- ✅ Correct: `C:\\Users\\username\\project\\src\\file.js`\n';
+        prompt += '- ❌ Wrong: `/c/Users/username/project/src/file.js`\n';
+        prompt += '- ❌ Wrong: `./src/file.js` (relative paths)\n\n';
+        prompt += '---\n\n';
+    }
 
     if (!openedFiles || typeof openedFiles !== 'object') {
         return prompt;

--- a/ai-bridge/services/system-prompts.js
+++ b/ai-bridge/services/system-prompts.js
@@ -41,14 +41,16 @@ function buildIDEContextPrompt(openedFiles, agentPrompt = null) {
     console.log('[Agent] ✗ buildIDEContextPrompt: No agent prompt provided');
   }
 
-  // Windows path format constraint (important technical workaround) - always include this constraint
-  prompt += '\n\n## CRITICAL: File Path Format Requirement\n\n';
-  prompt += '**IMPORTANT**: There\'s a file modification bug in Claude Code. The workaround is: always use complete absolute Windows paths with drive letters and backslashes for ALL file operations. Apply this rule going forward, not just for this file.\n\n';
-  prompt += '**Examples**:\n';
-  prompt += '- ✅ Correct: `C:\\Users\\username\\project\\src\\file.js`\n';
-  prompt += '- ❌ Wrong: `/c/Users/username/project/src/file.js`\n';
-  prompt += '- ❌ Wrong: `./src/file.js` (relative paths)\n\n';
-  prompt += '---\n\n';
+  // Windows path format constraint (important technical workaround) - only on Windows
+  if (process.platform === 'win32') {
+    prompt += '\n\n## CRITICAL: File Path Format Requirement\n\n';
+    prompt += '**IMPORTANT**: There\'s a file modification bug in Claude Code. The workaround is: always use complete absolute Windows paths with drive letters and backslashes for ALL file operations. Apply this rule going forward, not just for this file.\n\n';
+    prompt += '**Examples**:\n';
+    prompt += '- ✅ Correct: `C:\\Users\\username\\project\\src\\file.js`\n';
+    prompt += '- ❌ Wrong: `/c/Users/username/project/src/file.js`\n';
+    prompt += '- ❌ Wrong: `./src/file.js` (relative paths)\n\n';
+    prompt += '---\n\n';
+  }
 
   if (!openedFiles || typeof openedFiles !== 'object') {
     // If there's only an agent prompt with no IDE context, still return the agent prompt


### PR DESCRIPTION
## Summary
- Only display Windows path format constraints on Windows platform (`process.platform === 'win32'`)
- Prevents showing Windows-specific path instructions to macOS/Linux users
- Improves user experience by showing platform-relevant information only

## Changes
- Added platform detection in `quickfix-prompts.js`
- Added platform detection in `system-prompts.js`
- Windows path constraint prompts now conditionally rendered

## Test Plan
- [x] Test on Windows: Verify Windows path constraints appear
- [x] Test on macOS: Verify Windows path constraints do NOT appear

## Related Issue
Closes #485
