### PR TITLE
feat: auto tab title from first message + tab title management fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,12 @@ tasks.named('runIde') {
     // Configure log output to console
     systemProperty 'idea.log.debug.categories', '#com.github.claudecodegui'
 
+    // Point bridge resolver to pre-extracted ai-bridge with node_modules (dev only)
+    def stableBridge = layout.buildDirectory.dir("stable-ai-bridge").get().asFile
+    if (stableBridge.exists()) {
+        systemProperty 'claude.bridge.path', stableBridge.absolutePath
+    }
+
     // Redirect standard output
     standardOutput = System.out
     errorOutput = System.err

--- a/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
@@ -178,8 +178,10 @@ public class ClaudeChatWindow {
     }
 
     public void setOriginalTabName(String name) {
-        this.originalTabName = name;
-        LOG.debug("[TabLoading] Set original tab name: " + name);
+        this.originalTabName = (name != null && name.endsWith("..."))
+            ? name.substring(0, name.length() - 3)
+            : name;
+        LOG.debug("[TabLoading] Set original tab name: " + this.originalTabName);
     }
 
     public boolean isDisposed() { return disposed; }
@@ -467,6 +469,7 @@ public class ClaudeChatWindow {
             @Override public boolean isDisposed() { return disposed; }                       // Check if window has been disposed
             @Override public Content getParentContent() { return parentContent; }            // Tab content this window belongs to
             @Override public String getOriginalTabName() { return originalTabName; }         // Original tab name before any rename
+            @Override public void setOriginalTabName(String name) { ClaudeChatWindow.this.setOriginalTabName(name); }
             @Override public String getSessionId() { return sessionId; }                     // Unique session identifier
 
             // --- Handler context & wiring (initialized during startup) ---

--- a/src/main/java/com/github/claudecodegui/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSDKToolWindow.java
@@ -103,6 +103,13 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         contentToWindowMap.remove(content);
     }
 
+    /**
+     * Get the ClaudeChatWindow associated with the given Content tab.
+     */
+    public static ClaudeChatWindow getChatWindowForContent(Content content) {
+        return content != null ? contentToWindowMap.get(content) : null;
+    }
+
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         // Register JVM Shutdown Hook (only once)

--- a/src/main/java/com/github/claudecodegui/RenameTabAction.java
+++ b/src/main/java/com/github/claudecodegui/RenameTabAction.java
@@ -87,6 +87,12 @@ public class RenameTabAction extends AnAction implements DumbAware {
         // Update the tab name
         selectedContent.setDisplayName(newName);
 
+        // Update originalTabName so status indicators won't revert to the old name
+        ClaudeChatWindow chatWindow = ClaudeSDKToolWindow.getChatWindowForContent(selectedContent);
+        if (chatWindow != null) {
+            chatWindow.setOriginalTabName(newName);
+        }
+
         // Get tab index and save to persistent storage
         int tabIndex = contentManager.getIndexOfContent(selectedContent);
         if (tabIndex >= 0) {

--- a/src/main/java/com/github/claudecodegui/handler/TabHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/TabHandler.java
@@ -3,6 +3,8 @@ package com.github.claudecodegui.handler;
 import com.github.claudecodegui.ClaudeChatWindow;
 import com.github.claudecodegui.ClaudeSDKToolWindow;
 import com.github.claudecodegui.settings.TabStateService;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -22,8 +24,12 @@ public class TabHandler extends BaseMessageHandler {
     private static final Logger LOG = Logger.getInstance(TabHandler.class);
 
     private static final String[] SUPPORTED_TYPES = {
-        "create_new_tab"
+        "create_new_tab",
+        "rename_tab"
     };
+
+    private static final int MAX_TAB_TITLE_LENGTH = 30;
+    private static final String DEFAULT_TAB_NAME_PATTERN = "^AI\\d+$";
 
     public TabHandler(HandlerContext context) {
         super(context);
@@ -36,12 +42,18 @@ public class TabHandler extends BaseMessageHandler {
 
     @Override
     public boolean handle(String type, String content) {
-        if ("create_new_tab".equals(type)) {
-            LOG.debug("[TabHandler] Processing create_new_tab");
-            handleCreateNewTab();
-            return true;
+        switch (type) {
+            case "create_new_tab":
+                LOG.debug("[TabHandler] Processing create_new_tab");
+                handleCreateNewTab();
+                return true;
+            case "rename_tab":
+                LOG.debug("[TabHandler] Processing rename_tab");
+                handleRenameTab(content);
+                return true;
+            default:
+                return false;
         }
-        return false;
     }
 
     /**
@@ -98,5 +110,78 @@ public class TabHandler extends BaseMessageHandler {
                 callJavaScript("addErrorMessage", escapeJs("创建新标签页失败: " + e.getMessage()));
             }
         });
+    }
+
+    /**
+     * Auto-rename the current tab based on the first message content.
+     * Only renames tabs that still have the default "AIN" name.
+     */
+    private void handleRenameTab(String content) {
+        Project project = context.getProject();
+
+        try {
+            Gson gson = new Gson();
+            JsonObject payload = gson.fromJson(content, JsonObject.class);
+            String title = payload != null && payload.has("title") ? payload.get("title").getAsString() : null;
+
+            if (title == null || title.trim().isEmpty()) {
+                LOG.debug("[TabHandler] rename_tab: empty title, skipping");
+                return;
+            }
+
+            boolean force = payload != null && payload.has("force") && payload.get("force").getAsBoolean();
+
+            // Truncate to max length
+            title = title.trim().replace("\n", " ");
+            if (title.length() > MAX_TAB_TITLE_LENGTH) {
+                title = title.substring(0, MAX_TAB_TITLE_LENGTH) + "...";
+            }
+
+            final String newTitle = title;
+            final boolean forceRename = force;
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                try {
+                    ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+                    if (toolWindow == null) {
+                        return;
+                    }
+
+                    ContentManager contentManager = toolWindow.getContentManager();
+                    Content selectedContent = contentManager.getSelectedContent();
+                    if (selectedContent == null) {
+                        return;
+                    }
+
+                    // Only auto-rename if tab still has the default "AIN" name (unless force=true)
+                    String currentName = selectedContent.getDisplayName();
+                    if (!forceRename && currentName != null && !currentName.matches(DEFAULT_TAB_NAME_PATTERN)) {
+                        LOG.debug("[TabHandler] Tab already has custom name: " + currentName + ", skipping auto-rename");
+                        return;
+                    }
+
+                    // Update display name
+                    selectedContent.setDisplayName(newTitle);
+
+                    // Update originalTabName so status indicators use the new name
+                    ClaudeChatWindow chatWindow = ClaudeSDKToolWindow.getChatWindowForContent(selectedContent);
+                    if (chatWindow != null) {
+                        chatWindow.setOriginalTabName(newTitle);
+                    }
+
+                    // Persist
+                    int tabIndex = contentManager.getIndexOfContent(selectedContent);
+                    if (tabIndex >= 0) {
+                        TabStateService.getInstance(project).saveTabName(tabIndex, newTitle);
+                    }
+
+                    LOG.info("[TabHandler] Auto-renamed tab from '" + currentName + "' to '" + newTitle + "'");
+                } catch (Exception e) {
+                    LOG.error("[TabHandler] Error renaming tab: " + e.getMessage(), e);
+                }
+            });
+        } catch (Exception e) {
+            LOG.error("[TabHandler] Error parsing rename_tab payload: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -81,6 +81,7 @@ public class ChatWindowDelegate {
         void callJavaScript(String fn, String... args);
         Content getParentContent();
         String getOriginalTabName();
+        void setOriginalTabName(String name);
         String getSessionId();
         HandlerContext getHandlerContext();
         void setHandlerContext(HandlerContext ctx);
@@ -351,6 +352,17 @@ public class ChatWindowDelegate {
         }
 
         ApplicationManager.getApplication().invokeLater(() -> {
+            // Detect external renames: if current name doesn't start with originalTabName,
+            // someone renamed the tab (e.g. RenameTabAction) — adopt the new name
+            String currentDisplayName = parentContent.getDisplayName();
+            if (currentDisplayName != null && !currentDisplayName.startsWith(originalTabName)) {
+                originalTabName = currentDisplayName.endsWith("...")
+                    ? currentDisplayName.substring(0, currentDisplayName.length() - 3)
+                    : currentDisplayName;
+                host.setOriginalTabName(originalTabName);
+                LOG.debug("[TabStatus] Detected external rename, updated originalTabName to: " + originalTabName);
+            }
+
             String displayName;
             switch (status) {
                 case ANSWERING:

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -865,6 +865,12 @@ const App = () => {
     };
     setMessages((prev) => [...prev, userMessage]);
 
+    // Auto-rename tab title from first message (if no custom title set)
+    // Truncation is handled by TabHandler.java (MAX_TAB_TITLE_LENGTH)
+    if (!customSessionTitleRef.current && messagesRef.current.length === 0 && text) {
+      sendBridgeEvent('rename_tab', JSON.stringify({ title: text }));
+    }
+
     // Set loading state
     setLoading(true);
     setLoadingStartTime(Date.now());

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -150,6 +150,11 @@ export function useSessionManagement({
     const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
     setCustomSessionTitle(session?.title ?? null);
 
+    // Update IDE tab title to match the history session title
+    if (session?.title) {
+      sendBridgeEvent('rename_tab', JSON.stringify({ title: session.title, force: true }));
+    }
+
     setCurrentView('chat');
   }, [loading, setCurrentSessionId, setCustomSessionTitle, setCurrentView]);
 


### PR DESCRIPTION
## Summary
- **New feature**: Automatically set tab title from the first characters (up to 30) of the first user message, replacing the generic "AI*" default
- Fix tab title not updating when opening a session from history (stayed as AI*)
- Fix manual tab rename being overwritten when AI responds or status indicator changes
- Fix double "..." appearing on truncated history session titles when AI is thinking

## Changes
- `App.tsx` / `useSessionManagement.ts`: Send `rename_tab` bridge event on first message and when loading history sessions (with `force` flag)
- `TabHandler.java`: Handle `rename_tab` event with title truncation (30 chars) and `force` flag to bypass custom-name guard
- `RenameTabAction.java`: Update `originalTabName` when user manually renames a tab
- `ClaudeChatWindow.java`: Strip trailing "..." in `setOriginalTabName` to prevent double dots
- `ChatWindowDelegate.java`: Detect external renames in `updateTabStatus` and adopt new name
- `ClaudeSDKToolWindow.java`: Expose `getChatWindowForContent` accessor
- `build.gradle`: Add `claude.bridge.path` system property for dev environment stability

## Test plan
- [ ] Create new tab → send first message → tab should auto-rename to first 30 chars of message
- [ ] Open a session from history → tab title should update to the session title
- [ ] Manually rename a tab → send a message → tab title should keep the manual name
- [ ] Load a history session with a long truncated title → should show single "..." when AI is thinking, not "......"
- [ ] Rename a tab → close and reopen IDE → tab name should persist
