### PR TITLE
fix: resolve permission mode state desync between frontend and backend

### DIFF
--- a/src/main/java/com/github/claudecodegui/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSession.java
@@ -268,7 +268,7 @@ public class ClaudeSession {
      * Used for per-tab independent agent selection.
      */
     public CompletableFuture<Void> send(String input, String agentPrompt) {
-        return send(input, null, agentPrompt, null);
+        return send(input, null, agentPrompt, null, null);
     }
 
     /**
@@ -276,7 +276,15 @@ public class ClaudeSession {
      * Used for Codex context injection.
      */
     public CompletableFuture<Void> send(String input, String agentPrompt, List<String> fileTagPaths) {
-        return send(input, null, agentPrompt, fileTagPaths);
+        return send(input, null, agentPrompt, fileTagPaths, null);
+    }
+
+    /**
+     * Send a message with a specific agent prompt, file tags and requested permission mode.
+     * requestedPermissionMode priority: payload > sessionMode > default.
+     */
+    public CompletableFuture<Void> send(String input, String agentPrompt, List<String> fileTagPaths, String requestedPermissionMode) {
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode);
     }
 
     /**
@@ -284,7 +292,7 @@ public class ClaudeSession {
      * @deprecated Use {@link #send(String, List, String)} with explicit agent prompt instead.
      */
     public CompletableFuture<Void> send(String input, List<Attachment> attachments) {
-        return send(input, attachments, null, null);
+        return send(input, attachments, null, null, null);
     }
 
     /**
@@ -295,7 +303,7 @@ public class ClaudeSession {
      * @param agentPrompt Agent prompt (falls back to global setting if null)
      */
     public CompletableFuture<Void> send(String input, List<Attachment> attachments, String agentPrompt) {
-        return send(input, attachments, agentPrompt, null);
+        return send(input, attachments, agentPrompt, null, null);
     }
 
     /**
@@ -307,6 +315,21 @@ public class ClaudeSession {
      * @param fileTagPaths File tag paths for Codex context injection
      */
     public CompletableFuture<Void> send(String input, List<Attachment> attachments, String agentPrompt, List<String> fileTagPaths) {
+        return send(input, attachments, agentPrompt, fileTagPaths, null);
+    }
+
+    /**
+     * Send a message with attachments, agent prompt, file tags, and a requested permission mode.
+     * The effective mode is resolved with priority:
+     * requestedPermissionMode > sessionMode > default, with codex forced to bypassPermissions.
+     */
+    public CompletableFuture<Void> send(
+        String input,
+        List<Attachment> attachments,
+        String agentPrompt,
+        List<String> fileTagPaths,
+        String requestedPermissionMode
+    ) {
         // Prepare user message
         String normalizedInput = (input != null) ? input.trim() : "";
         Message userMessage = buildUserMessage(normalizedInput, attachments);
@@ -317,6 +340,7 @@ public class ClaudeSession {
         // Save agentPrompt and fileTagPaths for later use
         final String finalAgentPrompt = agentPrompt;
         final List<String> finalFileTagPaths = fileTagPaths;
+        final String finalRequestedPermissionMode = requestedPermissionMode;
 
         // Launch Claude and send message
         return launchClaude().thenCompose(chId -> {
@@ -338,7 +362,15 @@ public class ClaudeSession {
             contextCollector.setAutoOpenFileEnabled(autoOpenFileEnabled);
 
             return contextCollector.collectContext().thenCompose(openedFilesJson ->
-                sendMessageToProvider(chId, userMessage.content, attachments, openedFilesJson, finalAgentPrompt, finalFileTagPaths)
+                sendMessageToProvider(
+                    chId,
+                    userMessage.content,
+                    attachments,
+                    openedFilesJson,
+                    finalAgentPrompt,
+                    finalFileTagPaths,
+                    finalRequestedPermissionMode
+                )
             );
         }).exceptionally(ex -> {
             state.setError(ex.getMessage());
@@ -594,7 +626,8 @@ public class ClaudeSession {
         List<Attachment> attachments,
         JsonObject openedFilesJson,
         String externalAgentPrompt,
-        List<String> fileTagPaths
+        List<String> fileTagPaths,
+        String requestedPermissionMode
     ) {
         // Prefer external agent prompt; fall back to global setting if not provided
         String agentPrompt = externalAgentPrompt;
@@ -608,11 +641,33 @@ public class ClaudeSession {
 
         // Select SDK based on provider
         String currentProvider = state.getProvider();
+        String sessionModeBeforeSend = state.getPermissionMode();
+        String normalizedRequestedMode = normalizeRequestedPermissionMode(requestedPermissionMode);
+        String effectivePermissionMode = resolveEffectivePermissionMode(
+            currentProvider,
+            normalizedRequestedMode,
+            sessionModeBeforeSend
+        );
+
+        LOG.info(
+            "[ModeSync][Backend] provider=" + currentProvider
+                + ", requested=" + (normalizedRequestedMode != null ? normalizedRequestedMode : "(none)")
+                + ", session=" + (sessionModeBeforeSend != null ? sessionModeBeforeSend : "(none)")
+                + ", effective=" + effectivePermissionMode
+        );
 
         if ("codex".equals(currentProvider)) {
-            return sendToCodex(channelId, input, attachments, openedFilesJson, agentPrompt, fileTagPaths);
+            return sendToCodex(
+                channelId,
+                input,
+                attachments,
+                openedFilesJson,
+                agentPrompt,
+                fileTagPaths,
+                effectivePermissionMode
+            );
         } else {
-            return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt);
+            return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt, effectivePermissionMode);
         }
     }
 
@@ -626,7 +681,8 @@ public class ClaudeSession {
         List<Attachment> attachments,
         JsonObject openedFilesJson,
         String agentPrompt,
-        List<String> fileTagPaths
+        List<String> fileTagPaths,
+        String effectivePermissionMode
     ) {
         CodexMessageHandler handler = new CodexMessageHandler(state, callbackHandler);
 
@@ -639,7 +695,7 @@ public class ClaudeSession {
             state.getSessionId(),
             state.getCwd(),
             attachments,
-            state.getPermissionMode(),
+            effectivePermissionMode,
             state.getModel(),
             agentPrompt,
             state.getReasoningEffort(),
@@ -827,7 +883,8 @@ public class ClaudeSession {
         String input,
         List<Attachment> attachments,
         JsonObject openedFilesJson,
-        String agentPrompt
+        String agentPrompt,
+        String effectivePermissionMode
     ) {
         ClaudeMessageHandler handler = new ClaudeMessageHandler(
             project,
@@ -859,7 +916,7 @@ public class ClaudeSession {
             state.getSessionId(),
             state.getCwd(),
             attachments,
-            state.getPermissionMode(),
+            effectivePermissionMode,
             state.getModel(),
             openedFilesJson,
             agentPrompt,
@@ -888,6 +945,30 @@ public class ClaudeSession {
                 claudeSDKBridge.prewarmDaemonAsync(state.getCwd());
             }
         });
+    }
+
+    private String normalizeRequestedPermissionMode(String mode) {
+        if (mode == null) return null;
+        String trimmed = mode.trim();
+        if (trimmed.isEmpty()) return null;
+        if ("default".equals(trimmed) || "plan".equals(trimmed)
+            || "acceptEdits".equals(trimmed) || "bypassPermissions".equals(trimmed)) {
+            return trimmed;
+        }
+        LOG.warn("[ModeSync][Backend] Invalid requested permissionMode ignored: " + mode);
+        return null;
+    }
+
+    private String resolveEffectivePermissionMode(String provider, String requestedMode, String sessionMode) {
+        // Codex execution is always bypassPermissions to match provider constraints.
+        if ("codex".equals(provider)) {
+            return "bypassPermissions";
+        }
+        if (requestedMode != null) {
+            return requestedMode;
+        }
+        String normalizedSession = normalizeRequestedPermissionMode(sessionMode);
+        return normalizedSession != null ? normalizedSession : "default";
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -88,6 +88,7 @@ public class SessionHandler extends BaseMessageHandler {
         String prompt;
         String agentPrompt = null;
         java.util.List<String> fileTagPaths = null;
+        String requestedPermissionMode = null;
         try {
             Gson gson = new Gson();
             JsonObject payload = gson.fromJson(content, JsonObject.class);
@@ -119,6 +120,16 @@ public class SessionHandler extends BaseMessageHandler {
                     LOG.info("[SessionHandler] Extracted " + fileTagPaths.size() + " file tags for context injection");
                 }
             }
+
+            // Extract requested permission mode from payload (optional, backward compatible)
+            if (payload != null && payload.has("permissionMode") && !payload.get("permissionMode").isJsonNull()) {
+                String mode = payload.get("permissionMode").getAsString();
+                if (isValidPermissionMode(mode)) {
+                    requestedPermissionMode = mode;
+                } else {
+                    LOG.warn("[SessionHandler] Ignoring invalid permissionMode from payload: " + mode);
+                }
+            }
         } catch (Exception e) {
             // If parsing fails, treat content as plain text (backward compatibility)
             LOG.debug("[SessionHandler] Message is plain text, not JSON: " + e.getMessage());
@@ -128,6 +139,7 @@ public class SessionHandler extends BaseMessageHandler {
         final String finalPrompt = prompt;
         final String finalAgentPrompt = agentPrompt;
         final java.util.List<String> finalFileTagPaths = fileTagPaths;
+        final String finalRequestedPermissionMode = requestedPermissionMode;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -145,7 +157,7 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths)
+            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -198,6 +210,7 @@ public class SessionHandler extends BaseMessageHandler {
 
             // [FIX] Extract agent prompt from the payload for per-tab agent selection
             String agentPrompt = null;
+            String requestedPermissionMode = null;
             if (payload != null && payload.has("agent") && !payload.get("agent").isJsonNull()) {
                 JsonObject agent = payload.getAsJsonObject("agent");
                 if (agent.has("prompt") && !agent.get("prompt").isJsonNull()) {
@@ -223,7 +236,16 @@ public class SessionHandler extends BaseMessageHandler {
                 }
             }
 
-            sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths);
+            if (payload != null && payload.has("permissionMode") && !payload.get("permissionMode").isJsonNull()) {
+                String mode = payload.get("permissionMode").getAsString();
+                if (isValidPermissionMode(mode)) {
+                    requestedPermissionMode = mode;
+                } else {
+                    LOG.warn("[SessionHandler] Ignoring invalid permissionMode from attachment payload: " + mode);
+                }
+            }
+
+            sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths, requestedPermissionMode);
         } catch (Exception e) {
             LOG.error("[SessionHandler] 解析附件负载失败: " + e.getMessage(), e);
             handleSendMessage(content);
@@ -234,7 +256,13 @@ public class SessionHandler extends BaseMessageHandler {
      * Send message with attachments to Claude
      * [FIX] Now accepts agent prompt and file tags parameters
      */
-    private void sendMessageWithAttachments(String prompt, List<ClaudeSession.Attachment> attachments, String agentPrompt, java.util.List<String> fileTagPaths) {
+    private void sendMessageWithAttachments(
+        String prompt,
+        List<ClaudeSession.Attachment> attachments,
+        String agentPrompt,
+        java.util.List<String> fileTagPaths,
+        String requestedPermissionMode
+    ) {
         // Version check (consistent with handleSendMessage)
         String nodeVersion = context.getClaudeSDKBridge().getCachedNodeVersion();
         if (nodeVersion == null) {
@@ -254,6 +282,7 @@ public class SessionHandler extends BaseMessageHandler {
 
         final String finalAgentPrompt = agentPrompt;
         final java.util.List<String> finalFileTagPaths = fileTagPaths;
+        final String finalRequestedPermissionMode = requestedPermissionMode;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -270,7 +299,7 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths)
+            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -312,6 +341,13 @@ public class SessionHandler extends BaseMessageHandler {
         context.getSession().restart().thenRun(() -> {
             ApplicationManager.getApplication().invokeLater(() -> {});
         });
+    }
+
+    private boolean isValidPermissionMode(String mode) {
+        return "default".equals(mode)
+            || "plan".equals(mode)
+            || "acceptEdits".equals(mode)
+            || "bypassPermissions".equals(mode);
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -29,11 +29,13 @@ public class SessionState {
 
     // Configuration
     // Default to bypassPermissions to match frontend behavior and ensure write access in Codex mode
-    private String permissionMode = "bypassPermissions";
-    private String model = "claude-sonnet-4-6";
-    private String provider = "claude";
+    // Volatile ensures visibility across async handler threads
+    // (e.g. set_mode followed immediately by send_message).
+    private volatile String permissionMode = "bypassPermissions";
+    private volatile String model = "claude-sonnet-4-6";
+    private volatile String provider = "claude";
     // Codex reasoning effort (thinking depth)
-    private String reasoningEffort = "medium";
+    private volatile String reasoningEffort = "medium";
 
     // Slash commands
     private List<String> slashCommands = new ArrayList<>();

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -375,14 +375,6 @@ const App = () => {
       }
     };
 
-    // Register permission mode sync callback from Java
-    window.onModeReceived = (mode: string) => {
-      if (mode === 'default' || mode === 'plan' || mode === 'acceptEdits' || mode === 'bypassPermissions') {
-        setPermissionMode(mode);
-        setClaudePermissionMode(mode);
-      }
-    };
-
     // Initialize font scaling
     const savedLevel = localStorage.getItem('fontSizeLevel');
     const level = savedLevel ? parseInt(savedLevel, 10) : 2; // Default level 2 (90%)
@@ -779,9 +771,20 @@ const App = () => {
     text: string,
     attachments: Attachment[] | undefined,
     agentInfo: { id: string; name: string; prompt?: string } | null,
-    fileTagsInfo: { displayPath: string; absolutePath: string }[] | null
+    fileTagsInfo: { displayPath: string; absolutePath: string }[] | null,
+    requestedPermissionMode: PermissionMode
   ) => {
     const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
+    // Keep a single source of truth for each request:
+    // payload.permissionMode > sessionMode > default (backend fallback).
+    const effectivePermissionMode: PermissionMode = currentProvider === 'codex'
+      ? 'bypassPermissions'
+      : requestedPermissionMode;
+    console.info('[ModeSync][Frontend] send request mode', {
+      provider: currentProvider,
+      requestedMode: requestedPermissionMode,
+      effectiveMode: effectivePermissionMode,
+    });
 
     if (hasAttachments) {
       try {
@@ -794,18 +797,29 @@ const App = () => {
           })),
           agent: agentInfo,
           fileTags: fileTagsInfo,
+          permissionMode: effectivePermissionMode,
         });
         sendBridgeEvent('send_message_with_attachments', payload);
       } catch (error) {
         console.error('[Frontend] Failed to serialize attachments payload', error);
-        const fallbackPayload = JSON.stringify({ text, agent: agentInfo, fileTags: fileTagsInfo });
+        const fallbackPayload = JSON.stringify({
+          text,
+          agent: agentInfo,
+          fileTags: fileTagsInfo,
+          permissionMode: effectivePermissionMode,
+        });
         sendBridgeEvent('send_message', fallbackPayload);
       }
     } else {
-      const payload = JSON.stringify({ text, agent: agentInfo, fileTags: fileTagsInfo });
+      const payload = JSON.stringify({
+        text,
+        agent: agentInfo,
+        fileTags: fileTagsInfo,
+        permissionMode: effectivePermissionMode,
+      });
       sendBridgeEvent('send_message', payload);
     }
-  }, []);
+  }, [currentProvider]);
 
   /**
    * Execute message sending (from queue or directly)
@@ -896,11 +910,12 @@ const App = () => {
     })) : null;
 
     // Send message to backend
-    sendMessageToBackend(text, attachments, agentInfo, fileTagsInfo);
+    sendMessageToBackend(text, attachments, agentInfo, fileTagsInfo, permissionMode);
   }, [
     sdkStatusLoaded,
     currentSdkInstalled,
     currentProvider,
+    permissionMode,
     selectedAgent,
     buildUserContentBlocks,
     sendMessageToBackend,

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -864,17 +864,23 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     const updateMode = (mode?: PermissionMode, providerOverride?: string) => {
       const activeProvider = providerOverride || currentProviderRef.current;
       if (activeProvider === 'codex') {
-        setPermissionMode('bypassPermissions');
+        setPermissionMode((prev) => (prev === 'bypassPermissions' ? prev : 'bypassPermissions'));
         return;
       }
       if (mode === 'default' || mode === 'plan' || mode === 'acceptEdits' || mode === 'bypassPermissions') {
-        setPermissionMode(mode);
-        setClaudePermissionMode(mode);
+        setPermissionMode((prev) => (prev === mode ? prev : mode));
+        setClaudePermissionMode((prev) => (prev === mode ? prev : mode));
       }
     };
 
     window.onModeChanged = (mode) => updateMode(mode as PermissionMode);
     window.onModeReceived = (mode) => updateMode(mode as PermissionMode);
+    // Replay early mode update captured in main.tsx placeholder before callbacks are registered.
+    if ((window as unknown as Record<string, unknown>).__pendingModeReceived) {
+      const pending = (window as unknown as Record<string, unknown>).__pendingModeReceived as string;
+      delete (window as unknown as Record<string, unknown>).__pendingModeReceived;
+      window.onModeReceived?.(pending);
+    }
 
     window.onModelChanged = (modelId) => {
       const provider = currentProviderRef.current;
@@ -1171,6 +1177,21 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
       }
     };
     setTimeout(requestActiveProvider, 200);
+
+    let modeRetryCount = 0;
+    const requestMode = () => {
+      if (window.sendToJava) {
+        // Pull once after callback registration to guarantee eventual convergence
+        // even if backend push arrived before registration.
+        sendBridgeEvent('get_mode');
+      } else {
+        modeRetryCount++;
+        if (modeRetryCount < MAX_RETRIES) {
+          setTimeout(requestMode, 100);
+        }
+      }
+    };
+    setTimeout(requestMode, 200);
 
     let thinkingRetryCount = 0;
     const requestThinkingEnabled = () => {

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -359,6 +359,15 @@ if (typeof window !== 'undefined' && !window.updateUsageStatistics) {
   };
 }
 
+// Pre-register onModeReceived to avoid losing early backend push before React callbacks are ready.
+if (typeof window !== 'undefined' && !window.onModeReceived) {
+  console.log('[Main] Pre-registering onModeReceived placeholder');
+  window.onModeReceived = (mode: string) => {
+    console.log('[Main] Storing pending mode:', mode);
+    (window as unknown as Record<string, unknown>).__pendingModeReceived = mode;
+  };
+}
+
 if (typeof window !== 'undefined' && !window.showPermissionDialog) {
   console.log('[Main] Pre-registering showPermissionDialog placeholder');
   window.showPermissionDialog = (json: string) => {


### PR DESCRIPTION
Establish a unified permission mode flow with explicit priority rule: payload.permissionMode > sessionMode > default.

Frontend changes:
- Remove duplicate window.onModeReceived registration in App.tsx; funnel all mode callbacks through useWindowCallbacks as the single entry point
- Pre-register onModeReceived placeholder in main.tsx to capture early backend pushes before React callbacks are ready, then replay on registration
- Add get_mode pull request after callback registration to guarantee eventual convergence even if the backend push was missed
- Apply idempotent setter guards to prevent redundant mode re-renders
- Propagate current permissionMode in every send_message and send_message_with_attachments payload; codex provider is forced to bypassPermissions on the frontend as well

Backend changes:
- Extract optional permissionMode from both send_message and send_message_with_attachments payloads in SessionHandler; validate against whitelist, ignore unknowns (backward compatible)
- Add new ClaudeSession.send() overloads accepting requestedPermissionMode without breaking existing call sites
- Implement resolveEffectivePermissionMode: codex always uses bypassPermissions; otherwise payload mode > session mode > "default"
- Pass effectivePermissionMode directly to ClaudeSDKBridge and CodexSDKBridge so the SDK executes with the mode the user selected
- Add volatile to SessionState fields (permissionMode, model, provider, reasoningEffort) to ensure cross-thread visibility between set_mode and send_message handlers