### PR TITLE
feat: enhance AWS Bedrock configuration support

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -33,6 +33,21 @@ function injectProxyEnvVars(settings) {
 }
 
 /**
+ * Inject all remaining environment variables from settings.json into process.env.
+ * Covers AWS credentials, Bedrock flags, and any other custom vars that the IDE
+ * wouldn't inherit when launched from a desktop launcher.
+ */
+function injectSettingsEnvVars(settings) {
+  if (!settings?.env || typeof settings.env !== 'object') return;
+  for (const [varName, value] of Object.entries(settings.env)) {
+    if (value != null && value !== '' && !process.env[varName]) {
+      process.env[varName] = String(value);
+      debugLog(`[DEBUG] Set ${varName} from settings.json`);
+    }
+  }
+}
+
+/**
  * Read Claude Code configuration.
  */
 export function loadClaudeSettings() {
@@ -161,6 +176,7 @@ export function setupApiKey() {
 
   // Inject proxy env vars early, before any auth logic or network operations
   injectProxyEnvVars(settings);
+  injectSettingsEnvVars(settings);
 
   let apiKey;
   let baseUrl;

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -59,6 +59,7 @@ import { join } from 'path';
 import { getMcpServersStatus, loadMcpServersConfig, getMcpServerTools as getMcpServerToolsImpl } from './mcp-status/index.js';
 
 import { setupApiKey, isCustomBaseUrl, loadClaudeSettings } from '../../config/api-config.js';
+import { isAwsTokenExpiredError, runAwsTokenRefresh } from '../../utils/aws-auth.js';
 import { selectWorkingDirectory, getRealHomeDir, getClaudeDir } from '../../utils/path-utils.js';
 import { mapModelIdToSdkName, setModelEnvironmentVariables, resolveModelFromSettings } from '../../utils/model-utils.js';
 import { AsyncStream } from '../../utils/async-stream.js';
@@ -1146,11 +1147,28 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
 
     console.log('[DEBUG] Calling messages.create() with non-streaming API...');
 
-    const response = await client.messages.create({
-      model: modelId,
-      max_tokens: 8192,
-      messages: messagesForApi
-    });
+    let response;
+    try {
+      response = await client.messages.create({
+        model: modelId,
+        max_tokens: 8192,
+        messages: messagesForApi
+      });
+    } catch (apiError) {
+      if (authType === 'aws_bedrock' && isAwsTokenExpiredError(apiError) && runAwsTokenRefresh()) {
+        console.log('[AWS_REFRESH] Retrying with refreshed credentials...');
+        const bedrockModule = await ensureBedrockSdk();
+        const AnthropicBedrock = bedrockModule.AnthropicBedrock || bedrockModule.default || bedrockModule;
+        client = new AnthropicBedrock();
+        response = await client.messages.create({
+          model: modelId,
+          max_tokens: 8192,
+          messages: messagesForApi
+        });
+      } else {
+        throw apiError;
+      }
+    }
 
     console.log('[DEBUG] API response received');
 

--- a/ai-bridge/utils/aws-auth.js
+++ b/ai-bridge/utils/aws-auth.js
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process';
+
+/**
+ * Detect whether an error is an AWS token expiry (403 ExpiredTokenException).
+ */
+export function isAwsTokenExpiredError(error) {
+  const msg = error?.message || String(error);
+  return msg.includes('ExpiredTokenException')
+      || (msg.includes('security token') && msg.includes('expired'));
+}
+
+/**
+ * Run the AWS token refresh command from process.env.awsAuthRefresh.
+ * Returns true if refresh succeeded, false if not configured or failed.
+ */
+export function runAwsTokenRefresh() {
+  const cmd = process.env.awsAuthRefresh;
+  if (!cmd) return false;
+  try {
+    execSync(cmd, { timeout: 30000, stdio: 'pipe' });
+    console.log('[AWS_REFRESH] Token refresh succeeded');
+    return true;
+  } catch (e) {
+    console.error('[AWS_REFRESH] Token refresh failed:', e.message);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- **New `injectSettingsEnvVars()`**: Adds a new function alongside the existing `injectProxyEnvVars()`, called sequentially from `setupApiKey()`. Injects all remaining environment variables from `settings.json` into `process.env` — covers AWS credentials, Bedrock flags, and any custom vars the IDE wouldn't inherit when launched from a desktop launcher
- **New `aws-auth.js` utility**: Detects `ExpiredTokenException` / expired security token errors and runs the `awsAuthRefresh` command configured in settings
- **Automatic token refresh retry**: `sendMessageWithAnthropicSDK` now catches AWS token-expired errors, attempts a credential refresh via `awsAuthRefresh`, and retries the API call transparently

## Changes

| File | Change |
|------|--------|
| `ai-bridge/config/api-config.js` | Add `injectSettingsEnvVars()` after `injectProxyEnvVars()` (unchanged); call both sequentially in `setupApiKey()` |
| `ai-bridge/utils/aws-auth.js` | New utility: `isAwsTokenExpiredError()` + `runAwsTokenRefresh()` |
| `ai-bridge/services/claude/message-service.js` | Wrap `messages.create()` in try/catch; auto-refresh and retry on token expiry |

## Motivation

IDEs launched via a desktop launcher don't inherit shell environment variables (AWS credentials, Bedrock flags, proxy config, etc.). `injectSettingsEnvVars()` ensures all variables from `settings.json` are propagated into `process.env` before the SDK initializes, complementing the existing proxy-specific injection. The token refresh logic handles the common case where short-lived AWS session tokens expire mid-session.

## Test Plan

- [x] Verify AWS credentials and Bedrock flags from `settings.json` env section are injected into `process.env` before SDK init
- [x] Confirm existing proxy var injection (`injectProxyEnvVars`) is unaffected
- [ ] Simulate an expired AWS token and confirm the `awsAuthRefresh` command runs and the request retries successfully
- [x] Test with IDE desktop launcher scenario (no shell env var inheritance)