### PR TITLE
fix: replace type assertions with runtime type checks to prevent crashes

### DIFF
--- a/webview/src/components/toolBlocks/BashToolBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.tsx
@@ -19,8 +19,8 @@ const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
     return null;
   }
 
-  const command = (input.command as string | undefined) ?? '';
-  const description = (input.description as string | undefined) ?? '';
+  const command = typeof input.command === 'string' ? input.command : '';
+  const description = typeof input.description === 'string' ? input.description : '';
 
   const isDenied = useIsToolDenied(toolId);
 

--- a/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
@@ -44,8 +44,8 @@ function parseBashItem(
   const { input, result, toolId } = item;
   if (!input) return null;
 
-  const command = (input.command as string | undefined) ?? '';
-  const description = (input.description as string | undefined) ?? '';
+  const command = typeof input.command === 'string' ? input.command : '';
+  const description = typeof input.description === 'string' ? input.description : '';
 
   let output = '';
   if (result) {

--- a/webview/src/components/toolBlocks/EditToolBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolBlock.tsx
@@ -107,19 +107,19 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
   const isError = isDenied || (isCompleted && result?.is_error === true);
 
   const filePath =
-    (input?.file_path as string | undefined) ??
-    (input?.filePath as string | undefined) ??
-    (input?.path as string | undefined) ??
-    (input?.target_file as string | undefined) ??
-    (input?.targetFile as string | undefined);
+    (typeof input?.file_path === 'string' ? input.file_path : undefined) ??
+    (typeof input?.filePath === 'string' ? input.filePath : undefined) ??
+    (typeof input?.path === 'string' ? input.path : undefined) ??
+    (typeof input?.target_file === 'string' ? input.target_file : undefined) ??
+    (typeof input?.targetFile === 'string' ? input.targetFile : undefined);
 
   const oldString =
-    (input?.old_string as string | undefined) ??
-    (input?.oldString as string | undefined) ??
+    (typeof input?.old_string === 'string' ? input.old_string : undefined) ??
+    (typeof input?.oldString === 'string' ? input.oldString : undefined) ??
     '';
   const newString =
-    (input?.new_string as string | undefined) ??
-    (input?.newString as string | undefined) ??
+    (typeof input?.new_string === 'string' ? input.new_string : undefined) ??
+    (typeof input?.newString === 'string' ? input.newString : undefined) ??
     '';
 
   const diff = useMemo(() => {

--- a/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
@@ -87,22 +87,23 @@ function parseEditItem(item: { name?: string; input?: ToolInput; result?: ToolRe
   const { input, result } = item;
   if (!input) return null;
 
+  // Extract file path (ensure it is a string, not an object)
   const filePath =
-    (input.file_path as string | undefined) ??
-    (input.filePath as string | undefined) ??
-    (input.path as string | undefined) ??
-    (input.target_file as string | undefined) ??
-    (input.targetFile as string | undefined);
+    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+    (typeof input.filePath === 'string' ? input.filePath : undefined) ??
+    (typeof input.path === 'string' ? input.path : undefined) ??
+    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+    (typeof input.targetFile === 'string' ? input.targetFile : undefined);
 
   if (!filePath) return null;
 
   const oldString =
-    (input.old_string as string | undefined) ??
-    (input.oldString as string | undefined) ??
+    (typeof input.old_string === 'string' ? input.old_string : undefined) ??
+    (typeof input.oldString === 'string' ? input.oldString : undefined) ??
     '';
   const newString =
-    (input.new_string as string | undefined) ??
-    (input.newString as string | undefined) ??
+    (typeof input.new_string === 'string' ? input.new_string : undefined) ??
+    (typeof input.newString === 'string' ? input.newString : undefined) ??
     '';
 
   const { additions, deletions } = computeDiffStats(oldString, newString);

--- a/webview/src/components/toolBlocks/GenericToolBlock.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.tsx
@@ -185,19 +185,24 @@ const extractFilePathFromCommand = (command: string | undefined, workdir?: strin
 };
 
 const pickFilePath = (input: ToolInput, name?: string) => {
-  // First try standard file path fields
-  const standardPath = (input.file_path as string | undefined) ??
-    (input.path as string | undefined) ??
-    (input.target_file as string | undefined) ??
-    (input.notebook_path as string | undefined);
+  // First try standard file path fields (ensure they are strings, not objects)
+  const pathValue = input.path;
+  const filePathValue = input.file_path;
+  const targetFileValue = input.target_file;
+  const notebookPathValue = input.notebook_path;
+
+  const standardPath = (typeof filePathValue === 'string' ? filePathValue : undefined) ??
+    (typeof pathValue === 'string' ? pathValue : undefined) ??
+    (typeof targetFileValue === 'string' ? targetFileValue : undefined) ??
+    (typeof notebookPathValue === 'string' ? notebookPathValue : undefined);
 
   if (standardPath) return standardPath;
 
   // For Codex read or shell_command commands, extract from command string
   const lowerName = (name ?? '').toLowerCase();
-  if ((lowerName === 'read' || lowerName === 'shell_command') && input.command) {
-    const workdir = (input.workdir as string | undefined) ?? undefined;
-    return extractFilePathFromCommand(input.command as string, workdir);
+  if ((lowerName === 'read' || lowerName === 'shell_command') && typeof input.command === 'string') {
+    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
+    return extractFilePathFromCommand(input.command, workdir);
   }
 
   return undefined;

--- a/webview/src/components/toolBlocks/ReadToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolBlock.tsx
@@ -94,16 +94,16 @@ const ReadToolBlock = ({ input }: ReadToolBlockProps) => {
     return null;
   }
 
-  // Try standard file path fields first
+  // Try standard file path fields first (ensure they are strings, not objects)
   let filePath =
-    (input.file_path as string | undefined) ??
-    (input.target_file as string | undefined) ??
-    (input.path as string | undefined);
+    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+    (typeof input.path === 'string' ? input.path : undefined);
 
   // If not found, try extracting from Codex command
-  if (!filePath && input.command) {
-    const workdir = (input.workdir as string | undefined) ?? undefined;
-    filePath = extractFilePathFromCommand(input.command as string, workdir);
+  if (!filePath && typeof input.command === 'string') {
+    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
+    filePath = extractFilePathFromCommand(input.command, workdir);
   }
 
   // Remove line number suffix for display

--- a/webview/src/components/toolBlocks/ReadToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolGroupBlock.tsx
@@ -31,16 +31,16 @@ const ITEM_HEIGHT = 28;
  * Extract file path from tool input
  */
 const extractFilePath = (input: ToolInput): string | undefined => {
-  // Try standard file path fields first
+  // Try standard file path fields first (ensure they are strings, not objects)
   let filePath =
-    (input.file_path as string | undefined) ??
-    (input.target_file as string | undefined) ??
-    (input.path as string | undefined);
+    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+    (typeof input.path === 'string' ? input.path : undefined);
 
   // If not found, try extracting from Codex command
-  if (!filePath && input.command) {
-    const workdir = (input.workdir as string | undefined) ?? undefined;
-    filePath = extractFilePathFromCommand(input.command as string, workdir);
+  if (!filePath && typeof input.command === 'string') {
+    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
+    filePath = extractFilePathFromCommand(input.command, workdir);
   }
 
   return filePath;

--- a/webview/src/components/toolBlocks/SearchToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/SearchToolGroupBlock.tsx
@@ -43,18 +43,18 @@ const parseSearchItem = (item: { name?: string; input?: ToolInput; result?: Tool
 
   const toolName = name ?? 'search';
 
-  // Extract search pattern from various fields
+  // Extract search pattern from various fields (ensure they are strings)
   const pattern =
-    (input.pattern as string | undefined) ??
-    (input.search_term as string | undefined) ??
-    (input.query as string | undefined) ??
-    (input.regex as string | undefined) ??
+    (typeof input.pattern === 'string' ? input.pattern : undefined) ??
+    (typeof input.search_term === 'string' ? input.search_term : undefined) ??
+    (typeof input.query === 'string' ? input.query : undefined) ??
+    (typeof input.regex === 'string' ? input.regex : undefined) ??
     '';
 
-  // Extract search path
+  // Extract search path (ensure it is a string, not an object)
   const path =
-    (input.path as string | undefined) ??
-    (input.directory as string | undefined) ??
+    (typeof input.path === 'string' ? input.path : undefined) ??
+    (typeof input.directory === 'string' ? input.directory : undefined) ??
     '';
 
   const isCompleted = result !== undefined && result !== null;

--- a/webview/src/hooks/useFileChanges.ts
+++ b/webview/src/hooks/useFileChanges.ts
@@ -124,15 +124,22 @@ function computeLcsDiff(
 
 /**
  * Extract file path from tool input (handles various naming conventions)
+ * Ensures the returned value is a string, not an object (e.g., MCP tool path can be an object)
  */
 function extractFilePath(input: Record<string, unknown>): string | null {
+  const pathValue = input.path;
+  const filePathValue = input.file_path;
+  const targetFileValue = input.target_file;
+  const targetFileValue2 = input.targetFile;
+  const notebookPathValue = input.notebook_path;
+
   return (
-    (input.file_path as string | undefined) ??
-    (input.filePath as string | undefined) ??
-    (input.path as string | undefined) ??
-    (input.target_file as string | undefined) ??
-    (input.targetFile as string | undefined) ??
-    (input.notebook_path as string | undefined) ??
+    (typeof input.filePath === 'string' ? input.filePath : undefined) ??
+    (typeof filePathValue === 'string' ? filePathValue : undefined) ??
+    (typeof pathValue === 'string' ? pathValue : undefined) ??
+    (typeof targetFileValue === 'string' ? targetFileValue : undefined) ??
+    (typeof targetFileValue2 === 'string' ? targetFileValue2 : undefined) ??
+    (typeof notebookPathValue === 'string' ? notebookPathValue : undefined) ??
     null
   );
 }
@@ -142,15 +149,15 @@ function extractFilePath(input: Record<string, unknown>): string | null {
  */
 function extractStrings(input: Record<string, unknown>): { oldString: string; newString: string; replaceAll?: boolean } {
   const oldString =
-    (input.old_string as string | undefined) ??
-    (input.oldString as string | undefined) ??
+    (typeof input.old_string === 'string' ? input.old_string : undefined) ??
+    (typeof input.oldString === 'string' ? input.oldString : undefined) ??
     '';
   const newString =
-    (input.new_string as string | undefined) ??
-    (input.newString as string | undefined) ??
-    (input.content as string | undefined) ?? // Write tool uses 'content'
+    (typeof input.new_string === 'string' ? input.new_string : undefined) ??
+    (typeof input.newString === 'string' ? input.newString : undefined) ??
+    (typeof input.content === 'string' ? input.content : undefined) ?? // Write tool uses 'content'
     '';
-  const replaceAll = input.replace_all as boolean | undefined ?? input.replaceAll as boolean | undefined;
+  const replaceAll = typeof input.replace_all === 'boolean' ? input.replace_all : (typeof input.replaceAll === 'boolean' ? input.replaceAll : undefined);
 
   return { oldString, newString, replaceAll };
 }

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -184,7 +184,8 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     const getRawUuid = (msg: ClaudeMessage | undefined): string | undefined => {
       const raw = msg?.raw;
       if (!raw || typeof raw !== 'object') return undefined;
-      return (raw as any).uuid as string | undefined;
+      const rawObj = raw as Record<string, unknown>;
+      return typeof rawObj.uuid === 'string' ? rawObj.uuid : undefined;
     };
 
     const stripUuidFromRaw = (raw: unknown): unknown => {

--- a/webview/src/utils/helpers.ts
+++ b/webview/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 export const getFileName = (filePath?: string | null) => {
-  if (!filePath) {
+  if (!filePath || typeof filePath !== 'string') {
     return '';
   }
   const segments = filePath.split(/[\\/]/);
@@ -14,8 +14,8 @@ export const formatParamValue = (value: unknown) => {
 };
 
 export const truncate = (text: string, maxLength = 60) => {
-  if (text.length <= maxLength) {
-    return text;
+  if (typeof text !== 'string' || text.length <= maxLength) {
+    return text || '';
   }
   return `${text.substring(0, maxLength)}...`;
 };


### PR DESCRIPTION
Replace unsafe type assertions (as string | undefined) with runtime type checks (typeof === 'string') across tool block components and utility functions. This prevents crashes when MCP tools pass objects instead of strings for path fields.

Fixed files:
- GenericToolBlock.tsx: pickFilePath() function
- useFileChanges.ts: extractStrings() function
- ReadToolBlock.tsx, ReadToolGroupBlock.tsx: command extraction
- BashToolBlock.tsx, BashToolGroupBlock.tsx: command/description fields
- EditToolBlock.tsx: file path and string extraction
- useWindowCallbacks.ts: getRawUuid() function
- helpers.ts: getFileName() and truncate() functions

This resolves JCEF crashes when loading imported session records containing MCP tool calls with non-string path values.

Fixes #565 #477