### PR TITLE
feat: replace remote SDK slash command fetching with local registry

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -5,7 +5,6 @@
 import {
   sendMessage as claudeSendMessage,
   sendMessageWithAttachments as claudeSendMessageWithAttachments,
-  getSlashCommands as claudeGetSlashCommands,
   rewindFiles as claudeRewindFiles,
   getMcpServerStatus as claudeGetMcpServerStatus,
   getMcpServerTools as claudeGetMcpServerTools
@@ -63,12 +62,6 @@ export async function handleClaudeCommand(command, args, stdinData) {
       await claudeGetSessionMessages(args[0], args[1]);
       break;
 
-    case 'getSlashCommands': {
-      const cwd = stdinData?.cwd || args[0] || null;
-      await claudeGetSlashCommands(cwd);
-      break;
-    }
-
     case 'rewindFiles': {
       const sessionId = stdinData?.sessionId || args[0];
       const userMessageId = stdinData?.userMessageId || args[1];
@@ -102,5 +95,5 @@ export async function handleClaudeCommand(command, args, stdinData) {
 }
 
 export function getClaudeCommandList() {
-  return ['send', 'sendWithAttachments', 'getSession', 'getSlashCommands', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools'];
+  return ['send', 'sendWithAttachments', 'getSession', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools'];
 }

--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -9,7 +9,6 @@
  * Protocol (stdin, one JSON per line):
  *   {"id":"1","method":"claude.send","params":{...}}
  *   {"id":"2","method":"heartbeat"}
- *   {"id":"3","method":"claude.getSlashCommands","params":{"cwd":"..."}}
  *
  * Protocol (stdout, one JSON per line):
  *   {"type":"daemon","event":"ready","pid":12345}           // daemon lifecycle

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -935,11 +935,6 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
         // Store the query result for rewind operations
         activeQueryResults.set(msg.session_id, result);
         console.log('[REWIND_DEBUG] Stored query result for session:', msg.session_id);
-
-        // Output slash_commands (if present)
-        if (msg.subtype === 'init' && Array.isArray(msg.slash_commands)) {
-          // console.log('[SLASH_COMMANDS]', JSON.stringify(msg.slash_commands));
-        }
       }
 
       // Check for error result messages (quick detection of API Key errors)
@@ -1762,130 +1757,8 @@ ${payload.error}`;
 	  }
 	}
 
-/**
- * Get the slash commands list.
- * Uses the SDK's supportedCommands() method to get the full command list.
- * This method does not require sending a message and can be called at plugin startup.
- */
-export async function getSlashCommands(cwd = null) {
-  // Default command list (used as fallback)
-  const defaultCommands = [
-    { name: '/help', description: 'Get help with using Claude Code' },
-    { name: '/clear', description: 'Clear conversation history' },
-    { name: '/compact', description: 'Toggle compact mode' },
-    { name: '/config', description: 'View or modify configuration' },
-    { name: '/cost', description: 'Show current session cost' },
-    { name: '/doctor', description: 'Run diagnostic checks' },
-    { name: '/init', description: 'Initialize a new project' },
-    { name: '/login', description: 'Log in to your account' },
-    { name: '/logout', description: 'Log out of your account' },
-    { name: '/memory', description: 'View or manage memory' },
-    { name: '/model', description: 'Change the current model' },
-    { name: '/permissions', description: 'View or modify permissions' },
-    { name: '/review', description: 'Review changes before applying' },
-    { name: '/status', description: 'Show current status' },
-    { name: '/terminal-setup', description: 'Set up terminal integration' },
-    { name: '/vim', description: 'Toggle vim mode' },
-  ];
-
-  // Create a timeout Promise
-  const withTimeout = (promise, ms, fallback) => {
-    return Promise.race([
-      promise,
-      new Promise((resolve) => {
-        setTimeout(() => resolve(fallback), ms);
-      })
-    ]);
-  };
-
-  try {
-    process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
-
-    // Set up API Key
-    setupApiKey();
-
-    // Ensure the HOME environment variable is set correctly
-    if (!process.env.HOME) {
-      process.env.HOME = getRealHomeDir();
-    }
-
-    // Intelligently determine the working directory
-    const workingDirectory = selectWorkingDirectory(cwd);
-    try {
-      process.chdir(workingDirectory);
-    } catch (chdirError) {
-      console.error('[WARNING] Failed to change process.cwd():', chdirError.message);
-    }
-
-    // Create an empty input stream
-    const inputStream = new AsyncStream();
-
-    // Dynamically load Claude SDK (with timeout)
-    const loadSdkPromise = ensureClaudeSdk();
-    const sdk = await withTimeout(loadSdkPromise, 30000, null);
-
-    if (!sdk) {
-      console.log('[SLASH_COMMANDS]', JSON.stringify(defaultCommands));
-      return;
-    }
-
-    const query = sdk?.query;
-    if (typeof query !== 'function') {
-      console.log('[SLASH_COMMANDS]', JSON.stringify(defaultCommands));
-      return;
-    }
-
-    // Call the query function with the empty input stream
-    const result = query({
-      prompt: inputStream,
-      options: {
-        cwd: workingDirectory,
-        permissionMode: 'default',
-        maxTurns: 0,
-        canUseTool: async () => ({
-          behavior: 'deny',
-          message: 'Config loading only'
-        }),
-        tools: { type: 'preset', preset: 'claude_code' },
-        settingSources: ['user', 'project', 'local'],
-        stderr: (data) => {
-          if (data && data.trim()) {
-            console.log(`[SDK-STDERR] ${data.trim()}`);
-          }
-        }
-      }
-    });
-
-    // Close the input stream immediately
-    inputStream.done();
-
-    // Get supported commands list (with timeout)
-    const getCommandsPromise = result.supportedCommands?.() || Promise.resolve([]);
-    const slashCommands = await withTimeout(getCommandsPromise, 15000, defaultCommands);
-
-    // Clean up resources (with timeout, non-blocking)
-    withTimeout(result.return?.() || Promise.resolve(), 5000, null).catch(() => {});
-
-    // Output the command list
-    const finalCommands = slashCommands.length > 0 ? slashCommands : defaultCommands;
-    console.log('[SLASH_COMMANDS]', JSON.stringify(finalCommands));
-
-    console.log(JSON.stringify({
-      success: true,
-      commands: finalCommands
-    }));
-
-  } catch (error) {
-    console.error('[GET_SLASH_COMMANDS_ERROR]', error.message);
-    console.error('[GET_SLASH_COMMANDS_ERROR_STACK]', error.stack);
-    // On error, return the default command list instead of an empty list
-    console.log('[SLASH_COMMANDS]', JSON.stringify(defaultCommands));
-    console.log(JSON.stringify({
-      success: true, // Using default commands; not considered a failure
-      commands: defaultCommands
-    }));
-  }
-}
+// NOTE: getSlashCommands() was removed — slash commands are now resolved
+// locally by Java SlashCommandRegistry (no SDK/bridge call needed).
 
 /**
  * Get MCP server connection status.

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ repositories {
 dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'javazoom:jlayer:1.0.1'
+    implementation 'org.yaml:snakeyaml:2.2'
 
     intellijPlatform {
         def targetIde = project.findProperty('targetIde') ?: 'IC'

--- a/src/main/java/com/github/claudecodegui/SkillService.java
+++ b/src/main/java/com/github/claudecodegui/SkillService.java
@@ -7,12 +7,11 @@ import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import com.github.claudecodegui.skill.SkillFrontmatterParser;
 
 /**
  * Skills service.
@@ -35,10 +34,6 @@ public class SkillService {
     private static final String CONFIG_DIR_NAME = ".codemoss";
     private static final String SKILLS_DIR_NAME = "skills";
     private static final String GLOBAL_DIR_NAME = "global";
-
-    // Regex patterns for matching description in YAML frontmatter
-    private static final Pattern FRONTMATTER_PATTERN = Pattern.compile("^---\\s*\\n([\\s\\S]*?)\\n---");
-    private static final Pattern DESCRIPTION_PATTERN = Pattern.compile("description:\\s*(.+?)(?:\\n[a-z-]+:|$)", Pattern.DOTALL);
 
     // ==================== Active Directories (read by Claude) ====================
 
@@ -185,20 +180,31 @@ public class SkillService {
                 continue;
             }
 
-            String type = entry.isDirectory() ? "directory" : "file";
+            // Per Agent Skills spec: only directories are valid skills
+            if (!entry.isDirectory()) {
+                continue;
+            }
+
             // ID format includes an enabled/disabled marker to distinguish same-named skills
             String id = scope + "-" + entry.getName() + (enabled ? "" : "-disabled");
-            String description = extractDescription(entry.getAbsolutePath(), entry.isDirectory());
 
             JsonObject skill = new JsonObject();
             skill.addProperty("id", id);
-            skill.addProperty("name", entry.getName());
-            skill.addProperty("type", type);
+            skill.addProperty("type", "directory");
             skill.addProperty("scope", scope);
             skill.addProperty("path", entry.getAbsolutePath());
             skill.addProperty("enabled", enabled);
-            if (description != null) {
-                skill.addProperty("description", description);
+
+            // Parse frontmatter for name and description
+            SkillFrontmatterParser.SkillMetadata metadata =
+                    SkillFrontmatterParser.parse(entry.toPath());
+            if (metadata != null) {
+                skill.addProperty("name", metadata.name());
+                skill.addProperty("description", metadata.description());
+            } else {
+                // Keep skill in management list but mark as invalid
+                skill.addProperty("name", entry.getName());
+                skill.addProperty("warning", "invalid_frontmatter");
             }
 
             try {
@@ -217,46 +223,14 @@ public class SkillService {
     }
 
     /**
-     * Extracts the description from a skill.md file.
+     * Extracts the description from a skill directory's SKILL.md.
+     * Delegates to SkillFrontmatterParser for standard YAML parsing.
      */
     private static String extractDescription(String skillPath, boolean isDirectory) {
-        try {
-            String mdPath;
-            if (isDirectory) {
-                // If it's a directory, look for a skill.md or SKILL.md file
-                File skillMd = new File(skillPath, "skill.md");
-                if (!skillMd.exists()) {
-                    skillMd = new File(skillPath, "SKILL.md");
-                }
-                if (!skillMd.exists()) {
-                    return null;
-                }
-                mdPath = skillMd.getAbsolutePath();
-            } else {
-                // If it's a file, check if it's a .md file
-                if (!skillPath.toLowerCase().endsWith(".md")) {
-                    return null;
-                }
-                mdPath = skillPath;
-            }
-
-            String content = Files.readString(Path.of(mdPath), StandardCharsets.UTF_8);
-
-            // Extract description from the YAML frontmatter
-            Matcher frontmatterMatcher = FRONTMATTER_PATTERN.matcher(content);
-            if (frontmatterMatcher.find()) {
-                String frontmatter = frontmatterMatcher.group(1);
-                Matcher descMatcher = DESCRIPTION_PATTERN.matcher(frontmatter);
-                if (descMatcher.find()) {
-                    return descMatcher.group(1).trim();
-                }
-            }
-
-            return null;
-        } catch (IOException e) {
-            LOG.warn("[Skills] 提取 description 失败: " + e.getMessage());
+        if (!isDirectory) {
             return null;
         }
+        return SkillFrontmatterParser.extractDescription(Path.of(skillPath));
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/FileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/FileHandler.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.handler;
 import com.github.claudecodegui.model.FileSortItem;
 import com.github.claudecodegui.service.RunConfigMonitorService;
 import com.github.claudecodegui.terminal.TerminalMonitorService;
+import com.github.claudecodegui.skill.SlashCommandRegistry;
 import com.github.claudecodegui.util.EditorFileUtils;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
 import com.google.gson.Gson;
@@ -438,107 +439,55 @@ public class FileHandler extends BaseMessageHandler {
 
     /**
      * Handle get command list request.
-     * Calls ClaudeSDKBridge to get the real SDK slash command list.
+     * Uses local SlashCommandRegistry instead of SDK bridge call.
      */
     private void handleGetCommands(String content) {
-        CompletableFuture.runAsync(() -> {
+        String query = "";
+        if (content != null && !content.isEmpty()) {
             try {
-                String query = "";
-                if (content != null && !content.isEmpty()) {
-                    try {
-                        Gson gson = new Gson();
-                        JsonObject json = gson.fromJson(content, JsonObject.class);
-                        if (json.has("query")) {
-                            query = json.get("query").getAsString();
-                        }
-                    } catch (Exception e) {
-                        query = content;
-                    }
+                JsonObject json = new Gson().fromJson(content, JsonObject.class);
+                if (json.has("query")) {
+                    query = json.get("query").getAsString();
                 }
-
-                // Get working directory
-                String cwd = getEffectiveBasePath();
-
-                LOG.info("[FileHandler] Getting slash commands from SDK, cwd=" + cwd);
-
-                // Call ClaudeSDKBridge to get the real slash commands
-                final String finalQuery = query;
-                context.getClaudeSDKBridge().getSlashCommands(cwd).thenAccept(sdkCommands -> {
-                    try {
-                        Gson gson = new Gson();
-                        List<JsonObject> commands = new ArrayList<>();
-
-                        // Convert SDK returned command format
-                        for (JsonObject cmd : sdkCommands) {
-                            String name = cmd.has("name") ? cmd.get("name").getAsString() : "";
-                            String description = cmd.has("description") ? cmd.get("description").getAsString() : "";
-
-                            // Ensure command starts with /
-                            String label = name.startsWith("/") ? name : "/" + name;
-
-                            // Apply filter
-                            if (finalQuery.isEmpty() || label.toLowerCase().contains(finalQuery.toLowerCase()) || description.toLowerCase().contains(finalQuery.toLowerCase())) {
-                                JsonObject cmdObj = new JsonObject();
-                                cmdObj.addProperty("label", label);
-                                cmdObj.addProperty("description", description);
-                                commands.add(cmdObj);
-                            }
-                        }
-
-                        LOG.info("[FileHandler] Got " + commands.size() + " commands from SDK (filtered from " + sdkCommands.size() + ")");
-
-                        // If SDK returned no commands, use local default commands as fallback
-                        if (commands.isEmpty() && sdkCommands.isEmpty()) {
-                            LOG.info("[FileHandler] SDK returned no commands, using local fallback");
-                            addFallbackCommands(commands, finalQuery);
-                        }
-
-                        JsonObject result = new JsonObject();
-                        result.add("commands", gson.toJsonTree(commands));
-                        String resultJson = gson.toJson(result);
-
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            String js = "if (window.onCommandListResult) { window.onCommandListResult('" + escapeJs(resultJson) + "'); }";
-                            context.executeJavaScriptOnEDT(js);
-                        });
-                    } catch (Exception e) {
-                        LOG.error("[FileHandler] Failed to process SDK commands: " + e.getMessage(), e);
-                    }
-                }).exceptionally(ex -> {
-                    LOG.error("[FileHandler] Failed to get commands from SDK: " + ex.getMessage());
-                    // Use local default commands on error
-                    try {
-                        Gson gson = new Gson();
-                        List<JsonObject> commands = new ArrayList<>();
-                        addFallbackCommands(commands, finalQuery);
-
-                        JsonObject result = new JsonObject();
-                        result.add("commands", gson.toJsonTree(commands));
-                        String resultJson = gson.toJson(result);
-
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            String js = "if (window.onCommandListResult) { window.onCommandListResult('" + escapeJs(resultJson) + "'); }";
-                            context.executeJavaScriptOnEDT(js);
-                        });
-                    } catch (Exception e) {
-                        LOG.error("[FileHandler] Failed to send fallback commands: " + e.getMessage(), e);
-                    }
-                    return null;
-                });
             } catch (Exception e) {
-                LOG.error("[FileHandler] Failed to get commands: " + e.getMessage(), e);
+                query = content;
             }
-        });
-    }
+        }
 
-    private void addFallbackCommands(List<JsonObject> commands, String query) {
-        addCommand(commands, "/help", "显示帮助信息", query);
-        addCommand(commands, "/clear", "清空对话历史", query);
-        addCommand(commands, "/history", "查看历史记录", query);
-        addCommand(commands, "/model", "切换模型", query);
-        addCommand(commands, "/compact", "压缩对话上下文", query);
-        addCommand(commands, "/init", "初始化项目配置", query);
-        addCommand(commands, "/review", "代码审查", query);
+        String cwd = getEffectiveBasePath();
+        String provider = "claude";
+        if (context.getSession() != null && context.getSession().getProvider() != null) {
+            provider = context.getSession().getProvider();
+        }
+
+        var registryCommands = SlashCommandRegistry.getCommands(provider, cwd);
+
+        Gson gson = new Gson();
+        List<JsonObject> commands = new ArrayList<>();
+        final String finalQuery = query.toLowerCase();
+
+        for (var cmd : registryCommands) {
+            String name = cmd.name();
+            String description = cmd.description();
+            if (finalQuery.isEmpty()
+                    || name.toLowerCase().contains(finalQuery)
+                    || description.toLowerCase().contains(finalQuery)) {
+                JsonObject cmdObj = new JsonObject();
+                cmdObj.addProperty("label", name);
+                cmdObj.addProperty("description", description);
+                commands.add(cmdObj);
+            }
+        }
+
+        JsonObject result = new JsonObject();
+        result.add("commands", gson.toJsonTree(commands));
+        String resultJson = gson.toJson(result);
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            String js = "if (window.onCommandListResult) { window.onCommandListResult('"
+                    + escapeJs(resultJson) + "'); }";
+            context.executeJavaScriptOnEDT(js);
+        });
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -7,6 +7,7 @@ import com.github.claudecodegui.ClaudeSession;
 import com.github.claudecodegui.session.ClaudeMessageHandler;
 import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.model.NodeDetectionResult;
+import com.github.claudecodegui.skill.SlashCommandRegistry;
 import com.github.claudecodegui.util.FontConfigService;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
 import com.github.claudecodegui.util.SoundNotificationService;
@@ -459,10 +460,37 @@ public class SettingsHandler extends BaseMessageHandler {
                 context.getSession().setProvider(provider);
             }
 
+            // Refresh slash commands for the new provider
+            refreshSlashCommandsForProvider(provider);
+
             refreshContextBar();
         } catch (Exception e) {
             LOG.error("[SettingsHandler] Failed to set provider: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Refreshes slash commands after provider switch using local registry.
+     */
+    private void refreshSlashCommandsForProvider(String provider) {
+        String cwd = null;
+        if (context.getSession() != null) {
+            cwd = context.getSession().getCwd();
+        }
+        if (cwd == null) {
+            cwd = context.getProject().getBasePath();
+        }
+
+        var commands = SlashCommandRegistry.getCommands(provider, cwd);
+        String json = SlashCommandRegistry.toJson(commands);
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                callJavaScript("updateSlashCommands", escapeJs(json));
+            } catch (Exception e) {
+                LOG.warn("[SettingsHandler] Failed to refresh slash commands: " + e.getMessage());
+            }
+        });
     }
 
     private void refreshContextBar() {

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 public class ClaudeSDKBridge extends BaseSDKBridge {
 
     private static final String NODE_SCRIPT = "simple-query.js";
-    private static final String SLASH_COMMANDS_CHANNEL_ID = "__slash_commands__";
     private static final String MCP_STATUS_CHANNEL_ID = "__mcp_status__";
 
     /** Maximum characters to preview in log output */
@@ -310,9 +309,6 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         } else if (line.startsWith("[SESSION_ID]")) {
             String capturedSessionId = line.substring("[SESSION_ID]".length()).trim();
             callback.onMessage("session_id", capturedSessionId);
-        } else if (line.startsWith("[SLASH_COMMANDS]")) {
-            String slashCommandsJson = line.substring("[SLASH_COMMANDS]".length()).trim();
-            callback.onMessage("slash_commands", slashCommandsJson);
         } else if (line.startsWith("[TOOL_RESULT]")) {
             String toolResultJson = line.substring("[TOOL_RESULT]".length()).trim();
             callback.onMessage("tool_result", toolResultJson);
@@ -977,9 +973,6 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                             } else if (line.startsWith("[SESSION_ID]")) {
                                 String capturedSessionId = line.substring("[SESSION_ID]".length()).trim();
                                 callback.onMessage("session_id", capturedSessionId);
-                            } else if (line.startsWith("[SLASH_COMMANDS]")) {
-                                String slashCommandsJson = line.substring("[SLASH_COMMANDS]".length()).trim();
-                                callback.onMessage("slash_commands", slashCommandsJson);
                             } else if (line.startsWith("[TOOL_RESULT]")) {
                                 String toolResultJson = line.substring("[TOOL_RESULT]".length()).trim();
                                 callback.onMessage("tool_result", toolResultJson);
@@ -1128,138 +1121,6 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         } catch (Exception e) {
             throw new RuntimeException("Failed to get session messages: " + e.getMessage(), e);
         }
-    }
-
-    /**
-     * Get slash commands list.
-     */
-    public CompletableFuture<List<JsonObject>> getSlashCommands(String cwd) {
-        return CompletableFuture.supplyAsync(() -> {
-            Process process = null;
-
-            try {
-                String node = nodeDetector.findNodeExecutable();
-
-                JsonObject stdinInput = new JsonObject();
-                stdinInput.addProperty("cwd", cwd != null ? cwd : "");
-                String stdinJson = gson.toJson(stdinInput);
-
-                File bridgeDir = getDirectoryResolver().findSdkDir();
-                if (bridgeDir == null || !bridgeDir.exists()) {
-                    return new ArrayList<>();
-                }
-
-                File channelScript = new File(bridgeDir, CHANNEL_SCRIPT);
-                if (!channelScript.exists()) {
-                    LOG.error("channel-manager.js not found at: " + channelScript.getAbsolutePath());
-                    return new ArrayList<>();
-                }
-
-                List<String> command = new ArrayList<>();
-                command.add(node);
-                command.add(channelScript.getAbsolutePath());
-                command.add("claude");
-                command.add("getSlashCommands");
-
-                ProcessBuilder pb = new ProcessBuilder(command);
-                pb.directory(bridgeDir);
-                pb.redirectErrorStream(true);
-                envConfigurator.updateProcessEnvironment(pb, node);
-                pb.environment().put("CLAUDE_USE_STDIN", "true");
-
-                process = pb.start();
-                processManager.registerProcess(SLASH_COMMANDS_CHANNEL_ID, process);
-                final Process finalProcess = process;
-
-                try (java.io.OutputStream stdin = process.getOutputStream()) {
-                    stdin.write(stdinJson.getBytes(StandardCharsets.UTF_8));
-                    stdin.flush();
-                } catch (Exception e) {
-                    // Ignore stdin write error
-                }
-
-                final boolean[] found = {false};
-                final String[] slashCommandsJson = {null};
-                final StringBuilder output = new StringBuilder();
-
-                Thread readerThread = new Thread(() -> {
-                    try (BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(finalProcess.getInputStream(), StandardCharsets.UTF_8))) {
-                        String line;
-                        while (!found[0] && (line = reader.readLine()) != null) {
-                            output.append(line).append("\n");
-
-                            if (line.startsWith("[SLASH_COMMANDS]")) {
-                                slashCommandsJson[0] = line.substring("[SLASH_COMMANDS]".length()).trim();
-                                found[0] = true;
-                                break;
-                            }
-                        }
-                    } catch (Exception e) {
-                        // Reader thread exception, ignore
-                    }
-                });
-                readerThread.start();
-
-                long deadline = System.currentTimeMillis() + 60000; // 60-second timeout
-                while (!found[0] && System.currentTimeMillis() < deadline) {
-                    Thread.sleep(100);
-                }
-
-                if (process.isAlive()) {
-                    PlatformUtils.terminateProcess(process);
-                }
-
-                List<JsonObject> commands = new ArrayList<>();
-
-                if (found[0] && slashCommandsJson[0] != null && !slashCommandsJson[0].isEmpty()) {
-                    try {
-                        JsonArray commandsArray = gson.fromJson(slashCommandsJson[0], JsonArray.class);
-                        for (var cmd : commandsArray) {
-                            commands.add(cmd.getAsJsonObject());
-                        }
-                        return commands;
-                    } catch (Exception e) {
-                        LOG.warn("Failed to parse commands JSON: " + e.getMessage());
-                    }
-                }
-
-                // Fallback: use extractLastJsonLine for multi-line output handling
-                String outputStr = output.toString().trim();
-                String jsonStr = extractLastJsonLine(outputStr);
-                if (jsonStr != null) {
-                    try {
-                        JsonObject jsonResult = gson.fromJson(jsonStr, JsonObject.class);
-                        if (jsonResult.has("success") && jsonResult.get("success").getAsBoolean()) {
-                            if (jsonResult.has("commands")) {
-                                JsonArray commandsArray = jsonResult.getAsJsonArray("commands");
-                                for (var cmd : commandsArray) {
-                                    commands.add(cmd.getAsJsonObject());
-                                }
-                            }
-                        }
-                    } catch (Exception e) {
-                        // Fallback JSON parse failed, ignore
-                    }
-                }
-
-                return commands;
-
-            } catch (Exception e) {
-                LOG.error("getSlashCommands exception: " + e.getMessage());
-                return new ArrayList<>();
-            } finally {
-                if (process != null) {
-                    try {
-                        if (process.isAlive()) {
-                            PlatformUtils.terminateProcess(process);
-                        }
-                    } finally {
-                        processManager.unregisterProcess(SLASH_COMMANDS_CHANNEL_ID, process);
-                    }
-                }
-            }
-        });
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -7,6 +7,7 @@ import com.github.claudecodegui.handler.HandlerContext;
 import com.github.claudecodegui.handler.SettingsHandler;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.skill.SlashCommandRegistry;
 import com.github.claudecodegui.util.JsUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -100,6 +101,9 @@ public class SessionLifecycleManager {
             newSession.setSessionInfo(null, workingDirectory);
             LOG.info("New session created successfully, working directory: " + workingDirectory);
             host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory);
+
+            // Push slash commands for the new session
+            fetchSlashCommandsOnStartup();
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 host.callJavaScript("updateStatus",
@@ -209,7 +213,8 @@ public class SessionLifecycleManager {
     }
 
     /**
-     * Fetch slash commands from the SDK.
+     * Fetch slash commands using local registry (no SDK/API call needed).
+     * Merges built-in commands with skill-derived commands per provider.
      */
     public void fetchSlashCommandsOnStartup() {
         ClaudeSession currentSession = host.getSession();
@@ -218,25 +223,27 @@ public class SessionLifecycleManager {
             cwd = host.getProject().getBasePath();
         }
 
-        LOG.info("Fetching slash commands from SDK, cwd=" + cwd);
+        // Determine current provider
+        String provider = "claude";
+        if (currentSession != null && currentSession.getProvider() != null) {
+            provider = currentSession.getProvider();
+        }
 
-        host.getClaudeSDKBridge().getSlashCommands(cwd).thenAccept(commands -> {
-            host.setFetchedSlashCommandsCount(commands.size());
-            host.setSlashCommandsFetched(true);
-            LOG.info("Slash commands fetched from SDK: " + commands.size() + " commands");
+        LOG.info("Fetching slash commands locally, provider=" + provider + ", cwd=" + cwd);
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                try {
-                    String commandsJson = new Gson().toJson(commands);
-                    LOG.debug("Calling updateSlashCommands with JSON length=" + commandsJson.length());
-                    host.callJavaScript("updateSlashCommands", JsUtils.escapeJs(commandsJson));
-                } catch (Exception e) {
-                    LOG.warn("Failed to send slash commands to frontend: " + e.getMessage(), e);
-                }
-            });
-        }).exceptionally(e -> {
-            LOG.warn("Failed to fetch slash commands from SDK: " + e.getMessage(), e);
-            return null;
+        var commands = SlashCommandRegistry.getCommands(provider, cwd);
+        String commandsJson = SlashCommandRegistry.toJson(commands);
+
+        host.setFetchedSlashCommandsCount(commands.size());
+        host.setSlashCommandsFetched(true);
+        LOG.info("Slash commands resolved locally: " + commands.size() + " commands");
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                host.callJavaScript("updateSlashCommands", JsUtils.escapeJs(commandsJson));
+            } catch (Exception e) {
+                LOG.warn("Failed to send slash commands to frontend: " + e.getMessage(), e);
+            }
         });
     }
 

--- a/src/main/java/com/github/claudecodegui/skill/SkillFrontmatterParser.java
+++ b/src/main/java/com/github/claudecodegui/skill/SkillFrontmatterParser.java
@@ -1,0 +1,260 @@
+package com.github.claudecodegui.skill;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Parses SKILL.md YAML frontmatter per the Agent Skills specification.
+ * Extracts and validates name, description, and optional metadata fields.
+ */
+public final class SkillFrontmatterParser {
+
+    private static final Logger LOG = Logger.getInstance(SkillFrontmatterParser.class);
+
+    // Name validation: lowercase alphanumeric + hyphens, 1-64 chars,
+    // no leading/trailing hyphen, no consecutive hyphens
+    private static final Pattern NAME_PATTERN =
+            Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
+    private static final int NAME_MAX_LENGTH = 64;
+    private static final int DESCRIPTION_MAX_LENGTH = 1024;
+    private static final Pattern CONSECUTIVE_HYPHENS = Pattern.compile("--");
+
+    private SkillFrontmatterParser() {
+    }
+
+    /**
+     * Parsed skill metadata from SKILL.md frontmatter.
+     */
+    public record SkillMetadata(
+            String name,
+            String description,
+            String license,
+            String compatibility,
+            String allowedTools,
+            boolean userInvocable
+    ) {
+    }
+
+    /**
+     * Validates a skill name per the Agent Skills specification.
+     */
+    public static boolean isValidSkillName(String name) {
+        if (name == null || name.isEmpty() || name.length() > NAME_MAX_LENGTH) {
+            return false;
+        }
+        if (CONSECUTIVE_HYPHENS.matcher(name).find()) {
+            return false;
+        }
+        return NAME_PATTERN.matcher(name).matches();
+    }
+
+    /**
+     * Locates the SKILL.md file in a skill directory.
+     * Checks SKILL.md first, then skill.md as fallback.
+     *
+     * @return the path to the skill markdown file, or null if not found
+     */
+    static Path locateSkillMd(Path skillDir) {
+        Path upper = skillDir.resolve("SKILL.md");
+        if (Files.isRegularFile(upper)) {
+            return upper;
+        }
+        Path lower = skillDir.resolve("skill.md");
+        if (Files.isRegularFile(lower)) {
+            return lower;
+        }
+        return null;
+    }
+
+    /**
+     * Extracts YAML frontmatter text between the first pair of --- delimiters.
+     *
+     * @return the YAML text, or null if no valid frontmatter found
+     */
+    static String extractFrontmatter(Path filePath) {
+        String content;
+        try {
+            content = Files.readString(filePath, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.warn("Failed to read skill file: " + filePath, e);
+            return null;
+        }
+
+        if (!content.startsWith("---")) {
+            LOG.debug("No frontmatter delimiter at start of file: " + filePath);
+            return null;
+        }
+
+        // Find the closing --- delimiter (skip the opening one)
+        int secondDelimiter = content.indexOf("\n---", 3);
+        if (secondDelimiter < 0) {
+            LOG.debug("No closing frontmatter delimiter in file: " + filePath);
+            return null;
+        }
+
+        // Extract YAML between the two delimiters
+        String yaml = content.substring(3, secondDelimiter).trim();
+        if (yaml.isEmpty()) {
+            LOG.debug("Empty frontmatter in file: " + filePath);
+            return null;
+        }
+        return yaml;
+    }
+
+    /**
+     * Parses a skill directory's SKILL.md frontmatter into validated metadata.
+     * Combines file location, frontmatter extraction, YAML parsing, and validation.
+     *
+     * @param skillDir the skill directory (e.g. ~/.claude/skills/commit/)
+     * @return parsed and validated metadata, or null if parsing/validation fails
+     */
+    @SuppressWarnings("unchecked")
+    public static SkillMetadata parse(Path skillDir) {
+        // Step 1: Locate SKILL.md
+        Path skillMd = locateSkillMd(skillDir);
+        if (skillMd == null) {
+            return null;
+        }
+
+        // Step 2: Extract frontmatter YAML text
+        String yamlText = extractFrontmatter(skillMd);
+        if (yamlText == null) {
+            return null;
+        }
+
+        // Step 3: Parse YAML
+        Map<String, Object> yamlMap;
+        try {
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            Object parsed = yaml.load(yamlText);
+            if (!(parsed instanceof Map)) {
+                LOG.warn("Frontmatter is not a YAML mapping: " + skillMd);
+                return null;
+            }
+            yamlMap = (Map<String, Object>) parsed;
+        } catch (Exception e) {
+            LOG.warn("Failed to parse YAML frontmatter in " + skillMd + ": " + e.getMessage());
+            return null;
+        }
+
+        // Step 4: Extract name (optional per docs, falls back to directory name)
+        String dirName = skillDir.getFileName().toString();
+        Object nameObj = yamlMap.get("name");
+        String name;
+        if (nameObj != null) {
+            name = String.valueOf(nameObj).trim();
+            if (!isValidSkillName(name)) {
+                LOG.warn("Invalid skill name '" + name + "' in " + skillMd
+                        + ", falling back to directory name '" + dirName + "'");
+                name = dirName;
+            }
+        } else {
+            name = dirName;
+        }
+
+        // Step 5: Extract description (optional per docs, falls back to first paragraph)
+        Object descObj = yamlMap.get("description");
+        String description = descObj != null ? String.valueOf(descObj).trim() : null;
+        if (description == null || description.isEmpty()) {
+            description = extractFirstParagraph(skillMd);
+            if (description != null) {
+                LOG.debug("Using first paragraph as description for: " + skillMd);
+            }
+        }
+        if (description == null) {
+            description = "";
+        }
+        if (description.length() > DESCRIPTION_MAX_LENGTH) {
+            description = description.substring(0, DESCRIPTION_MAX_LENGTH);
+        }
+
+        // Step 6: Extract optional fields
+        String license = getOptionalString(yamlMap, "license");
+        String compatibility = getOptionalString(yamlMap, "compatibility");
+        String allowedTools = getOptionalString(yamlMap, "allowed-tools");
+
+        // Step 7: Extract user-invocable (default true per docs)
+        boolean userInvocable = true;
+        Object uiObj = yamlMap.get("user-invocable");
+        if (uiObj != null) {
+            userInvocable = Boolean.parseBoolean(String.valueOf(uiObj).trim());
+        }
+
+        return new SkillMetadata(name, description, license, compatibility, allowedTools, userInvocable);
+    }
+
+    /**
+     * Convenience method for SkillService backward compatibility.
+     * Extracts only the description field from a skill directory's SKILL.md.
+     *
+     * @param skillDir the skill directory path
+     * @return the description string, or null if parsing fails
+     */
+    public static String extractDescription(Path skillDir) {
+        SkillMetadata metadata = parse(skillDir);
+        return metadata != null ? metadata.description() : null;
+    }
+
+    /**
+     * Extracts the first non-empty paragraph from the markdown body after frontmatter.
+     * Used as fallback when the description field is missing from frontmatter.
+     */
+    static String extractFirstParagraph(Path filePath) {
+        String content;
+        try {
+            content = Files.readString(filePath, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return null;
+        }
+
+        // Find the end of frontmatter
+        if (!content.startsWith("---")) {
+            return null;
+        }
+        int closingDelimiter = content.indexOf("\n---", 3);
+        if (closingDelimiter < 0) {
+            return null;
+        }
+
+        // Skip past the closing --- and any trailing newline
+        int bodyStart = content.indexOf('\n', closingDelimiter + 4);
+        if (bodyStart < 0 || bodyStart >= content.length()) {
+            return null;
+        }
+        String body = content.substring(bodyStart + 1).stripLeading();
+        if (body.isEmpty()) {
+            return null;
+        }
+
+        // Take text up to the first blank line (double newline)
+        int blankLine = body.indexOf("\n\n");
+        String firstParagraph = (blankLine > 0 ? body.substring(0, blankLine) : body).trim();
+
+        // Strip leading markdown heading markers (# ## etc.)
+        firstParagraph = firstParagraph.replaceFirst("^#+\\s*", "");
+
+        if (firstParagraph.isEmpty() || firstParagraph.length() > DESCRIPTION_MAX_LENGTH) {
+            return firstParagraph.isEmpty() ? null
+                    : firstParagraph.substring(0, DESCRIPTION_MAX_LENGTH);
+        }
+        return firstParagraph;
+    }
+
+    private static String getOptionalString(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        String str = String.valueOf(value).trim();
+        return str.isEmpty() ? null : str;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -1,0 +1,300 @@
+package com.github.claudecodegui.skill;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Merges built-in slash commands with skill-derived commands per provider.
+ * Produces a deduplicated command list in the same JSON format as the SDK.
+ */
+public final class SlashCommandRegistry {
+
+    private static final Logger LOG = Logger.getInstance(SlashCommandRegistry.class);
+
+    private SlashCommandRegistry() {
+    }
+
+    /**
+     * A slash command with name (including / prefix) and description.
+     */
+    public record SlashCommand(String name, String description) {
+    }
+
+    // Claude built-in commands (GUI-relevant only; CLI-only and frontend-local ones are excluded)
+    public static final List<SlashCommand> CLAUDE_BUILTIN = List.of(
+            new SlashCommand("/compact", "Toggle compact mode"),
+            new SlashCommand("/init", "Initialize a new project"),
+            new SlashCommand("/review", "Review changes before applying")
+    );
+
+    // Codex built-in commands (GUI-relevant only; CLI-only ones like /status, /model, /quit are excluded)
+    public static final List<SlashCommand> CODEX_BUILTIN = List.of(
+            new SlashCommand("/compact", "Summarize conversation to free tokens"),
+            new SlashCommand("/diff", "Show pending changes diff including untracked files"),
+            new SlashCommand("/init", "Generate an AGENTS.md scaffold"),
+            new SlashCommand("/plan", "Switch to plan mode"),
+            new SlashCommand("/review", "Review working tree changes")
+    );
+
+    /**
+     * Scans a skills directory for valid skill subdirectories and converts them to slash commands.
+     * Skips plain files and hidden directories.
+     */
+    private static List<SlashCommand> scanSkillsAsCommands(String dirPath) {
+        if (dirPath == null || dirPath.isEmpty()) {
+            return List.of();
+        }
+        File dir = new File(dirPath);
+        if (!dir.isDirectory()) {
+            return List.of();
+        }
+
+        File[] entries = dir.listFiles();
+        if (entries == null) {
+            return List.of();
+        }
+
+        List<SlashCommand> commands = new ArrayList<>();
+        for (File entry : entries) {
+            // Only process directories, skip files and hidden dirs
+            if (!entry.isDirectory() || entry.getName().startsWith(".")) {
+                continue;
+            }
+
+            SkillFrontmatterParser.SkillMetadata metadata =
+                    SkillFrontmatterParser.parse(entry.toPath());
+            if (metadata == null) {
+                LOG.debug("Skipping skill directory with invalid metadata: " + entry.getName());
+                continue;
+            }
+
+            // Skills with user-invocable: false are hidden from the slash menu
+            if (!metadata.userInvocable()) {
+                continue;
+            }
+
+            commands.add(new SlashCommand("/" + metadata.name(), metadata.description()));
+        }
+        return commands;
+    }
+
+    /**
+     * Scans a commands directory for .md files and converts them to slash commands.
+     * Supports namespaced commands via subdirectories (e.g. opsx/explore.md → /opsx:explore).
+     */
+    private static List<SlashCommand> scanCommandsAsCommands(String dirPath) {
+        if (dirPath == null || dirPath.isEmpty()) {
+            return List.of();
+        }
+        File dir = new File(dirPath);
+        if (!dir.isDirectory()) {
+            return List.of();
+        }
+
+        File[] entries = dir.listFiles();
+        if (entries == null) {
+            return List.of();
+        }
+
+        List<SlashCommand> commands = new ArrayList<>();
+        for (File entry : entries) {
+            if (entry.getName().startsWith(".")) {
+                continue;
+            }
+
+            if (entry.isFile() && entry.getName().endsWith(".md")) {
+                // Top-level command: commit.md → /commit
+                SlashCommand cmd = parseCommandFile(entry, null);
+                if (cmd != null) {
+                    commands.add(cmd);
+                }
+            } else if (entry.isDirectory()) {
+                // Namespaced commands: opsx/explore.md → /opsx:explore
+                String namespace = entry.getName();
+                File[] subEntries = entry.listFiles();
+                if (subEntries == null) continue;
+
+                for (File subEntry : subEntries) {
+                    if (subEntry.isFile() && subEntry.getName().endsWith(".md")
+                            && !subEntry.getName().startsWith(".")) {
+                        SlashCommand cmd = parseCommandFile(subEntry, namespace);
+                        if (cmd != null) {
+                            commands.add(cmd);
+                        }
+                    }
+                }
+            }
+        }
+        return commands;
+    }
+
+    /**
+     * Scans a Codex prompts directory for .md files and converts them to slash commands.
+     * All prompts are namespaced as /prompts:&lt;name&gt; per Codex convention.
+     */
+    private static List<SlashCommand> scanPromptsAsCommands(String dirPath) {
+        if (dirPath == null || dirPath.isEmpty()) {
+            return List.of();
+        }
+        File dir = new File(dirPath);
+        if (!dir.isDirectory()) {
+            return List.of();
+        }
+
+        File[] entries = dir.listFiles();
+        if (entries == null) {
+            return List.of();
+        }
+
+        List<SlashCommand> commands = new ArrayList<>();
+        for (File entry : entries) {
+            if (!entry.isFile() || !entry.getName().endsWith(".md")
+                    || entry.getName().startsWith(".")) {
+                continue;
+            }
+            String baseName = entry.getName().replaceFirst("\\.md$", "");
+            String description = extractCommandDescription(entry.toPath());
+            commands.add(new SlashCommand(
+                    "/prompts:" + baseName,
+                    description != null ? description : ""));
+        }
+        return commands;
+    }
+
+    /**
+     * Parses a single command .md file to extract name and description from frontmatter.
+     */
+    private static SlashCommand parseCommandFile(File mdFile, String namespace) {
+        String baseName = mdFile.getName().replaceFirst("\\.md$", "");
+        String commandName = namespace != null
+                ? "/" + namespace + ":" + baseName
+                : "/" + baseName;
+
+        // Try to extract description from YAML frontmatter
+        String description = extractCommandDescription(mdFile.toPath());
+        if (description == null) {
+            description = "";
+        }
+
+        return new SlashCommand(commandName, description);
+    }
+
+    /**
+     * Extracts description from a command .md file's YAML frontmatter.
+     */
+    private static String extractCommandDescription(Path mdPath) {
+        String yamlText = SkillFrontmatterParser.extractFrontmatter(mdPath);
+        if (yamlText == null) {
+            return null;
+        }
+
+        try {
+            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(
+                    new org.yaml.snakeyaml.constructor.SafeConstructor(
+                            new org.yaml.snakeyaml.LoaderOptions()));
+            Object parsed = yaml.load(yamlText);
+            if (parsed instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> map = (Map<String, Object>) parsed;
+                Object desc = map.get("description");
+                return desc != null ? String.valueOf(desc).trim() : null;
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to parse command frontmatter: " + mdPath);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the merged slash command list for a given provider and working directory.
+     * Claude merge order: built-in → project commands → project skills → personal commands → personal skills.
+     * Codex merge order: built-in → prompts.
+     * Later entries override earlier ones with the same name (personal > project per Claude docs).
+     * @param provider "claude" or "codex"
+     * @param cwd      current working directory (for local skills/commands lookup)
+     * @return deduplicated list of slash commands
+     */
+    public static List<SlashCommand> getCommands(String provider, String cwd) {
+        boolean isCodex = "codex".equalsIgnoreCase(provider);
+
+        // Step 1: Select built-in commands by provider
+        List<SlashCommand> builtins = isCodex ? CODEX_BUILTIN : CLAUDE_BUILTIN;
+
+        String userHome = System.getProperty("user.home");
+
+        List<SlashCommand> globalCmdCommands;
+        List<SlashCommand> globalSkillCommands;
+        List<SlashCommand> localCmdCommands = List.of();
+        List<SlashCommand> localSkillCommands = List.of();
+
+        if (isCodex) {
+            // Codex slash commands come only from ~/.codex/prompts/ (namespaced as /prompts:<name>)
+            // Codex skills (.agents/skills/) use $ prefix, not / — they are NOT slash commands
+            globalCmdCommands = scanPromptsAsCommands(
+                    userHome + File.separator + ".codex" + File.separator + "prompts");
+            globalSkillCommands = List.of();
+        } else {
+            // Claude: ~/.claude/commands/ and ~/.claude/skills/
+            String claudeDir = userHome + File.separator + ".claude";
+            globalCmdCommands = scanCommandsAsCommands(
+                    claudeDir + File.separator + "commands");
+            globalSkillCommands = scanSkillsAsCommands(
+                    claudeDir + File.separator + "skills");
+
+            // Claude local: {cwd}/.claude/commands/ and skills/
+            if (cwd != null && !cwd.isEmpty()) {
+                String localClaudeDir = cwd + File.separator + ".claude";
+                localCmdCommands = scanCommandsAsCommands(
+                        localClaudeDir + File.separator + "commands");
+                localSkillCommands = scanSkillsAsCommands(
+                        localClaudeDir + File.separator + "skills");
+            }
+        }
+
+        // Merge (preserves insertion order, later overrides earlier)
+        // For Claude: built-in → project → personal (personal wins per docs)
+        Map<String, SlashCommand> merged = new LinkedHashMap<>();
+        for (SlashCommand cmd : builtins) {
+            merged.put(cmd.name(), cmd);
+        }
+        for (SlashCommand cmd : localCmdCommands) {
+            merged.put(cmd.name(), cmd);
+        }
+        for (SlashCommand cmd : localSkillCommands) {
+            merged.put(cmd.name(), cmd);
+        }
+        for (SlashCommand cmd : globalCmdCommands) {
+            merged.put(cmd.name(), cmd);
+        }
+        for (SlashCommand cmd : globalSkillCommands) {
+            merged.put(cmd.name(), cmd);
+        }
+
+        // Step 6: Return merged results
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Serializes a command list to JSON array format:
+     * [{"name": "/help", "description": "..."}, ...]
+     */
+    public static String toJson(List<SlashCommand> commands) {
+        JsonArray array = new JsonArray();
+        for (SlashCommand cmd : commands) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("name", cmd.name());
+            obj.addProperty("description", cmd.description());
+            array.add(obj);
+        }
+        return new Gson().toJson(array);
+    }
+}

--- a/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
+++ b/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
@@ -13,6 +13,7 @@ const HIDDEN_COMMANDS = new Set([
   '/release-notes',
   '/security-review',
   '/todo',
+  '/doctor',
 ]);
 
 /**


### PR DESCRIPTION
Move slash command loading from async SDK API calls to fully local parsing of skill directories and built-in command lists.

- Add SkillFrontmatterParser to parse SKILL.md YAML frontmatter with SafeConstructor (prevents deserialization attacks)
- Add SlashCommandRegistry to merge built-in + user skill/command lists per provider with name-based deduplication
- Claude: scan ~/.claude/commands/, ~/.claude/skills/ (personal) and {cwd}/.claude/commands/, {cwd}/.claude/skills/ (project)
- Codex: scan ~/.codex/prompts/ only (Codex skills use $ prefix and are NOT slash commands — $ skill scanning is not yet implemented)
- Support optional name (falls back to directory name), optional description (falls back to first markdown paragraph), and user-invocable: false filtering
- Refresh slash commands on provider switch via SettingsHandler
- Add SnakeYAML 2.2 dependency for frontmatter parsing

Remove dead remote slash command fetching code:
- Remove getSlashCommands() from message-service.js (~125 lines)
- Remove getSlashCommands case/import from claude-channel.js
- Remove getSlashCommands protocol comment from daemon.js
- Remove ClaudeSDKBridge.getSlashCommands() method and [SLASH_COMMANDS] tag parsing (two locations)
- Rewrite FileHandler.handleGetCommands() to use local registry instead of bridge call; ***note: the get_commands event from frontend may no longer be triggered since slash commands are now pushed proactively on session creation and provider switch***
- Remove addFallbackCommands() which is no longer needed