### PR TITLE
fix: accumulate streaming token usage from message_start and message_delta events

### DIFF
--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -67,6 +67,7 @@ import { persistJsonlMessage, loadSessionHistory } from './session-service.js';
 import { loadAttachments, buildContentBlocks } from './attachment-service.js';
 import { buildIDEContextPrompt } from '../system-prompts.js';
 import { buildQuickFixPrompt } from '../quickfix-prompts.js';
+import { mergeUsage, emitAccumulatedUsage } from '../../utils/usage-utils.js';
 
 // Store active query results for rewind operations
 // Key: sessionId, Value: query result object
@@ -739,6 +740,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       let hasStreamEvents = false;
       let lastAssistantContent = '';
       let lastThinkingContent = '';
+      let accumulatedUsage = null;
 
       // Only log retry attempts (not the first attempt)
       if (retryAttempt > 0) {
@@ -805,6 +807,17 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
         const event = msg.event;
 
         if (event) {
+          // message_start: accumulate input_tokens, cache_*_tokens
+          if (event.type === 'message_start' && event.message?.usage) {
+            accumulatedUsage = mergeUsage(accumulatedUsage, event.message.usage);
+          }
+
+          // message_delta: accumulate output_tokens and emit [USAGE] tag
+          if (event.type === 'message_delta' && event.usage) {
+            accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+            emitAccumulatedUsage(accumulatedUsage);
+          }
+
           // content_block_delta: text or JSON incremental update
           if (event.type === 'content_block_delta' && event.delta) {
             if (event.delta.type === 'text_delta' && event.delta.text) {
@@ -1464,6 +1477,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
       let hasStreamEvents = false;
       let lastAssistantContent = '';
       let lastThinkingContent = '';
+      let accumulatedUsage = null;
 
       // Only log retry attempts (not the first attempt)
       if (retryAttempt > 0) {
@@ -1529,6 +1543,17 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
 		        const event = msg.event;
 
 		        if (event) {
+		          // message_start: accumulate input_tokens, cache_*_tokens
+		          if (event.type === 'message_start' && event.message?.usage) {
+		            accumulatedUsage = mergeUsage(accumulatedUsage, event.message.usage);
+		          }
+
+		          // message_delta: accumulate output_tokens and emit [USAGE] tag
+		          if (event.type === 'message_delta' && event.usage) {
+		            accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+		            emitAccumulatedUsage(accumulatedUsage);
+		          }
+
 		          // content_block_delta: text or JSON incremental update
 		          if (event.type === 'content_block_delta' && event.delta) {
 		            if (event.delta.type === 'text_delta' && event.delta.text) {

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -14,6 +14,7 @@ import { canUseTool, requestPlanApproval } from '../../permission-handler.js';
 import { loadAttachments, buildContentBlocks } from './attachment-service.js';
 import { buildIDEContextPrompt } from '../system-prompts.js';
 import { buildQuickFixPrompt } from '../quickfix-prompts.js';
+import { mergeUsage, emitAccumulatedUsage } from '../../utils/usage-utils.js';
 import { registerActiveQueryResult, removeSession } from './message-service.js';
 
 const runtimesBySessionId = new Map();
@@ -590,6 +591,18 @@ function processStreamEvent(msg, turnState) {
   const event = msg.event;
   if (!event) return;
 
+  // Handle message_start: accumulate input_tokens, cache_*_tokens
+  if (event.type === 'message_start' && event.message?.usage) {
+    turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.message.usage);
+  }
+
+  // Handle message_delta: accumulate output_tokens and emit [USAGE] tag
+  if (event.type === 'message_delta' && event.usage) {
+    turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.usage);
+    emitAccumulatedUsage(turnState.accumulatedUsage);
+  }
+
+  // Handle content_block_delta: text and thinking deltas
   if (event.type === 'content_block_delta' && event.delta) {
     if (event.delta.type === 'text_delta' && event.delta.text) {
       process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(event.delta.text)}\n`);
@@ -692,7 +705,8 @@ async function executeTurn(runtime, requestContext, turnMeta) {
     hasStreamEvents: false,
     lastAssistantContent: '',
     lastThinkingContent: '',
-    finalSessionId: requestContext.requestedSessionId || runtime.sessionId || ''
+    finalSessionId: requestContext.requestedSessionId || runtime.sessionId || '',
+    accumulatedUsage: null
   };
   if (turnMeta) {
     turnMeta.state = turnState;

--- a/ai-bridge/utils/usage-utils.js
+++ b/ai-bridge/utils/usage-utils.js
@@ -1,0 +1,44 @@
+/**
+ * Shared usage accumulation utilities for streaming token tracking.
+ * Used by message-service.js and persistent-query-service.js.
+ */
+
+export const DEFAULT_USAGE = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0
+};
+
+/**
+ * Merge usage data following CLI's nz6() logic.
+ * - input_tokens, cache_*: only update if new value > 0 (preserve accumulated)
+ * - output_tokens: use new value directly (incremental updates)
+ */
+export function mergeUsage(accumulated, newUsage) {
+  if (!newUsage) return accumulated || { ...DEFAULT_USAGE };
+  if (!accumulated) return { ...DEFAULT_USAGE, ...newUsage };
+  return {
+    input_tokens: newUsage.input_tokens > 0 ? newUsage.input_tokens : accumulated.input_tokens,
+    cache_creation_input_tokens: newUsage.cache_creation_input_tokens > 0
+      ? newUsage.cache_creation_input_tokens : accumulated.cache_creation_input_tokens,
+    cache_read_input_tokens: newUsage.cache_read_input_tokens > 0
+      ? newUsage.cache_read_input_tokens : accumulated.cache_read_input_tokens,
+    output_tokens: newUsage.output_tokens ?? accumulated.output_tokens
+  };
+}
+
+/**
+ * Emit [USAGE] tag from accumulated usage data during streaming.
+ * NOTE: The console.log below is intentional IPC — the Java backend parses
+ * stdout lines starting with "[USAGE]" to extract token metrics.
+ */
+export function emitAccumulatedUsage(accumulated) {
+  if (!accumulated) return;
+  console.log('[USAGE]', JSON.stringify({
+    input_tokens: accumulated.input_tokens || 0,
+    output_tokens: accumulated.output_tokens || 0,
+    cache_creation_input_tokens: accumulated.cache_creation_input_tokens || 0,
+    cache_read_input_tokens: accumulated.cache_read_input_tokens || 0
+  }));
+}


### PR DESCRIPTION
Previously, token usage was always 0 during streaming because processStreamEvent() only handled content_block_delta events and ignored message_start/message_delta, which carry the actual usage data from the Anthropic API.

- Add mergeUsage() following CLI's nz6() logic: input/cache tokens preserved from message_start, output tokens updated incrementally from message_delta
- Emit [USAGE] IPC tag at message_delta so Java layer receives real-time token counts during streaming
- Extract DEFAULT_USAGE, mergeUsage, emitAccumulatedUsage to shared ai-bridge/utils/usage-utils.js, eliminating duplication between message-service.js and persistent-query-service.js