### PR TITLE
fix: apply date range filter on server side for usage statistics

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -758,6 +758,7 @@ public class SettingsHandler extends BaseMessageHandler {
             try {
                 String projectPath = "all";
                 String provider = "claude"; // Default to Claude
+                long cutoffTime = 0; // 0 means no cutoff (all time)
 
                 if (content != null && !content.isEmpty() && !content.equals("{}")) {
                     try {
@@ -778,6 +779,17 @@ public class SettingsHandler extends BaseMessageHandler {
                         if (json.has("provider")) {
                             provider = json.get("provider").getAsString();
                         }
+
+                        // Parse dateRange and convert to cutoff timestamp
+                        if (json.has("dateRange")) {
+                            String dateRange = json.get("dateRange").getAsString();
+                            long now = System.currentTimeMillis();
+                            if ("7d".equals(dateRange)) {
+                                cutoffTime = now - 7L * 24 * 60 * 60 * 1000;
+                            } else if ("30d".equals(dateRange)) {
+                                cutoffTime = now - 30L * 24 * 60 * 60 * 1000;
+                            }
+                        }
                     } catch (Exception e) {
                         if ("current".equals(content)) {
                             projectPath = context.getProject().getBasePath();
@@ -788,10 +800,11 @@ public class SettingsHandler extends BaseMessageHandler {
                 }
 
                 // Use corresponding reader based on provider
+                Gson gson = new Gson();
                 String json;
                 if ("codex".equals(provider)) {
                     CodexHistoryReader reader = new CodexHistoryReader();
-                    CodexHistoryReader.ProjectStatistics stats = reader.getProjectStatistics(projectPath);
+                    CodexHistoryReader.ProjectStatistics stats = reader.getProjectStatistics(projectPath, cutoffTime);
 
                     // Debug logging for Codex statistics
                     LOG.info("[SettingsHandler] Codex statistics - sessions: " + stats.totalSessions +
@@ -801,12 +814,10 @@ public class SettingsHandler extends BaseMessageHandler {
                              ", cache read tokens: " + stats.totalUsage.cacheReadTokens +
                              ", total tokens: " + stats.totalUsage.totalTokens);
 
-                    Gson gson = new Gson();
                     json = gson.toJson(stats);
                 } else {
                     ClaudeHistoryReader reader = new ClaudeHistoryReader();
-                    ClaudeHistoryReader.ProjectStatistics stats = reader.getProjectStatistics(projectPath);
-                    Gson gson = new Gson();
+                    ClaudeHistoryReader.ProjectStatistics stats = reader.getProjectStatistics(projectPath, cutoffTime);
                     json = gson.toJson(stats);
                 }
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryReader.java
@@ -932,8 +932,11 @@ public class ClaudeHistoryReader {
 
     /**
      * Get project usage statistics.
+     *
+     * @param projectPath project path or "all" for all projects
+     * @param cutoffTime  earliest timestamp (ms) to include; 0 means no cutoff (all time)
      */
-    public ProjectStatistics getProjectStatistics(String projectPath) {
+    public ProjectStatistics getProjectStatistics(String projectPath, long cutoffTime) {
         ProjectStatistics stats = new ProjectStatistics();
         stats.projectPath = projectPath;
         stats.projectName = projectPath.equals("all") ? "All Projects" : Paths.get(projectPath).getFileName().toString();
@@ -973,9 +976,16 @@ public class ClaudeHistoryReader {
                 }
             }
 
-            stats.totalSessions = allSessions.size();
+            // Filter sessions by date range when cutoffTime is specified
+            List<SessionSummary> filteredSessions = (cutoffTime > 0)
+                    ? allSessions.stream()
+                        .filter(s -> s.timestamp >= cutoffTime)
+                        .collect(Collectors.toList())
+                    : allSessions;
 
-            processSessions(allSessions, stats);
+            stats.totalSessions = filteredSessions.size();
+
+            processSessions(filteredSessions, stats);
 
             return stats;
 

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryReader.java
@@ -726,8 +726,11 @@ public class CodexHistoryReader {
     /**
      * Get project statistics for usage tracking.
      * Note: Codex sessions don't store project path, so we return all sessions.
+     *
+     * @param projectPath project path (Codex ignores this and returns all sessions)
+     * @param cutoffTime  earliest timestamp (ms) to include; 0 means no cutoff (all time)
      */
-    public ProjectStatistics getProjectStatistics(String projectPath) {
+    public ProjectStatistics getProjectStatistics(String projectPath, long cutoffTime) {
         ProjectStatistics stats = new ProjectStatistics();
         stats.projectPath = projectPath;
         stats.projectName = projectPath.equals("all") ? "All Projects" : Paths.get(projectPath).getFileName().toString();
@@ -754,9 +757,18 @@ public class CodexHistoryReader {
                 // Don't filter Codex sessions by project - show all
             }
 
-            stats.totalSessions = allSessions.size();
-            LOG.info("[CodexHistoryReader] Final sessions count: " + stats.totalSessions);
-            processSessions(allSessions, stats);
+            LOG.info("[CodexHistoryReader] Total sessions before date filtering: " + allSessions.size());
+
+            // Filter sessions by date range when cutoffTime is specified
+            List<SessionSummary> filteredSessions = (cutoffTime > 0)
+                    ? allSessions.stream()
+                        .filter(s -> s.timestamp >= cutoffTime)
+                        .collect(Collectors.toList())
+                    : allSessions;
+
+            stats.totalSessions = filteredSessions.size();
+            LOG.info("[CodexHistoryReader] Filtered sessions count (cutoffTime=" + cutoffTime + "): " + stats.totalSessions);
+            processSessions(filteredSessions, stats);
 
             return stats;
         } catch (Exception e) {

--- a/webview/src/components/UsageStatisticsSection.tsx
+++ b/webview/src/components/UsageStatisticsSection.tsx
@@ -66,13 +66,14 @@ const UsageStatisticsSection = ({ currentProvider }: { currentProvider?: string 
     }
 
     isFirstMount.current = false;
-  }, [projectScope]);
+  }, [projectScope, dateRange]);
 
   const loadStatistics = () => {
     setLoading(true);
     sendToJava('get_usage_statistics', {
       scope: projectScope,
-      provider: currentProvider || 'claude'
+      provider: currentProvider || 'claude',
+      dateRange: dateRange
     });
   };
 


### PR DESCRIPTION
Previously, switching between "Last 7 Days", "Last 30 Days" and "All Time" in the usage statistics panel only filtered the Timeline chart and Sessions list on the front end, while the Overview totals (cost, sessions, tokens) and Models tab always displayed all-time aggregated data.

Changes:
- Frontend: pass dateRange in the get_usage_statistics request payload and add it to the useEffect dependency array so a new request fires on every switch; remove unused optional range parameter from loadStatistics()
- SettingsHandler: parse dateRange ("7d" | "30d" | "all") and convert it to a cutoffTime timestamp (0 = no cutoff); hoist Gson instantiation to avoid duplicate declarations in each branch
- ClaudeHistoryReader.getProjectStatistics: accept cutoffTime, filter the session list before aggregation, use imported Collectors instead of fully qualified name
- CodexHistoryReader.getProjectStatistics: same cutoffTime parameter and filtering; remove redundant totalSessions assignment before filtering