### PR TITLE
fix: restore Claude slash-command skill discovery for plugin skills

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/FileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/FileHandler.java
@@ -2,7 +2,6 @@ package com.github.claudecodegui.handler;
 
 import com.github.claudecodegui.model.FileSortItem;
 import com.github.claudecodegui.service.RunConfigMonitorService;
-import com.github.claudecodegui.skill.SlashCommandRegistry;
 import com.github.claudecodegui.terminal.TerminalMonitorService;
 import com.github.claudecodegui.util.EditorFileUtils;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
@@ -28,13 +27,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * File and command related message handler.
+ * File related message handler.
  */
 public class FileHandler extends BaseMessageHandler {
 
     private static final Logger LOG = Logger.getInstance(FileHandler.class);
 
-    private static final String[] SUPPORTED_TYPES = {"list_files", "get_commands", "open_file", "open_browser",};
+    private static final String[] SUPPORTED_TYPES = {"list_files", "open_file", "open_browser"};
 
     // Constants
     private static final int MAX_RECENT_FILES = 50;
@@ -87,22 +86,21 @@ public class FileHandler extends BaseMessageHandler {
 
     @Override
     public boolean handle(String type, String content) {
-        switch (type) {
-            case "list_files":
+        return switch (type) {
+            case "list_files" -> {
                 handleListFiles(content);
-                return true;
-            case "get_commands":
-                handleGetCommands(content);
-                return true;
-            case "open_file":
+                yield true;
+            }
+            case "open_file" -> {
                 handleOpenFile(content);
-                return true;
-            case "open_browser":
+                yield true;
+            }
+            case "open_browser" -> {
                 handleOpenBrowser(content);
-                return true;
-            default:
-                return false;
-        }
+                yield true;
+            }
+            default -> false;
+        };
     }
 
     /**
@@ -439,59 +437,6 @@ public class FileHandler extends BaseMessageHandler {
     }
 
     /**
-     * Handle get command list request.
-     * Uses local SlashCommandRegistry instead of SDK bridge call.
-     */
-    private void handleGetCommands(String content) {
-        String query = "";
-        if (content != null && !content.isEmpty()) {
-            try {
-                JsonObject json = new Gson().fromJson(content, JsonObject.class);
-                if (json.has("query")) {
-                    query = json.get("query").getAsString();
-                }
-            } catch (Exception e) {
-                query = content;
-            }
-        }
-
-        String cwd = getEffectiveBasePath();
-        String provider = "claude";
-        if (context.getSession() != null && context.getSession().getProvider() != null) {
-            provider = context.getSession().getProvider();
-        }
-
-        var registryCommands = SlashCommandRegistry.getCommands(provider, cwd);
-
-        Gson gson = new Gson();
-        List<JsonObject> commands = new ArrayList<>();
-        final String finalQuery = query.toLowerCase();
-
-        for (var cmd : registryCommands) {
-            String name = cmd.name();
-            String description = cmd.description();
-            if (finalQuery.isEmpty()
-                        || name.toLowerCase().contains(finalQuery)
-                        || description.toLowerCase().contains(finalQuery)) {
-                JsonObject cmdObj = new JsonObject();
-                cmdObj.addProperty("label", name);
-                cmdObj.addProperty("description", description);
-                commands.add(cmdObj);
-            }
-        }
-
-        JsonObject result = new JsonObject();
-        result.add("commands", gson.toJsonTree(commands));
-        String resultJson = gson.toJson(result);
-
-        ApplicationManager.getApplication().invokeLater(() -> {
-            String js = "if (window.onCommandListResult) { window.onCommandListResult('"
-                                + escapeJs(resultJson) + "'); }";
-            context.executeJavaScriptOnEDT(js);
-        });
-    }
-
-    /**
      * Open a file in the editor.
      * Supports file paths with line numbers: file.txt:100 or file.txt:100-200.
      */
@@ -777,18 +722,6 @@ public class FileHandler extends BaseMessageHandler {
             }
         }
         return fileObj;
-    }
-
-    /**
-     * Add a command to the list.
-     */
-    private void addCommand(List<JsonObject> commands, String label, String description, String query) {
-        if (query.isEmpty() || label.toLowerCase().contains(query.toLowerCase()) || description.toLowerCase().contains(query.toLowerCase())) {
-            JsonObject cmd = new JsonObject();
-            cmd.addProperty("label", label);
-            cmd.addProperty("description", description);
-            commands.add(cmd);
-        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -16,11 +16,13 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
 import java.util.HashMap;
@@ -484,7 +486,8 @@ public class SettingsHandler extends BaseMessageHandler {
 
         final String finalCwd = cwd;
         CompletableFuture.runAsync(() -> {
-            var commands = SlashCommandRegistry.getCommands(provider, finalCwd);
+            String currentFilePath = getCurrentEditorFilePath();
+            var commands = SlashCommandRegistry.getCommands(provider, finalCwd, currentFilePath);
             String json = SlashCommandRegistry.toJson(commands);
 
             final String codexJson;
@@ -512,6 +515,30 @@ public class SettingsHandler extends BaseMessageHandler {
             LOG.error("[SettingsHandler] Failed to refresh slash commands asynchronously: " + ex.getMessage(), ex);
             return null;
         });
+    }
+
+    /**
+     * Gets currently selected editor file path for conditional skill filtering.
+     *
+     * @return selected file path, or null if no active file
+     */
+    private String getCurrentEditorFilePath() {
+        try {
+            Project project = this.context.getProject();
+            if (project == null || project.isDisposed()) {
+                return null;
+            }
+            return ReadAction.compute(() -> {
+                VirtualFile[] files = FileEditorManager.getInstance(project).getSelectedFiles();
+                if (files.length == 0 || files[0] == null) {
+                    return null;
+                }
+                return files[0].getPath();
+            });
+        } catch (Exception e) {
+            LOG.debug("[SettingsHandler] Failed to resolve current file path", e);
+        }
+        return null;
     }
 
     private void refreshContextBar() {

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -14,8 +14,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.jcef.JBCefBrowser;
 
 import java.io.File;
@@ -246,7 +249,8 @@ public class SessionLifecycleManager {
 
         LOG.info("Fetching slash commands locally, provider=" + provider + ", cwd=" + cwd);
 
-        var commands = SlashCommandRegistry.getCommands(provider, cwd);
+        String currentFilePath = getCurrentEditorFilePath();
+        var commands = SlashCommandRegistry.getCommands(provider, cwd, currentFilePath);
         String commandsJson = SlashCommandRegistry.toJson(commands);
 
         host.setFetchedSlashCommandsCount(commands.size());
@@ -331,6 +335,30 @@ public class SessionLifecycleManager {
                                 "  }" +
                                 "})();";
             browser.getCefBrowser().executeJavaScript(js, browser.getCefBrowser().getURL(), 0);
+        }
+    }
+
+    /**
+     * Gets the currently selected editor file path.
+     *
+     * @return selected file path, or null if unavailable
+     */
+    private String getCurrentEditorFilePath() {
+        try {
+            Project project = this.host.getProject();
+            if (project == null || project.isDisposed()) {
+                return null;
+            }
+            return ReadAction.compute(() -> {
+                VirtualFile[] selectedFiles = FileEditorManager.getInstance(project).getSelectedFiles();
+                if (selectedFiles.length == 0 || selectedFiles[0] == null) {
+                    return null;
+                }
+                return selectedFiles[0].getPath();
+            });
+        } catch (Exception e) {
+            LOG.debug("Failed to resolve current editor file path", e);
+            return null;
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/skill/ConditionalSkillFilter.java
+++ b/src/main/java/com/github/claudecodegui/skill/ConditionalSkillFilter.java
@@ -1,0 +1,33 @@
+package com.github.claudecodegui.skill;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Filters conditional skills by active file path.
+ */
+public final class ConditionalSkillFilter {
+
+    private ConditionalSkillFilter() {
+    }
+
+    /**
+     * Returns whether a skill should be shown for the current file.
+     *
+     * @param metadata parsed skill metadata
+     * @param currentFile current file path
+     * @return true when skill is visible
+     */
+    public static boolean filter(SkillFrontmatterParser.SkillMetadata metadata, Path currentFile) {
+        if (metadata == null) {
+            return false;
+        }
+
+        List<String> patterns = metadata.paths();
+        if (patterns == null || patterns.isEmpty()) {
+            return true;
+        }
+
+        return SlashCommandRegistry.matchesPathPatterns(currentFile, patterns);
+    }
+}

--- a/src/main/java/com/github/claudecodegui/skill/SkillFrontmatterParser.java
+++ b/src/main/java/com/github/claudecodegui/skill/SkillFrontmatterParser.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -39,7 +41,8 @@ public final class SkillFrontmatterParser {
             String license,
             String compatibility,
             String allowedTools,
-            boolean userInvocable
+            boolean userInvocable,
+            List<String> paths
     ) {
     }
 
@@ -192,7 +195,43 @@ public final class SkillFrontmatterParser {
             userInvocable = Boolean.parseBoolean(String.valueOf(uiObj).trim());
         }
 
-        return new SkillMetadata(name, description, license, compatibility, allowedTools, userInvocable);
+        // Step 8: Extract paths (conditional skills - glob patterns for file matching)
+        List<String> paths = extractPathsList(yamlMap);
+
+        return new SkillMetadata(name, description, license, compatibility, allowedTools, userInvocable, paths);
+    }
+
+    /**
+     * Extracts the paths list from YAML frontmatter.
+     * Used for conditional skills that activate based on file patterns.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<String> extractPathsList(Map<String, Object> yamlMap) {
+        Object pathsObj = yamlMap.get("paths");
+        if (pathsObj == null) {
+            return List.of();
+        }
+
+        if (pathsObj instanceof List) {
+            List<String> paths = new ArrayList<>();
+            for (Object item : (List<?>) pathsObj) {
+                if (item != null) {
+                    String path = String.valueOf(item).trim();
+                    if (!path.isEmpty()) {
+                        paths.add(path);
+                    }
+                }
+            }
+            return paths;
+        }
+
+        // Handle single string path
+        String singlePath = String.valueOf(pathsObj).trim();
+        if (!singlePath.isEmpty()) {
+            return List.of(singlePath);
+        }
+
+        return List.of();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -4,17 +4,26 @@ import com.github.claudecodegui.CodexSkillService;
 import com.github.claudecodegui.util.PlatformUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Merges built-in slash commands with skill-derived commands per provider.
@@ -28,32 +37,658 @@ public final class SlashCommandRegistry {
     }
 
     /**
-     * A slash command with name (including / prefix) and description.
+     * A slash command with name (including / prefix), description, and source.
      */
-    public record SlashCommand(String name, String description) {
+    public record SlashCommand(String name, String description, String source) {
+    }
+
+    /**
+     * Represents a directory to scan for skills or commands, with its scope.
+     */
+    public record SkillScanDir(String path, String scope) {
+    }
+
+    /**
+     * Represents plugin-contributed skill directory info.
+     */
+    public record PluginSkillPath(String pluginName, String path) {
+    }
+
+    /**
+     * Installed plugin descriptor from installed_plugins.json.
+     */
+    private record InstalledPlugin(String pluginId, String installPath, String version) {
     }
 
     // Claude built-in commands (GUI-relevant only; CLI-only and frontend-local ones are excluded)
     public static final List<SlashCommand> CLAUDE_BUILTIN = List.of(
-            new SlashCommand("/compact", "Toggle compact mode"),
-            new SlashCommand("/init", "Initialize a new project"),
-            new SlashCommand("/review", "Review changes before applying")
+            new SlashCommand("/compact", "Toggle compact mode", "builtin"),
+            new SlashCommand("/init", "Initialize a new project", "builtin"),
+            new SlashCommand("/review", "Review changes before applying", "builtin")
     );
 
     // Codex built-in commands (GUI-relevant only; CLI-only ones like /status, /model, /quit are excluded)
     public static final List<SlashCommand> CODEX_BUILTIN = List.of(
-            new SlashCommand("/compact", "Summarize conversation to free tokens"),
-            new SlashCommand("/diff", "Show pending changes diff including untracked files"),
-            new SlashCommand("/init", "Generate an AGENTS.md scaffold"),
-            new SlashCommand("/plan", "Switch to plan mode"),
-            new SlashCommand("/review", "Review working tree changes")
+            new SlashCommand("/compact", "Summarize conversation to free tokens", "builtin"),
+            new SlashCommand("/diff", "Show pending changes diff including untracked files", "builtin"),
+            new SlashCommand("/init", "Generate an AGENTS.md scaffold", "builtin"),
+            new SlashCommand("/plan", "Switch to plan mode", "builtin"),
+            new SlashCommand("/review", "Review working tree changes", "builtin")
     );
+
+    /**
+     * Finds the repository root by walking up from cwd looking for a .git directory.
+     *
+     * @param cwd the current working directory
+     * @return the repo root path, or null if not in a git repository
+     */
+    public static String findRepoRoot(String cwd) {
+        if (cwd == null || cwd.isEmpty()) {
+            return null;
+        }
+        Path current;
+        try {
+            current = Paths.get(cwd).toAbsolutePath().normalize();
+        } catch (Exception e) {
+            LOG.debug("Invalid cwd for repo root detection: " + cwd);
+            return null;
+        }
+        Path root = current.getRoot();
+
+        while (current != null && !current.equals(root)) {
+            if (Files.isDirectory(current.resolve(".git"))) {
+                return current.toString();
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    /**
+     * Gets the list of directories to scan for Claude skills or commands.
+     * Scans from CWD upward to home directory.
+     *
+     * @param cwd  the current working directory
+     * @param type "skills" or "commands"
+     * @return list of directories to scan
+     */
+    public static List<SkillScanDir> getSkillScanDirs(String cwd, String type) {
+        return getSkillScanDirs(cwd, type, resolveUserHome());
+    }
+
+    /**
+     * Gets the list of directories to scan for Claude skills or commands with explicit home path.
+     */
+    static List<SkillScanDir> getSkillScanDirs(String cwd, String type, String userHome) {
+        List<SkillScanDir> dirs = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        if (cwd == null || cwd.isEmpty() || type == null || type.isEmpty()) {
+            return dirs;
+        }
+
+        Path current;
+        try {
+            current = Paths.get(cwd).toAbsolutePath().normalize();
+        } catch (Exception e) {
+            LOG.debug("Invalid cwd for skill scanning: " + cwd);
+            return dirs;
+        }
+        Path fsRoot = current.getRoot();
+        Path homePath = null;
+        if (userHome != null && !userHome.isEmpty()) {
+            try {
+                homePath = Paths.get(userHome).toAbsolutePath().normalize();
+            } catch (Exception e) {
+                LOG.debug("Invalid user home path for skill scanning: " + userHome);
+            }
+        }
+
+        while (current != null && !current.equals(fsRoot)) {
+            Path candidate = current.resolve(".claude").resolve(type);
+            String normalizedCandidate = normalizePath(candidate.toString());
+            if (Files.isDirectory(candidate) && seen.add(normalizedCandidate)) {
+                dirs.add(new SkillScanDir(candidate.toString(), "project"));
+            }
+
+            if (homePath != null && current.equals(homePath)) {
+                break;
+            }
+
+            current = current.getParent();
+        }
+
+        return dirs;
+    }
+
+    /**
+     * Gets the list of directories to scan for Claude commands.
+     *
+     * @param cwd the current working directory
+     * @return list of directories to scan
+     */
+    public static List<SkillScanDir> getCommandScanDirs(String cwd) {
+        return getSkillScanDirs(cwd, "commands");
+    }
+
+    /**
+     * Gets the list of directories to scan for Claude skills.
+     *
+     * @param cwd the current working directory
+     * @return list of directories to scan
+     */
+    public static List<SkillScanDir> getSkillsScanDirs(String cwd) {
+        return getSkillScanDirs(cwd, "skills");
+    }
+
+    /**
+     * Gets configured additional directories for Claude scanning.
+     * Reads additionalDirectoriesForClaudeMd from settings.
+     *
+     * @param cwd current working directory
+     * @return validated directories
+     */
+    public static List<String> getAdditionalDirectories(String cwd) {
+        return getAdditionalDirectories(cwd, resolveUserHome());
+    }
+
+    /**
+     * Gets configured additional directories for Claude scanning with explicit home path.
+     */
+    static List<String> getAdditionalDirectories(String cwd, String userHome) {
+        Set<String> seen = new HashSet<>();
+        List<String> result = new ArrayList<>();
+
+        for (JsonObject settings : getMergedClaudeSettings(cwd, userHome)) {
+            JsonElement value = settings.get("additionalDirectoriesForClaudeMd");
+            if (value == null || value.isJsonNull()) {
+                continue;
+            }
+
+            if (value.isJsonArray()) {
+                for (JsonElement item : value.getAsJsonArray()) {
+                    if (item != null && item.isJsonPrimitive()) {
+                        addAdditionalDirectory(result, seen, item.getAsString(), cwd);
+                    }
+                }
+            } else if (value.isJsonPrimitive()) {
+                addAdditionalDirectory(result, seen, value.getAsString(), cwd);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns managed directory from env or policy settings file.
+     *
+     * @return managed directory path, or null if unavailable
+     */
+    public static String getManagedDirectory() {
+        return getManagedDirectory(System.getenv(), getPolicySettingsPath());
+    }
+
+    /**
+     * Returns managed directory from env or policy settings file.
+     */
+    static String getManagedDirectory(Map<String, String> env, Path policyPath) {
+        String fromEnv = env != null ? env.get("CLAUDE_CODE_MANAGED_DIR") : null;
+        if (fromEnv != null && !fromEnv.trim().isEmpty()) {
+            String normalized = normalizePath(fromEnv.trim());
+            LOG.info("Managed directory from env: " + normalized);
+            return normalized;
+        }
+
+        JsonObject policy = readJsonObject(policyPath);
+        if (policy == null) {
+            return null;
+        }
+
+        for (String key : List.of("managedDirectory", "managedSkillsDirectory", "managedDir")) {
+            JsonElement value = policy.get(key);
+            if (value != null && value.isJsonPrimitive()) {
+                String dir = value.getAsString();
+                if (dir != null && !dir.trim().isEmpty()) {
+                    String normalized = normalizePath(dir.trim());
+                    LOG.info("Managed directory from policy file: " + normalized);
+                    return normalized;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Scans managed skills directory.
+     *
+     * @param managedDir managed directory path
+     * @param currentFilePath current file path for conditional filtering
+     * @return managed slash commands
+     */
+    public static List<SlashCommand> scanManagedSkills(String managedDir, String currentFilePath) {
+        if (managedDir == null || managedDir.isEmpty()) {
+            return List.of();
+        }
+
+        Path managedPath = Paths.get(managedDir).toAbsolutePath().normalize();
+        if (!isManagedPathSafe(managedPath)) {
+            LOG.warn("Skipping unsafe managed directory: " + managedPath);
+            return List.of();
+        }
+
+        Path skillsDir = resolveManagedSkillsDirectory(managedPath);
+        if (skillsDir == null) {
+            LOG.info("Managed skills directory not found under: " + managedPath);
+            return List.of();
+        }
+
+        return scanSkillsAsCommands(skillsDir.toString(), "managed", null, toNormalizedPath(currentFilePath));
+    }
+
+    /**
+     * Gets plugin skill paths from enabled Claude Code plugins.
+     *
+     * @param cwd current working directory
+     * @return plugin skill paths
+     */
+    public static List<PluginSkillPath> getPluginSkillPaths(String cwd) {
+        return getPluginSkillPaths(cwd, resolveUserHome());
+    }
+
+    /**
+     * Gets plugin skill paths from enabled Claude Code plugins with explicit home path.
+     */
+    static List<PluginSkillPath> getPluginSkillPaths(String cwd, String userHome) {
+        if (userHome == null || userHome.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, Boolean> enabledPlugins = getEnabledPlugins(cwd, userHome);
+        if (enabledPlugins.isEmpty()) {
+            return List.of();
+        }
+
+        Path pluginsBase;
+        try {
+            pluginsBase = Paths.get(userHome, ".claude", "plugins").toAbsolutePath().normalize();
+        } catch (Exception e) {
+            LOG.warn("Invalid user home path for plugin scanning: " + userHome);
+            return List.of();
+        }
+        Map<String, InstalledPlugin> installedPlugins = getInstalledPlugins(pluginsBase);
+
+        List<PluginSkillPath> result = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        for (Map.Entry<String, Boolean> entry : enabledPlugins.entrySet()) {
+            if (!Boolean.TRUE.equals(entry.getValue())) {
+                continue;
+            }
+
+            String pluginId = entry.getKey();
+            String pluginName = pluginId.split("@", 2)[0];
+            InstalledPlugin installed = installedPlugins.get(pluginId);
+            Path pluginDir = installed != null && installed.installPath() != null
+                    ? toNormalizedPath(installed.installPath())
+                    : null;
+            if (pluginDir == null) {
+                pluginDir = pluginsBase.resolve(pluginId).toAbsolutePath().normalize();
+            }
+            Path manifestPath = resolvePluginManifestPath(pluginDir);
+
+            if (manifestPath == null || !Files.isRegularFile(manifestPath)) {
+                LOG.info("Plugin manifest not found, skip: " + manifestPath);
+                continue;
+            }
+
+            JsonObject manifest = readJsonObject(manifestPath);
+            if (manifest == null) {
+                LOG.warn("Failed to parse plugin manifest: " + manifestPath);
+                continue;
+            }
+
+            List<String> declaredPaths = new ArrayList<>();
+            JsonElement skillsPath = manifest.get("skillsPath");
+            if (skillsPath != null && skillsPath.isJsonPrimitive()) {
+                declaredPaths.add(skillsPath.getAsString());
+            }
+            JsonElement skillsPaths = manifest.get("skillsPaths");
+            if (skillsPaths != null && skillsPaths.isJsonArray()) {
+                for (JsonElement item : skillsPaths.getAsJsonArray()) {
+                    if (item != null && item.isJsonPrimitive()) {
+                        declaredPaths.add(item.getAsString());
+                    }
+                }
+            }
+            // Claude plugin packages commonly use implicit ./skills without explicit skillsPath.
+            if (declaredPaths.isEmpty()) {
+                declaredPaths.add("skills");
+            }
+
+            for (String declaredPath : declaredPaths) {
+                if (declaredPath == null || declaredPath.trim().isEmpty()) {
+                    continue;
+                }
+
+                Path resolved = resolvePluginSkillsPath(pluginDir, declaredPath.trim());
+                if (resolved == null || !isPluginSkillPathSafe(resolved, pluginDir)) {
+                    LOG.warn("Rejected plugin skill path: " + declaredPath + " from plugin " + pluginId);
+                    continue;
+                }
+                if (!Files.isDirectory(resolved)) {
+                    LOG.info("Plugin skill directory does not exist: " + resolved);
+                    continue;
+                }
+
+                String key = pluginName + "::" + normalizePath(resolved.toString());
+                if (seen.add(key)) {
+                    result.add(new PluginSkillPath(pluginName, resolved.toString()));
+                    LOG.info("Accepted plugin skill path: " + resolved + " (plugin=" + pluginId + ")");
+                }
+            }
+        }
+
+        LOG.info("Discovered plugin skill paths: " + result.size());
+        return result;
+    }
+
+    /**
+     * Matches current file against conditional path patterns.
+     *
+     * @param currentFile current file path
+     * @param patterns glob patterns from frontmatter
+     * @return true if any pattern matches
+     */
+    public static boolean matchesPathPatterns(Path currentFile, List<String> patterns) {
+        if (patterns == null || patterns.isEmpty()) {
+            return true;
+        }
+        if (currentFile == null) {
+            return false;
+        }
+
+        String normalized = currentFile.toString().replace('\\', '/');
+        for (String pattern : patterns) {
+            if (pattern == null || pattern.trim().isEmpty()) {
+                continue;
+            }
+
+            String trimmed = pattern.trim();
+            String candidatePattern = trimmed.startsWith("glob:") ? trimmed : "glob:" + trimmed;
+
+            try {
+                PathMatcher matcher = Paths.get("").getFileSystem().getPathMatcher(candidatePattern);
+                Path currentPath = Paths.get(normalized);
+                if (matcher.matches(currentPath)) {
+                    return true;
+                }
+
+                Path fileName = currentFile.getFileName();
+                if (fileName != null && matcher.matches(fileName)) {
+                    return true;
+                }
+
+                for (int i = 0; i < currentPath.getNameCount(); i++) {
+                    if (matcher.matches(currentPath.subpath(i, currentPath.getNameCount()))) {
+                        return true;
+                    }
+                }
+            } catch (Exception e) {
+                LOG.debug("Invalid path pattern, skip: " + trimmed);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets the merged slash command list for a given provider and working directory.
+     *
+     * @param provider "claude" or "codex"
+     * @param cwd current working directory
+     * @return deduplicated list of slash commands
+     */
+    public static List<SlashCommand> getCommands(String provider, String cwd) {
+        return getCommands(provider, cwd, null);
+    }
+
+    /**
+     * Gets the merged slash command list for a given provider and working directory.
+     *
+     * @param provider "claude" or "codex"
+     * @param cwd current working directory
+     * @param currentFilePath active editor file path for conditional skills
+     * @return deduplicated list of slash commands
+     */
+    public static List<SlashCommand> getCommands(String provider, String cwd, String currentFilePath) {
+        boolean isCodex = "codex".equalsIgnoreCase(provider);
+
+        // Step 1: Select built-in commands by provider
+        List<SlashCommand> builtins = isCodex ? CODEX_BUILTIN : CLAUDE_BUILTIN;
+
+        String userHome = resolveUserHome();
+        Path currentFile = toNormalizedPath(currentFilePath);
+
+        List<SlashCommand> globalCmdCommands;
+        List<SlashCommand> globalSkillCommands;
+        List<SlashCommand> localCmdCommands = List.of();
+        List<SlashCommand> localSkillCommands = List.of();
+        List<SlashCommand> additionalCmdCommands = List.of();
+        List<SlashCommand> additionalSkillCommands = List.of();
+        List<SlashCommand> managedSkillCommands = List.of();
+        List<SlashCommand> pluginSkillCommands = List.of();
+
+        if (isCodex) {
+            // Codex slash commands come only from ~/.codex/prompts/ (namespaced as /prompts:<name>)
+            // Codex skills (.agents/skills/) use $ prefix, not / — they are NOT slash commands
+            if (userHome.isEmpty()) {
+                globalCmdCommands = List.of();
+            } else {
+                globalCmdCommands = scanPromptsAsCommands(
+                        userHome + File.separator + ".codex" + File.separator + "prompts");
+            }
+            globalSkillCommands = List.of();
+        } else {
+            if (userHome.isEmpty()) {
+                globalCmdCommands = List.of();
+                globalSkillCommands = List.of();
+            } else {
+                String claudeDir = userHome + File.separator + ".claude";
+                globalCmdCommands = scanCommandsAsCommands(
+                        claudeDir + File.separator + "commands", "user");
+                globalSkillCommands = scanSkillsAsCommands(
+                        claudeDir + File.separator + "skills", "user", null, currentFile);
+            }
+
+            if (cwd != null && !cwd.isEmpty()) {
+                List<SkillScanDir> cmdDirs = getCommandScanDirs(cwd);
+                List<SkillScanDir> skillDirs = getSkillsScanDirs(cwd);
+
+                localCmdCommands = scanCommandsFromDirs(cmdDirs, "local");
+                localSkillCommands = scanSkillsFromDirs(skillDirs, "local", null, currentFile);
+
+                List<String> additionalDirs = getAdditionalDirectories(cwd, userHome);
+                additionalCmdCommands = scanAdditionalCommands(additionalDirs);
+                additionalSkillCommands = scanAdditionalSkills(additionalDirs, currentFile);
+            }
+
+            managedSkillCommands = scanManagedSkills(getManagedDirectory(), currentFilePath);
+            pluginSkillCommands = scanPluginSkills(cwd, currentFilePath, userHome);
+        }
+
+        // Merge (preserves insertion order, later overrides earlier)
+        // Merge order: builtins → local → additional → managed → user → plugin
+        return mergeCommandsInOrder(
+                builtins,
+                localCmdCommands,
+                localSkillCommands,
+                additionalCmdCommands,
+                additionalSkillCommands,
+                managedSkillCommands,
+                globalCmdCommands,
+                globalSkillCommands,
+                pluginSkillCommands
+        );
+    }
+
+    /**
+     * Serializes a command list to JSON array format:
+     * [{"name": "/help", "description": "...", "source": "..."}, ...]
+     */
+    public static String toJson(List<SlashCommand> commands) {
+        JsonArray array = new JsonArray();
+        for (SlashCommand cmd : commands) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("name", cmd.name());
+            obj.addProperty("description", cmd.description());
+            if (cmd.source() != null && !cmd.source().isEmpty()) {
+                obj.addProperty("source", cmd.source());
+            }
+            array.add(obj);
+        }
+        return new Gson().toJson(array);
+    }
+
+    /**
+     * Gets Codex skills as $-prefixed commands for autocomplete.
+     * Derives from CodexSkillService.getAllSkills() to ensure consistent data
+     * with the Skills settings page. Only includes enabled, user-invocable skills.
+     */
+    public static List<SlashCommand> getCodexSkills(String cwd) {
+        JsonObject allSkills = CodexSkillService.getAllSkills(cwd);
+
+        Map<String, SlashCommand> merged = new LinkedHashMap<>();
+        for (String scope : new String[]{"user", "repo"}) {
+            JsonObject scopeSkills = allSkills.getAsJsonObject(scope);
+            if (scopeSkills == null) {
+                continue;
+            }
+
+            for (String key : scopeSkills.keySet()) {
+                JsonObject skill = scopeSkills.getAsJsonObject(key);
+
+                // Skip disabled skills
+                if (skill.has("enabled") && !skill.get("enabled").getAsBoolean()) {
+                    continue;
+                }
+                // Skip non-user-invocable skills
+                if (skill.has("userInvocable") && !skill.get("userInvocable").getAsBoolean()) {
+                    continue;
+                }
+
+                String name = skill.has("name") ? skill.get("name").getAsString() : "";
+                String desc = skill.has("description") ? skill.get("description").getAsString() : "";
+                if (!name.isEmpty()) {
+                    merged.put("$" + name, new SlashCommand("$" + name, desc, "codex-skill"));
+                }
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Scans multiple skill directories and returns aggregated slash commands.
+     * Child directories keep precedence over parent directories.
+     */
+    private static List<SlashCommand> scanSkillsFromDirs(
+            List<SkillScanDir> scanDirs,
+            String source,
+            String namespacePrefix,
+            Path currentFilePath
+    ) {
+        Map<String, SlashCommand> merged = new LinkedHashMap<>();
+        for (SkillScanDir scanDir : scanDirs) {
+            List<SlashCommand> commands = scanSkillsAsCommands(
+                    scanDir.path(), source, namespacePrefix, currentFilePath);
+            for (SlashCommand cmd : commands) {
+                merged.putIfAbsent(cmd.name(), cmd);
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Scans multiple command directories and returns aggregated slash commands.
+     * Child directories keep precedence over parent directories.
+     */
+    private static List<SlashCommand> scanCommandsFromDirs(List<SkillScanDir> scanDirs, String source) {
+        Map<String, SlashCommand> merged = new LinkedHashMap<>();
+        for (SkillScanDir scanDir : scanDirs) {
+            List<SlashCommand> commands = scanCommandsAsCommands(scanDir.path(), source);
+            for (SlashCommand cmd : commands) {
+                merged.putIfAbsent(cmd.name(), cmd);
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Scans additional directories for skills.
+     */
+    private static List<SlashCommand> scanAdditionalSkills(List<String> additionalDirs, Path currentFilePath) {
+        List<SkillScanDir> dirs = new ArrayList<>();
+        for (String dir : additionalDirs) {
+            Path path = Paths.get(dir).toAbsolutePath().normalize();
+            Path candidate = path.resolve(".claude").resolve("skills");
+            if (Files.isDirectory(candidate)) {
+                dirs.add(new SkillScanDir(candidate.toString(), "additional"));
+            }
+        }
+        return scanSkillsFromDirs(dirs, "additional", null, currentFilePath);
+    }
+
+    /**
+     * Scans additional directories for commands.
+     */
+    private static List<SlashCommand> scanAdditionalCommands(List<String> additionalDirs) {
+        List<SkillScanDir> dirs = new ArrayList<>();
+        for (String dir : additionalDirs) {
+            Path path = Paths.get(dir).toAbsolutePath().normalize();
+            Path candidate = path.resolve(".claude").resolve("commands");
+            if (Files.isDirectory(candidate)) {
+                dirs.add(new SkillScanDir(candidate.toString(), "additional"));
+            }
+        }
+        return scanCommandsFromDirs(dirs, "additional");
+    }
+
+    /**
+     * Scans enabled plugins and returns plugin-prefixed slash commands.
+     */
+    private static List<SlashCommand> scanPluginSkills(String cwd, String currentFilePath, String userHome) {
+        List<PluginSkillPath> pluginPaths = getPluginSkillPaths(cwd, userHome);
+        if (pluginPaths.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, SlashCommand> merged = new LinkedHashMap<>();
+        Path currentFile = toNormalizedPath(currentFilePath);
+        for (PluginSkillPath pluginPath : pluginPaths) {
+            List<SlashCommand> commands = scanSkillsAsCommands(
+                    pluginPath.path(),
+                    "plugin",
+                    pluginPath.pluginName(),
+                    currentFile
+            );
+            for (SlashCommand cmd : commands) {
+                merged.put(cmd.name(), cmd);
+            }
+        }
+
+        return new ArrayList<>(merged.values());
+    }
 
     /**
      * Scans a skills directory for valid skill subdirectories and converts them to slash commands.
      * Skips plain files and hidden directories.
      */
-    private static List<SlashCommand> scanSkillsAsCommands(String dirPath) {
+    private static List<SlashCommand> scanSkillsAsCommands(
+            String dirPath,
+            String source,
+            String namespacePrefix,
+            Path currentFilePath
+    ) {
         if (dirPath == null || dirPath.isEmpty()) {
             return List.of();
         }
@@ -86,7 +721,19 @@ public final class SlashCommandRegistry {
                 continue;
             }
 
-            commands.add(new SlashCommand("/" + metadata.name(), metadata.description()));
+            if (!ConditionalSkillFilter.filter(metadata, currentFilePath)) {
+                continue;
+            }
+
+            String commandName = namespacePrefix != null && !namespacePrefix.isEmpty()
+                    ? "/" + namespacePrefix + ":" + metadata.name()
+                    : "/" + metadata.name();
+            String commandSource = source;
+            if ("plugin".equals(source) && namespacePrefix != null && !namespacePrefix.isEmpty()) {
+                commandSource = "plugin:" + namespacePrefix;
+            }
+
+            commands.add(new SlashCommand(commandName, metadata.description(), commandSource));
         }
         return commands;
     }
@@ -95,7 +742,7 @@ public final class SlashCommandRegistry {
      * Scans a commands directory for .md files and converts them to slash commands.
      * Supports namespaced commands via subdirectories (e.g. opsx/explore.md → /opsx:explore).
      */
-    private static List<SlashCommand> scanCommandsAsCommands(String dirPath) {
+    private static List<SlashCommand> scanCommandsAsCommands(String dirPath, String source) {
         if (dirPath == null || dirPath.isEmpty()) {
             return List.of();
         }
@@ -117,7 +764,7 @@ public final class SlashCommandRegistry {
 
             if (entry.isFile() && entry.getName().endsWith(".md")) {
                 // Top-level command: commit.md → /commit
-                SlashCommand cmd = parseCommandFile(entry, null);
+                SlashCommand cmd = parseCommandFile(entry, null, source);
                 if (cmd != null) {
                     commands.add(cmd);
                 }
@@ -125,12 +772,14 @@ public final class SlashCommandRegistry {
                 // Namespaced commands: opsx/explore.md → /opsx:explore
                 String namespace = entry.getName();
                 File[] subEntries = entry.listFiles();
-                if (subEntries == null) continue;
+                if (subEntries == null) {
+                    continue;
+                }
 
                 for (File subEntry : subEntries) {
                     if (subEntry.isFile() && subEntry.getName().endsWith(".md")
                                 && !subEntry.getName().startsWith(".")) {
-                        SlashCommand cmd = parseCommandFile(subEntry, namespace);
+                        SlashCommand cmd = parseCommandFile(subEntry, namespace, source);
                         if (cmd != null) {
                             commands.add(cmd);
                         }
@@ -143,7 +792,7 @@ public final class SlashCommandRegistry {
 
     /**
      * Scans a Codex prompts directory for .md files and converts them to slash commands.
-     * All prompts are namespaced as /prompts:&lt;name&gt; per Codex convention.
+     * All prompts are namespaced as /prompts:<name> per Codex convention.
      */
     private static List<SlashCommand> scanPromptsAsCommands(String dirPath) {
         if (dirPath == null || dirPath.isEmpty()) {
@@ -169,7 +818,8 @@ public final class SlashCommandRegistry {
             String description = extractCommandDescription(entry.toPath());
             commands.add(new SlashCommand(
                     "/prompts:" + baseName,
-                    description != null ? description : ""));
+                    description != null ? description : "",
+                    "codex-prompt"));
         }
         return commands;
     }
@@ -177,19 +827,18 @@ public final class SlashCommandRegistry {
     /**
      * Parses a single command .md file to extract name and description from frontmatter.
      */
-    private static SlashCommand parseCommandFile(File mdFile, String namespace) {
+    private static SlashCommand parseCommandFile(File mdFile, String namespace, String source) {
         String baseName = mdFile.getName().replaceFirst("\\.md$", "");
         String commandName = namespace != null
-                                     ? "/" + namespace + ":" + baseName
-                                     : "/" + baseName;
+                ? "/" + namespace + ":" + baseName
+                : "/" + baseName;
 
-        // Try to extract description from YAML frontmatter
         String description = extractCommandDescription(mdFile.toPath());
         if (description == null) {
             description = "";
         }
 
-        return new SlashCommand(commandName, description);
+        return new SlashCommand(commandName, description, source);
     }
 
     /**
@@ -218,127 +867,318 @@ public final class SlashCommandRegistry {
         } catch (Exception e) {
             LOG.debug("Failed to parse command frontmatter: " + mdPath);
         }
-        return null; // Ensure we always return a value if not found
+        return null;
     }
 
     /**
-     * Gets the merged slash command list for a given provider and working directory.
-     * Claude merge order: built-in → project commands → project skills → personal commands → personal skills.
-     * Codex merge order: built-in → prompts.
-     * Later entries override earlier ones with the same name (personal > project per Claude docs).
-     *
-     * @param provider "claude" or "codex"
-     * @param cwd      current working directory (for local skills/commands lookup)
-     * @return deduplicated list of slash commands
+     * Resolves user home from platform helper.
      */
-    public static List<SlashCommand> getCommands(String provider, String cwd) {
-        boolean isCodex = "codex".equalsIgnoreCase(provider);
+    private static String resolveUserHome() {
+        String home = PlatformUtils.getHomeDirectory();
+        return home != null ? home : "";
+    }
 
-        // Step 1: Select built-in commands by provider
-        List<SlashCommand> builtins = isCodex ? CODEX_BUILTIN : CLAUDE_BUILTIN;
+    /**
+     * Normalizes a path string for consistent cross-platform comparison.
+     */
+    private static String normalizePath(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        try {
+            return Paths.get(path).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return path;
+        }
+    }
 
-        String userHome = PlatformUtils.getHomeDirectory();
+    private static Path toNormalizedPath(String path) {
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        try {
+            return Paths.get(path).toAbsolutePath().normalize();
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
-        List<SlashCommand> globalCmdCommands;
-        List<SlashCommand> globalSkillCommands;
-        List<SlashCommand> localCmdCommands = List.of();
-        List<SlashCommand> localSkillCommands = List.of();
+    private static void addAdditionalDirectory(List<String> result, Set<String> seen, String pathValue, String cwd) {
+        if (pathValue == null || pathValue.trim().isEmpty()) {
+            return;
+        }
 
-        if (isCodex) {
-            // Codex slash commands come only from ~/.codex/prompts/ (namespaced as /prompts:<name>)
-            // Codex skills (.agents/skills/) use $ prefix, not / — they are NOT slash commands
-            globalCmdCommands = scanPromptsAsCommands(
-                    userHome + File.separator + ".codex" + File.separator + "prompts");
-            globalSkillCommands = List.of();
-        } else {
-            // Claude: ~/.claude/commands/ and ~/.claude/skills/
-            String claudeDir = userHome + File.separator + ".claude";
-            globalCmdCommands = scanCommandsAsCommands(
-                    claudeDir + File.separator + "commands");
-            globalSkillCommands = scanSkillsAsCommands(
-                    claudeDir + File.separator + "skills");
+        Path path;
+        try {
+            path = Paths.get(pathValue.trim());
+            if (!path.isAbsolute() && cwd != null && !cwd.isEmpty()) {
+                path = Paths.get(cwd).resolve(path).normalize();
+            }
+        } catch (Exception e) {
+            LOG.debug("Invalid additional directory path: " + pathValue);
+            return;
+        }
+        Path normalized = path.toAbsolutePath().normalize();
+        if (!Files.isDirectory(normalized)) {
+            return;
+        }
 
-            // Claude local: {cwd}/.claude/commands/ and skills/
-            if (cwd != null && !cwd.isEmpty()) {
-                String localClaudeDir = cwd + File.separator + ".claude";
-                localCmdCommands = scanCommandsAsCommands(
-                        localClaudeDir + File.separator + "commands");
-                localSkillCommands = scanSkillsAsCommands(
-                        localClaudeDir + File.separator + "skills");
+        String key = normalized.toString();
+        if (seen.add(key)) {
+            result.add(key);
+        }
+    }
+
+    private static Path resolveManagedSkillsDirectory(Path managedPath) {
+        Path candidate = managedPath.resolve(".claude").resolve("skills");
+        if (Files.isDirectory(candidate)) {
+            return candidate;
+        }
+        Path directSkills = managedPath.resolve("skills");
+        if (Files.isDirectory(directSkills)) {
+            return directSkills;
+        }
+        if (Files.isDirectory(managedPath) && managedPath.getFileName() != null
+                && "skills".equals(managedPath.getFileName().toString())) {
+            return managedPath;
+        }
+        return null;
+    }
+
+    private static boolean isManagedPathSafe(Path managedPath) {
+        if (managedPath == null || !managedPath.isAbsolute()) {
+            return false;
+        }
+        if (!Files.isDirectory(managedPath)) {
+            return false;
+        }
+        if (managedPath.getNameCount() <= 1) {
+            return false;
+        }
+        return !Files.isSymbolicLink(managedPath);
+    }
+
+    private static Path getPolicySettingsPath() {
+        if (PlatformUtils.isWindows()) {
+            String programData = System.getenv("ProgramData");
+            if (programData == null || programData.isEmpty()) {
+                programData = "C:\\ProgramData";
+            }
+            return Paths.get(programData, "ClaudeCode", "managed-settings.json");
+        }
+        if (PlatformUtils.isMac()) {
+            return Paths.get("/Library/Application Support/ClaudeCode/managed-settings.json");
+        }
+        return Paths.get("/etc/claude-code/managed-settings.json");
+    }
+
+    private static List<JsonObject> getMergedClaudeSettings(String cwd, String userHome) {
+        List<JsonObject> settings = new ArrayList<>();
+
+        if (userHome != null && !userHome.isEmpty()) {
+            try {
+                Path userSettings = Paths.get(userHome, ".claude", "settings.json");
+                JsonObject user = readJsonObject(userSettings);
+                if (user != null) {
+                    settings.add(user);
+                }
+            } catch (Exception e) {
+                LOG.debug("Invalid user home for settings merge: " + userHome);
             }
         }
 
-        // Merge (preserves insertion order, later overrides earlier)
-        // For Claude: built-in → project → personal (personal wins per docs)
-        Map<String, SlashCommand> merged = new LinkedHashMap<>();
-        for (SlashCommand cmd : builtins) {
-            merged.put(cmd.name(), cmd);
-        }
-        for (SlashCommand cmd : localCmdCommands) {
-            merged.put(cmd.name(), cmd);
-        }
-        for (SlashCommand cmd : localSkillCommands) {
-            merged.put(cmd.name(), cmd);
-        }
-        for (SlashCommand cmd : globalCmdCommands) {
-            merged.put(cmd.name(), cmd);
-        }
-        for (SlashCommand cmd : globalSkillCommands) {
-            merged.put(cmd.name(), cmd);
+        if (cwd != null && !cwd.isEmpty()) {
+            try {
+                Path cwdPath = Paths.get(cwd).toAbsolutePath().normalize();
+                Path projectSettings = cwdPath.resolve(".claude").resolve("settings.json");
+                JsonObject project = readJsonObject(projectSettings);
+                if (project != null) {
+                    settings.add(project);
+                }
+
+                Path localSettings = cwdPath.resolve(".claude").resolve("settings.local.json");
+                JsonObject local = readJsonObject(localSettings);
+                if (local != null) {
+                    settings.add(local);
+                }
+            } catch (Exception e) {
+                LOG.debug("Invalid cwd for settings merge: " + cwd);
+            }
         }
 
-        // Step 6: Return merged results
-        return new ArrayList<>(merged.values());
+        return settings;
     }
 
-    /**
-     * Serializes a command list to JSON array format:
-     * [{"name": "/help", "description": "..."}, ...]
-     */
-    public static String toJson(List<SlashCommand> commands) {
-        JsonArray array = new JsonArray();
-        for (SlashCommand cmd : commands) {
-            JsonObject obj = new JsonObject();
-            obj.addProperty("name", cmd.name());
-            obj.addProperty("description", cmd.description());
-            array.add(obj);
+    private static Map<String, Boolean> getEnabledPlugins(String cwd, String userHome) {
+        Map<String, Boolean> merged = new HashMap<>();
+
+        for (JsonObject settings : getMergedClaudeSettings(cwd, userHome)) {
+            JsonElement enabledPlugins = settings.get("enabledPlugins");
+            if (enabledPlugins == null || !enabledPlugins.isJsonObject()) {
+                continue;
+            }
+
+            JsonObject map = enabledPlugins.getAsJsonObject();
+            for (String key : map.keySet()) {
+                JsonElement value = map.get(key);
+                boolean enabled = value != null && value.isJsonPrimitive() && value.getAsBoolean();
+                merged.put(key, enabled);
+            }
         }
-        return new Gson().toJson(array);
+
+        return merged;
     }
 
-    /**
-     * Gets Codex skills as $-prefixed commands for autocomplete.
-     * Derives from CodexSkillService.getAllSkills() to ensure consistent data
-     * with the Skills settings page. Only includes enabled, user-invocable skills.
-     */
-    public static List<SlashCommand> getCodexSkills(String cwd) {
-        JsonObject allSkills = CodexSkillService.getAllSkills(cwd);
+    private static Path resolvePluginSkillsPath(Path pluginDir, String declaredPath) {
+        try {
+            Path path = Paths.get(declaredPath);
+            if (path.isAbsolute()) {
+                return path.normalize();
+            }
+            return pluginDir.resolve(path).normalize();
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
+    private static boolean isPluginSkillPathSafe(Path skillPath, Path pluginDir) {
+        if (skillPath == null || pluginDir == null) {
+            return false;
+        }
+
+        Path normalizedSkillPath = skillPath.toAbsolutePath().normalize();
+        Path normalizedPluginDir = pluginDir.toAbsolutePath().normalize();
+
+        if (!normalizedSkillPath.startsWith(normalizedPluginDir)) {
+            return false;
+        }
+
+        if (normalizedSkillPath.equals(normalizedPluginDir)) {
+            return false;
+        }
+
+        return !Files.isSymbolicLink(normalizedSkillPath);
+    }
+
+    private static Path resolvePluginManifestPath(Path pluginDir) {
+        if (pluginDir == null) {
+            return null;
+        }
+        Path claudePluginManifest = pluginDir.resolve(".claude-plugin").resolve("plugin.json");
+        if (Files.isRegularFile(claudePluginManifest)) {
+            return claudePluginManifest;
+        }
+        Path rootManifest = pluginDir.resolve("plugin.json");
+        if (Files.isRegularFile(rootManifest)) {
+            return rootManifest;
+        }
+        return null;
+    }
+
+    private static Map<String, InstalledPlugin> getInstalledPlugins(Path pluginsBase) {
+        Map<String, InstalledPlugin> result = new HashMap<>();
+        if (pluginsBase == null) {
+            return result;
+        }
+
+        Path installedPluginsPath = pluginsBase.resolve("installed_plugins.json");
+        JsonObject root = readJsonObject(installedPluginsPath);
+        if (root == null) {
+            return result;
+        }
+
+        JsonElement pluginsElement = root.get("plugins");
+        if (pluginsElement == null || !pluginsElement.isJsonObject()) {
+            return result;
+        }
+
+        JsonObject plugins = pluginsElement.getAsJsonObject();
+        for (String pluginId : plugins.keySet()) {
+            JsonElement versionsElement = plugins.get(pluginId);
+            if (versionsElement == null || !versionsElement.isJsonArray()) {
+                continue;
+            }
+
+            JsonArray versions = versionsElement.getAsJsonArray();
+            InstalledPlugin fallback = null;
+            for (int i = versions.size() - 1; i >= 0; i--) {
+                JsonElement versionElement = versions.get(i);
+                if (versionElement == null || !versionElement.isJsonObject()) {
+                    continue;
+                }
+
+                InstalledPlugin candidate = toInstalledPlugin(pluginId, versionElement.getAsJsonObject());
+                if (candidate == null) {
+                    continue;
+                }
+                if (fallback == null) {
+                    fallback = candidate;
+                }
+                if (isUsableInstalledPlugin(candidate)) {
+                    result.put(pluginId, candidate);
+                    fallback = null;
+                    break;
+                }
+            }
+
+            if (fallback != null) {
+                result.put(pluginId, fallback);
+            }
+        }
+
+        return result;
+    }
+
+    private static InstalledPlugin toInstalledPlugin(String pluginId, JsonObject versionObj) {
+        JsonElement installPathElement = versionObj.get("installPath");
+        if (installPathElement == null || !installPathElement.isJsonPrimitive()) {
+            return null;
+        }
+
+        String installPath = installPathElement.getAsString();
+        if (installPath == null || installPath.trim().isEmpty()) {
+            return null;
+        }
+
+        String version = versionObj.has("version") && versionObj.get("version").isJsonPrimitive()
+                ? versionObj.get("version").getAsString()
+                : "";
+        return new InstalledPlugin(pluginId, installPath, version);
+    }
+
+    private static boolean isUsableInstalledPlugin(InstalledPlugin plugin) {
+        Path installDir = toNormalizedPath(plugin.installPath());
+        return installDir != null && Files.isDirectory(installDir);
+    }
+
+    private static JsonObject readJsonObject(Path path) {
+        if (path == null || !Files.isRegularFile(path)) {
+            return null;
+        }
+
+        try (var reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            JsonElement parsed = JsonParser.parseReader(reader);
+            if (parsed != null && parsed.isJsonObject()) {
+                return parsed.getAsJsonObject();
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to read JSON: " + path);
+        }
+
+        return null;
+    }
+
+    @SafeVarargs
+    static List<SlashCommand> mergeCommandsInOrder(List<SlashCommand>... commandSources) {
         Map<String, SlashCommand> merged = new LinkedHashMap<>();
-        for (String scope : new String[]{"user", "repo"}) {
-            JsonObject scopeSkills = allSkills.getAsJsonObject(scope);
-            if (scopeSkills == null) continue;
-
-            for (String key : scopeSkills.keySet()) {
-                JsonObject skill = scopeSkills.getAsJsonObject(key);
-
-                // Skip disabled skills
-                if (skill.has("enabled") && !skill.get("enabled").getAsBoolean()) {
-                    continue;
-                }
-                // Skip non-user-invocable skills
-                if (skill.has("userInvocable") && !skill.get("userInvocable").getAsBoolean()) {
-                    continue;
-                }
-
-                String name = skill.has("name") ? skill.get("name").getAsString() : "";
-                String desc = skill.has("description") ? skill.get("description").getAsString() : "";
-                if (!name.isEmpty()) {
-                    merged.put("$" + name, new SlashCommand("$" + name, desc));
-                }
+        for (List<SlashCommand> source : commandSources) {
+            if (source == null) {
+                continue;
+            }
+            for (SlashCommand cmd : source) {
+                merged.put(cmd.name(), cmd);
             }
         }
         return new ArrayList<>(merged.values());
     }
-
 }

--- a/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
+++ b/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
@@ -64,6 +64,7 @@ export function resetSlashCommandsState() {
 interface SDKSlashCommand {
   name: string;
   description?: string;
+  source?: string;
 }
 
 export function setupSlashCommandsCallback() {
@@ -84,7 +85,7 @@ export function setupSlashCommandsCallback() {
             commands = sdkCommands.map(cmd => ({
               id: cmd.name.replace(/^\//, ''),
               label: cmd.name.startsWith('/') ? cmd.name : `/${cmd.name}`,
-              description: cmd.description || '',
+              description: formatCommandDescription(cmd.description || '', cmd.source),
               category: getCategoryFromCommand(cmd.name),
             }));
           } else if (typeof parsed[0] === 'string') {
@@ -232,6 +233,13 @@ function getCategoryFromCommand(name: string): string {
   if (lowerName.includes('speckit')) return 'speckit';
   if (lowerName.includes('cli')) return 'cli';
   return 'user';
+}
+
+function formatCommandDescription(description: string, source?: string): string {
+  if (!source) return description;
+  const suffix = `[${source}]`;
+  if (!description) return suffix;
+  return `${description} ${suffix}`;
 }
 
 function filterCommands(commands: CommandItem[], query: string): CommandItem[] {

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -152,11 +152,6 @@ interface Window {
   onFileListResult?: (json: string) => void;
 
   /**
-   * Command list result callback (for slash command provider)
-   */
-  onCommandListResult?: (json: string) => void;
-
-  /**
    * Update MCP servers list
    */
   updateMcpServers?: (json: string) => void;


### PR DESCRIPTION
Slash command autocomplete was missing many Claude skills, especially skills installed through Claude plugins, because scanning relied on a legacy plugin manifest path and incomplete directory traversal rules.

The previous flow also had a stale get_commands path that was no longer used by the frontend refresh pipeline, which increased complexity and left dead code in FileHandler.

Changes:
- Add multi-directory upward traversal for `.claude/skills` and `.claude/commands` from cwd to home
- Extend skill frontmatter parsing with `paths` and introduce `ConditionalSkillFilter` for context-aware skill visibility
- Pass active editor file path into slash-command resolution from:
  - SessionLifecycleManager startup refresh
  - SettingsHandler provider refresh
- Add additional/managed/plugin skill scanning and merge by source priority in SlashCommandRegistry
- Rework plugin discovery to read `~/.claude/plugins/installed_plugins.json` and resolve manifests from:
  - `<installPath>/.claude-plugin/plugin.json` (primary)
  - `<installPath>/plugin.json` (fallback)
- Support implicit plugin `skills` directory when manifest does not declare `skillsPath` / `skillsPaths`
- Improve installed plugin selection by preferring existing installPath entries and falling back safely
- Add source metadata to slash command JSON and show source suffix in frontend command descriptions
- Remove obsolete `get_commands` handling from FileHandler and remove `window.onCommandListResult` global typing

Root cause: runtime scanning assumed a legacy plugin layout (`~/.claude/plugins/<plugin-id>/plugin.json`) and a single-level local scan strategy, while real plugin installs are versioned under cache with manifest metadata and may require context/path-based filtering.