### PR TITLE
修复：支持文件标签中带空格的文件名

### DIFF
--- a/webview/src/components/ChatInputBox/hooks/useFileTags.ts
+++ b/webview/src/components/ChatInputBox/hooks/useFileTags.ts
@@ -95,12 +95,6 @@ export function useFileTags({
     const timer = perfTimer('renderFileTags');
     if (!editableRef.current) return;
 
-    // Regex: match @filepath (ending with space or string end)
-    // Supports files and directories: extension is optional
-    // Supports Windows paths (backslash) and Unix paths (forward slash)
-    // Matches all characters except space and @ (including backslash, forward slash, colon, etc.)
-    const fileRefRegex = /@([^\s@]+?)(\s|$)/g;
-
     const currentText = getTextContent();
     timer.mark('getText');
 
@@ -118,8 +112,78 @@ export function useFileTags({
       return;
     }
 
-    const matches = Array.from(currentText.matchAll(fileRefRegex));
-    timer.mark('regex');
+    /**
+     * Smart file reference matching that supports filenames with spaces.
+     *
+     * Strategy:
+     * 1. Find all @ positions in the text
+     * 2. For each @, try to match against known paths in pathMappingRef
+     * 3. Choose the longest matching path to handle filenames with spaces correctly
+     * 4. Fall back to simple regex matching for paths not in pathMappingRef
+     */
+    interface FileMatch {
+      index: number;
+      path: string;
+      fullMatch: string;
+    }
+
+    const matches: FileMatch[] = [];
+
+    // First pass: Find @ positions and try to match against pathMappingRef
+    for (let i = 0; i < currentText.length; i++) {
+      if (currentText[i] === '@') {
+        let longestMatch: { path: string; length: number } | null = null;
+
+        // Try to find the longest matching path from pathMappingRef
+        for (const [key] of pathMappingRef.current) {
+          const pathWithAt = '@' + key;
+          const remainingText = currentText.substring(i);
+
+          // Check if the text at this position matches this path
+          // Match must be followed by space, newline, or end of string
+          if (remainingText.startsWith(pathWithAt)) {
+            const afterPath = remainingText.substring(pathWithAt.length);
+            if (afterPath.length === 0 || afterPath[0] === ' ' || afterPath[0] === '\n') {
+              // This is a valid match
+              if (!longestMatch || key.length > longestMatch.length) {
+                longestMatch = { path: key, length: key.length };
+              }
+            }
+          }
+        }
+
+        if (longestMatch) {
+          // Found a match from pathMappingRef
+          const spacer = currentText[i + 1 + longestMatch.length] === ' ' ? ' ' : '';
+          matches.push({
+            index: i,
+            path: longestMatch.path,
+            fullMatch: '@' + longestMatch.path + spacer,
+          });
+          // Skip past this match
+          i += longestMatch.length;
+          continue;
+        }
+
+        // Fall back to simple pattern matching for paths not in pathMappingRef
+        // This handles absolute paths and paths with line numbers
+        // Match pattern: @[non-space-non-@-chars](space|newline|end)
+        const remainingText = currentText.substring(i);
+        const simpleMatch = remainingText.match(/^@([^\s@]+?)(\s|$)/);
+
+        if (simpleMatch) {
+          matches.push({
+            index: i,
+            path: simpleMatch[1],
+            fullMatch: simpleMatch[0],
+          });
+          // Skip past this match (minus 1 because the loop will increment i)
+          i += simpleMatch[0].length - 1;
+        }
+      }
+    }
+
+    timer.mark('smart-matching');
 
     if (matches.length === 0) {
       // No file references, keep as is
@@ -166,9 +230,9 @@ export function useFileTags({
     let lastIndex = 0;
 
     limitedMatches.forEach((match) => {
-      const fullMatch = match[0];
-      const filePath = match[1];
-      const matchIndex = match.index || 0;
+      const fullMatch = match.fullMatch;
+      const filePath = match.path;
+      const matchIndex = match.index;
 
       // Add text before match
       if (matchIndex > lastIndex) {


### PR DESCRIPTION
## 概述

修复 #480（问题2）

将基于简单正则表达式的文件标签匹配替换为智能路径匹配算法，正确处理带空格的文件名。

## 主要改动

- 实现智能匹配算法，优先从已知路径中匹配最长路径
- 通过检查 `pathMappingRef` 来支持带空格的文件名
- 对未知/绝对路径回退到简单模式匹配
- 保持与现有文件引用模式的向后兼容性

## 工作原理

1. 在文本中查找所有 @ 符号位置
2. 对每个 @，尝试匹配 `pathMappingRef` 中的已知路径
3. 选择最长匹配路径，以正确处理带空格的文件名
4. 对于 `pathMappingRef` 中不存在的路径，回退到简单正则表达式匹配

## 技术细节

**之前的实现**：
- 使用正则表达式 `/@([^\s@]+?)(\s|$)/g` 匹配文件路径
- 遇到空格就截断，无法处理带空格的文件名

**新实现**：
- 遍历文本中的每个 @ 符号
- 在 `pathMappingRef` 中查找最长匹配路径
- 确保匹配后跟空格、换行或字符串结束
- 对于不在映射中的路径（如绝对路径），保持原有正则匹配逻辑

## 测试计划

- [x] 验证带空格的文件名能够正确工作
- [x] 现有测试通过
- [x] 手动测试确认文件标签正确渲染
- [x] 测试不同场景：
  - 带空格的相对路径（如 `my file.ts`）
  - 不带空格的路径（向后兼容）
  - 绝对路径
  - 带行号的路径

## 关联 Issue

Closes #480
