### PR TITLE
fix: defer JCEF browser creation to avoid service initialization conflict

### DIFF
--- a/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
@@ -149,8 +149,19 @@ public class ClaudeChatWindow {
         setupSessionCallbacks();
         initializeSessionInfo();
         webviewInitializer.overrideBridgePathIfAvailable();
-        webviewInitializer.createUIComponents();
-        registerSessionLoadListener();
+
+        // Delay JCEF browser creation to avoid service initialization conflicts
+        // during JBCefApp$Holder class init (ProxyMigrationService dependency).
+        // Operations that depend on browser readiness are also deferred.
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!disposed) {
+                webviewInitializer.createUIComponents();
+                registerSessionLoadListener();
+                this.initialized = true;
+                LOG.info("Window instance fully initialized, project: " + project.getName());
+            }
+        });
+
         if (!skipRegister) {
             registerInstance();
         }
@@ -158,9 +169,6 @@ public class ClaudeChatWindow {
 
         // Sync IDEA keymap for ChatSendAction based on current sendShortcut setting
         SendShortcutSync.syncFromSettings();
-
-        this.initialized = true;
-        LOG.info("Window instance fully initialized, project: " + project.getName());
     }
 
     // ==================== Public API ====================


### PR DESCRIPTION
Delay webviewInitializer.createUIComponents() via invokeLater to prevent JBCefApp$Holder from requesting ProxyMigrationService during class init. Also defer registerSessionLoadListener() and initialized flag to ensure browser is ready before accepting session load requests.

Fixes #568