### PR TITLE
fix: preserve Node.js version cache when new IDEA window opens

### DIFF
--- a/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
+++ b/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
@@ -634,30 +634,18 @@ public class NodeDetector {
 
     /**
      * Manually sets the Node.js executable path.
-     * When setting a non-null path, verifies it and caches the detection result
-     * to ensure getCachedNodeVersion() returns a valid value.
-     * When setting null, clears both caches.
+     * Clears the cached detection result when the path changes,
+     * but preserves it when the same path is set again to avoid losing version info.
      */
     public void setNodeExecutable(String path) {
         synchronized (this.cacheLock) {
             this.clearInFlightLocked();
             this.cachedNodeExecutable = path;
-            if (path == null || path.isEmpty()) {
+            // Preserve detection result if the path is unchanged (e.g. re-set on new window init).
+            // Only clear when the path actually differs or is null, to avoid discarding version info.
+            if (path == null || this.cachedDetectionResult == null
+                    || !path.equals(this.cachedDetectionResult.getNodePath())) {
                 this.cachedDetectionResult = null;
-            } else if (this.cachedDetectionResult == null
-                       || !path.equals(this.cachedDetectionResult.getNodePath())) {
-                // Path changed or no cached result — verify and cache synchronously.
-                // This runs outside the lock via verifyNodePath (which only reads).
-                // We temporarily release nothing here because verifyNodePath is safe to call under lock
-                // (it spawns a child process but doesn't re-acquire cacheLock).
-                String version = verifyNodePath(path);
-                if (version != null) {
-                    this.cachedDetectionResult = NodeDetectionResult.success(
-                            path, version, NodeDetectionResult.DetectionMethod.KNOWN_PATH);
-                }
-                // If verification fails, preserve existing cachedDetectionResult
-                // rather than clearing it — this avoids the race condition where
-                // SessionHandler.getCachedNodeVersion() returns null.
             }
         }
     }

--- a/src/main/java/com/github/claudecodegui/handler/DependencyHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/DependencyHandler.java
@@ -119,7 +119,7 @@ public class DependencyHandler extends BaseMessageHandler {
                 }
 
                 NodeDetectionResult result = this.nodeDetector.verifyAndCacheNodePath(configuredNodePath);
-                if (result != null && result.isFound()) {
+                if (result.isFound()) {
                     LOG.info("[DependencyHandler] Using configured Node.js path: " +
                              configuredNodePath + " (" + result.getNodeVersion() + ")");
                 } else {

--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.handler;
 
 import com.github.claudecodegui.ClaudeSession;
 import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.model.NodeDetectionResult;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -65,11 +66,36 @@ public class SessionHandler extends BaseMessageHandler {
     }
 
     /**
+     * Resolves the cached Node.js version, attempting recovery when the cache is stale.
+     * If the version is absent but a cached path exists, re-verifies the path to restore
+     * the detection result (e.g. after a new window resets the cache via setNodeExecutable).
+     *
+     * @return the Node.js version string, or null if detection fails entirely
+     */
+    private String resolveNodeVersion() {
+        String nodeVersion = context.getClaudeSDKBridge().getCachedNodeVersion();
+        if (nodeVersion != null) {
+            return nodeVersion;
+        }
+        // Version absent — try to recover using the cached path (path may still be valid).
+        String cachedPath = context.getClaudeSDKBridge().getCachedNodePath();
+        if (cachedPath == null || cachedPath.isEmpty()) {
+            return null;
+        }
+        LOG.info("[SessionHandler] Node version cache miss, re-verifying path: " + cachedPath);
+        NodeDetectionResult recovery = context.getClaudeSDKBridge().verifyAndCacheNodePath(cachedPath);
+        if (recovery != null && recovery.isFound()) {
+            return recovery.getNodeVersion();
+        }
+        return null;
+    }
+
+    /**
      * Send message to Claude
      * [FIX] Now parses JSON format to extract text, agent info and file tags
      */
     private void handleSendMessage(String content) {
-        String nodeVersion = context.getClaudeSDKBridge().getCachedNodeVersion();
+        String nodeVersion = this.resolveNodeVersion();
         if (nodeVersion == null) {
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("addErrorMessage", escapeJs("未检测到有效的 Node.js 版本，请在设置中配置或重新打开工具窗口。"));
@@ -265,7 +291,7 @@ public class SessionHandler extends BaseMessageHandler {
         String requestedPermissionMode
     ) {
         // Version check (consistent with handleSendMessage)
-        String nodeVersion = context.getClaudeSDKBridge().getCachedNodeVersion();
+        String nodeVersion = this.resolveNodeVersion();
         if (nodeVersion == null) {
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("addErrorMessage", escapeJs("未检测到有效的 Node.js 版本，请在设置中配置或重新打开工具窗口。"));


### PR DESCRIPTION
When a new project window opened, DependencyHandler.ensureInitializedAsync() called setNodeExecutable() after verifying the configured path. This unconditionally cleared cachedDetectionResult (which holds the version string), causing SessionHandler to reject all messages with "Node.js version not detected" until the user re-saved the path in Settings.

- DependencyHandler: replace verifyNodePath() + setNodeExecutable() with a single verifyAndCacheNodePath() call, which caches both path and version
- NodeDetector: preserve cachedDetectionResult in setNodeExecutable() when the path being set matches the already-cached path, avoiding unnecessary version cache invalidation across windows
- SessionHandler: add resolveNodeVersion() fallback that re-verifies the cached path when getCachedNodeVersion() returns null, making the version check resilient to transient cache staleness