### PR TITLE
fix: prevent stale loading panel blocking error UI on Node.js detection failure

### DIFF
--- a/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
@@ -192,7 +192,7 @@ public abstract class BaseSDKBridge {
             LOG.info("Environment check passed for " + getProviderName());
             return true;
         } catch (Exception e) {
-            LOG.error("Environment check failed: " + e.getMessage());
+            LOG.warn("Environment check failed: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -370,6 +370,19 @@ public class WebviewInitializer {
         }
     }
 
+    /**
+     * Replace the main panel's CENTER content, then force a layout refresh.
+     * All show*Panel helpers must go through this to avoid stale loading/error panels
+     * lingering when called from async callbacks (invokeLater).
+     */
+    private void replaceMainContent(JPanel newPanel) {
+        JPanel mainPanel = host.getMainPanel();
+        mainPanel.removeAll();
+        mainPanel.add(newPanel, BorderLayout.CENTER);
+        mainPanel.revalidate();
+        mainPanel.repaint();
+    }
+
     public void showErrorPanel() {
         ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
         String message = ClaudeCodeGuiBundle.message(
@@ -381,7 +394,7 @@ public class WebviewInitializer {
             claudeSDKBridge.getNodeExecutable(),
             this::handleNodePathSave
         );
-        host.getMainPanel().add(errorPanel, BorderLayout.CENTER);
+        replaceMainContent(errorPanel);
     }
 
     private void showVersionErrorPanel(String currentVersion) {
@@ -397,7 +410,7 @@ public class WebviewInitializer {
             claudeSDKBridge.getNodeExecutable(),
             this::handleNodePathSave
         );
-        host.getMainPanel().add(errorPanel, BorderLayout.CENTER);
+        replaceMainContent(errorPanel);
     }
 
     private void showInvalidNodePathPanel(String path, String errMsg) {
@@ -411,7 +424,7 @@ public class WebviewInitializer {
             path,
             this::handleNodePathSave
         );
-        host.getMainPanel().add(errorPanel, BorderLayout.CENTER);
+        replaceMainContent(errorPanel);
     }
 
     private void showJcefNotSupportedPanel() {
@@ -420,7 +433,7 @@ public class WebviewInitializer {
             ClaudeCodeGuiBundle.message("toolwindow.jcefNotInstalled"),
             ClaudeCodeGuiBundle.message("toolwindow.jcefNotInstalledSolution")
         );
-        host.getMainPanel().add(panel, BorderLayout.CENTER);
+        replaceMainContent(panel);
     }
 
     private void showJcefRemoteModeErrorPanel() {
@@ -429,7 +442,7 @@ public class WebviewInitializer {
             ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteError"),
             ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteSolution")
         );
-        host.getMainPanel().add(panel, BorderLayout.CENTER);
+        replaceMainContent(panel);
     }
 
     private void showLoadingPanel() {
@@ -438,7 +451,7 @@ public class WebviewInitializer {
             ClaudeCodeGuiBundle.message("toolwindow.extractingTitle"),
             ClaudeCodeGuiBundle.message("toolwindow.extractingDesc")
         );
-        host.getMainPanel().add(panel, BorderLayout.CENTER);
+        replaceMainContent(panel);
         LOG.info("[ClaudeSDKToolWindow] Showing loading panel while bridge extracts...");
     }
 


### PR DESCRIPTION
When checkEnvironment() fails after bridge extraction (isExtractionComplete), retryCheckEnvironmentWithBackoff showed a loading panel then invoked showErrorPanel() asynchronously without clearing it, leaving the UI stuck.

- Extract replaceMainContent() helper: removeAll + add + revalidate + repaint
- Route all show*Panel() methods through replaceMainContent() so async invokeLater callbacks always replace stale content regardless of prior panel state
- Downgrade LOG.error to LOG.warn in checkEnvironment() to avoid triggering IntelliJ error notification system for an already-handled exception