### PR TITLE
fix: support Ctrl+C/X/V in native input and textarea elements

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/ChatPasteAction.java
+++ b/src/main/java/com/github/claudecodegui/action/ChatPasteAction.java
@@ -13,7 +13,8 @@ import java.awt.datatransfer.DataFlavor;
 
 /**
  * IDEA Action for Ctrl+V in the Claude chat tool window.
- * Reads system clipboard and inserts text at cursor in the focused contenteditable element.
+ * Reads system clipboard and inserts text at the cursor in the focused element,
+ * supporting contenteditable divs, input fields, and textareas.
  */
 public class ChatPasteAction extends ChatToolWindowAction {
 
@@ -39,6 +40,10 @@ public class ChatPasteAction extends ChatToolWindowAction {
                 "  var el=document.activeElement;" +
                 "  if(el&&el.getAttribute('contenteditable')==='true'){" +
                 "    document.execCommand('insertText',false,txt);" +
+                "  } else if(el&&(el.tagName==='INPUT'||el.tagName==='TEXTAREA')){" +
+                "    var s=el.selectionStart,e=el.selectionEnd;" +
+                "    el.setRangeText(txt,s,e,'end');" +
+                "    el.dispatchEvent(new Event('input',{bubbles:true}));" +
                 "  } else if(window.onClipboardRead){" +
                 "    var cb=window.onClipboardRead;" +
                 "    window.onClipboardRead=undefined;" +

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1503,19 +1503,37 @@ const App = () => {
     window.execContextAction = (action: string) => {
       switch (action) {
         case 'copy': {
-          const sel = window.getSelection();
-          const text = sel?.toString() ?? '';
+          const activeEl = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+          let text = '';
+          if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA')) {
+            text = activeEl.value.substring(activeEl.selectionStart ?? 0, activeEl.selectionEnd ?? 0);
+          } else {
+            text = window.getSelection()?.toString() ?? '';
+          }
           if (text) {
             sendBridgeEvent('write_clipboard', text);
           }
           break;
         }
         case 'cut': {
-          const sel = window.getSelection();
-          const text = sel?.toString() ?? '';
+          const activeEl = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+          let text = '';
+          if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA')) {
+            const start = activeEl.selectionStart ?? 0;
+            const end = activeEl.selectionEnd ?? 0;
+            text = activeEl.value.substring(start, end);
+            if (text) {
+              activeEl.setRangeText('', start, end, 'end');
+              activeEl.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+          } else {
+            text = window.getSelection()?.toString() ?? '';
+            if (text) {
+              document.execCommand('delete');
+            }
+          }
           if (text) {
             sendBridgeEvent('write_clipboard', text);
-            document.execCommand('delete');
           }
           break;
         }


### PR DESCRIPTION
Previously, clipboard shortcuts only worked in contenteditable divs (the chat input box). Ctrl+V in settings page input fields was silently dropped, and Ctrl+C/X used window.getSelection() which cannot read selected text from native <input> and <textarea> elements.

- ChatPasteAction: add setRangeText branch for INPUT/TEXTAREA elements
- App.tsx copy/cut: detect active element type and use selectionStart/ selectionEnd for native form fields instead of window.getSelection()