### PR TITLE
fix: align token usage display with CLI behavior and notify webview on stream end

### DIFF
--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -4,13 +4,32 @@
  */
 
 // Dynamic SDK loading - loaded on demand instead of static imports
-import {
-    loadClaudeSdk,
-    loadAnthropicSdk,
-    loadBedrockSdk,
-    isClaudeSdkAvailable
-} from '../../utils/sdk-loader.js';
+import { isClaudeSdkAvailable, loadAnthropicSdk, loadBedrockSdk, loadClaudeSdk } from '../../utils/sdk-loader.js';
 import { randomUUID } from 'crypto';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import {
+  getMcpServersStatus,
+  getMcpServerTools as getMcpServerToolsImpl,
+  loadMcpServersConfig
+} from './mcp-status/index.js';
+
+import { isCustomBaseUrl, loadClaudeSettings, setupApiKey } from '../../config/api-config.js';
+import { getClaudeDir, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
+import {
+  mapModelIdToSdkName,
+  resolveModelFromSettings,
+  setModelEnvironmentVariables
+} from '../../utils/model-utils.js';
+import { AsyncStream } from '../../utils/async-stream.js';
+import { canUseTool, requestPlanApproval } from '../../permission-handler.js';
+import { loadSessionHistory, persistJsonlMessage } from './session-service.js';
+import { buildContentBlocks, loadAttachments } from './attachment-service.js';
+import { buildIDEContextPrompt } from '../system-prompts.js';
+import { buildQuickFixPrompt } from '../quickfix-prompts.js';
+import { emitAccumulatedUsage, mergeUsage } from '../../utils/usage-utils.js';
 
 // SDK cache
 let claudeSdk = null;
@@ -21,53 +40,37 @@ let bedrockSdk = null;
  * Ensure Claude SDK is loaded
  */
 async function ensureClaudeSdk() {
-    if (!claudeSdk) {
-        if (!isClaudeSdkAvailable()) {
-            const error = new Error('Claude Code SDK not installed. Please install via Settings > Dependencies.');
-            error.code = 'SDK_NOT_INSTALLED';
-            error.provider = 'claude';
-            throw error;
-        }
-        claudeSdk = await loadClaudeSdk();
+  if (!claudeSdk) {
+    if (!isClaudeSdkAvailable()) {
+      const error = new Error('Claude Code SDK not installed. Please install via Settings > Dependencies.');
+      error.code = 'SDK_NOT_INSTALLED';
+      error.provider = 'claude';
+      throw error;
     }
-    return claudeSdk;
+    claudeSdk = await loadClaudeSdk();
+  }
+  return claudeSdk;
 }
 
 /**
  * Ensure Anthropic SDK is loaded
  */
 async function ensureAnthropicSdk() {
-    if (!anthropicSdk) {
-        anthropicSdk = await loadAnthropicSdk();
-    }
-    return anthropicSdk;
+  if (!anthropicSdk) {
+    anthropicSdk = await loadAnthropicSdk();
+  }
+  return anthropicSdk;
 }
 
 /**
  * Ensure Bedrock SDK is loaded
  */
 async function ensureBedrockSdk() {
-    if (!bedrockSdk) {
-        bedrockSdk = await loadBedrockSdk();
-    }
-    return bedrockSdk;
+  if (!bedrockSdk) {
+    bedrockSdk = await loadBedrockSdk();
+  }
+  return bedrockSdk;
 }
-import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
-import { join } from 'path';
-
-import { getMcpServersStatus, loadMcpServersConfig, getMcpServerTools as getMcpServerToolsImpl } from './mcp-status/index.js';
-
-import { setupApiKey, isCustomBaseUrl, loadClaudeSettings } from '../../config/api-config.js';
-import { selectWorkingDirectory, getRealHomeDir, getClaudeDir } from '../../utils/path-utils.js';
-import { mapModelIdToSdkName, setModelEnvironmentVariables, resolveModelFromSettings } from '../../utils/model-utils.js';
-import { AsyncStream } from '../../utils/async-stream.js';
-import { canUseTool, requestPlanApproval } from '../../permission-handler.js';
-import { persistJsonlMessage, loadSessionHistory } from './session-service.js';
-import { loadAttachments, buildContentBlocks } from './attachment-service.js';
-import { buildIDEContextPrompt } from '../system-prompts.js';
-import { buildQuickFixPrompt } from '../quickfix-prompts.js';
-import { mergeUsage, emitAccumulatedUsage } from '../../utils/usage-utils.js';
 
 // Store active query results for rewind operations
 // Key: sessionId, Value: query result object
@@ -365,18 +368,19 @@ function truncateErrorContent(content, maxLen = 1000) {
 
 /**
  * Emit [USAGE] tag for Java-side token tracking.
- * NOTE: The console.log below is intentional IPC — the Java backend parses
- * stdout lines starting with "[USAGE]" to extract token metrics.
- * This follows the same pattern used by other IPC tags (e.g. [TOOL_RESULT]).
+ * NOTE: Uses process.stdout.write for consistent buffering with other IPC messages.
+ * The Java backend parses stdout lines starting with "[USAGE]" to extract token metrics.
  */
 function emitUsageTag(msg) {
   if (msg.type === 'assistant' && msg.message?.usage) {
-    const { input_tokens = 0, output_tokens = 0,
-            cache_creation_input_tokens = 0, cache_read_input_tokens = 0 } = msg.message.usage;
+    const {
+      input_tokens = 0, output_tokens = 0,
+      cache_creation_input_tokens = 0, cache_read_input_tokens = 0
+    } = msg.message.usage;
     // Intentional stdout IPC — parsed by Java backend (see ClaudeMessageHandler.parseUsageTag)
-    console.log('[USAGE]', JSON.stringify({
+    process.stdout.write('[USAGE] ' + JSON.stringify({
       input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens
-    }));
+    }) + '\n');
   }
 }
 
@@ -427,21 +431,21 @@ function truncateToolResultBlock(block) {
  * @param {Error} error - The error object to build payload from
  * @returns {Object} Error payload with error message and details
  */
-	function buildConfigErrorPayload(error) {
-			  try {
-			    const rawError = error?.message || String(error);
-			    const errorName = error?.name || 'Error';
-			    const errorStack = error?.stack || null;
+function buildConfigErrorPayload(error) {
+  try {
+    const rawError = error?.message || String(error);
+    const errorName = error?.name || 'Error';
+    const errorStack = error?.stack || null;
 
-			    // Previously this handled AbortError / "Claude Code process aborted by user" with a timeout-specific message.
-			    // Now we use unified error handling, but still record whether it's a timeout/abort error in details for debugging.
-			    const isAbortError =
-			      errorName === 'AbortError' ||
-			      rawError.includes('Claude Code process aborted by user') ||
-			      rawError.includes('The operation was aborted');
+    // Previously this handled AbortError / "Claude Code process aborted by user" with a timeout-specific message.
+    // Now we use unified error handling, but still record whether it's a timeout/abort error in details for debugging.
+    const isAbortError =
+      errorName === 'AbortError' ||
+      rawError.includes('Claude Code process aborted by user') ||
+      rawError.includes('The operation was aborted');
 
-		    const settings = loadClaudeSettings();
-	    const env = settings?.env || {};
+    const settings = loadClaudeSettings();
+    const env = settings?.env || {};
 
     const settingsApiKey =
       env.ANTHROPIC_AUTH_TOKEN !== undefined && env.ANTHROPIC_AUTH_TOKEN !== null
@@ -474,42 +478,42 @@ function truncateToolResultBlock(block) {
       ? `${rawKey.substring(0, 10)}... (length: ${rawKey.length} chars)`
       : 'Not configured (value is empty or missing)';
 
-		    let baseUrl = settingsBaseUrl || 'https://api.anthropic.com';
-		    let baseUrlSource;
-		    if (settingsBaseUrl) {
-		      baseUrlSource = '~/.claude/settings.json: ANTHROPIC_BASE_URL';
-		    } else {
-		      baseUrlSource = 'Default (https://api.anthropic.com)';
-		    }
+    let baseUrl = settingsBaseUrl || 'https://api.anthropic.com';
+    let baseUrlSource;
+    if (settingsBaseUrl) {
+      baseUrlSource = '~/.claude/settings.json: ANTHROPIC_BASE_URL';
+    } else {
+      baseUrlSource = 'Default (https://api.anthropic.com)';
+    }
 
-		    const heading = isAbortError
-		      ? 'Claude Code was interrupted (possibly response timeout or user cancellation):'
-		      : 'Claude Code error:';
+    const heading = isAbortError
+      ? 'Claude Code was interrupted (possibly response timeout or user cancellation):'
+      : 'Claude Code error:';
 
-		    const userMessage = [
-	      heading,
-	      `- Error message: ${truncateString(rawError)}`,
-	      `- Current API Key source: ${keySource}`,
-	      `- Current API Key preview: ${keyPreview}`,
-	      `- Current Base URL: ${baseUrl} (source: ${baseUrlSource})`,
-	      `- Tip: CLI can read from environment variables or settings.json; this plugin only supports reading from settings.json to avoid issues. You can configure it in the plugin's top-right Settings > Provider Management`,
-	      ''
-	    ].join('\n');
+    const userMessage = [
+      heading,
+      `- Error message: ${truncateString(rawError)}`,
+      `- Current API Key source: ${keySource}`,
+      `- Current API Key preview: ${keyPreview}`,
+      `- Current Base URL: ${baseUrl} (source: ${baseUrlSource})`,
+      `- Tip: CLI can read from environment variables or settings.json; this plugin only supports reading from settings.json to avoid issues. You can configure it in the plugin's top-right Settings > Provider Management`,
+      ''
+    ].join('\n');
 
-	    return {
-	      success: false,
-	      error: userMessage,
-	      details: {
-	        rawError,
-	        errorName,
-	        errorStack,
-	        isAbortError,
-	        keySource,
-	        keyPreview,
-	        baseUrl,
-	        baseUrlSource
-	      }
-	    };
+    return {
+      success: false,
+      error: userMessage,
+      details: {
+        rawError,
+        errorName,
+        errorStack,
+        isAbortError,
+        keySource,
+        keyPreview,
+        baseUrl,
+        baseUrlSource
+      }
+    };
   } catch (innerError) {
     const rawError = error?.message || String(error);
     return {
@@ -605,27 +609,27 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     console.log('[DEBUG] Model resolved for API:', model, '->', resolvedModel);
     setModelEnvironmentVariables(resolvedModel, model);
 
-	    // Build systemPrompt.append content (for adding opened files context and agent prompt)
-	    // Use the unified prompt management module to build IDE context prompt (including agent prompt)
-	    console.log('[Agent] message-service.sendMessage received agentPrompt:', agentPrompt ? `✓ (${agentPrompt.length} chars)` : '✗ null');
-	    let systemPromptAppend;
-	    if (openedFiles && openedFiles.isQuickFix) {
-	      systemPromptAppend = buildQuickFixPrompt(openedFiles, message);
-	    } else {
-	      systemPromptAppend = buildIDEContextPrompt(openedFiles, agentPrompt);
-	    }
-	    console.log('[Agent] systemPromptAppend built:', systemPromptAppend ? `✓ (${systemPromptAppend.length} chars)` : '✗ empty');
+    // Build systemPrompt.append content (for adding opened files context and agent prompt)
+    // Use the unified prompt management module to build IDE context prompt (including agent prompt)
+    console.log('[Agent] message-service.sendMessage received agentPrompt:', agentPrompt ? `✓ (${agentPrompt.length} chars)` : '✗ null');
+    let systemPromptAppend;
+    if (openedFiles && openedFiles.isQuickFix) {
+      systemPromptAppend = buildQuickFixPrompt(openedFiles, message);
+    } else {
+      systemPromptAppend = buildIDEContextPrompt(openedFiles, agentPrompt);
+    }
+    console.log('[Agent] systemPromptAppend built:', systemPromptAppend ? `✓ (${systemPromptAppend.length} chars)` : '✗ empty');
 
-	    // Prepare options
-	    // Note: No longer passing pathToClaudeCodeExecutable; the SDK will use its built-in cli.js.
-	    // This avoids system CLI path issues on Windows (ENOENT errors).
-	    const effectivePermissionMode = (!permissionMode || permissionMode === '') ? 'default' : permissionMode;
-	    // Always provide canUseTool to ensure interactive tools like AskUserQuestion can receive user input
-	    const shouldUseCanUseTool = true;
-	    console.log('[PERM_DEBUG] permissionMode:', permissionMode);
-	    console.log('[PERM_DEBUG] effectivePermissionMode:', effectivePermissionMode);
-	    console.log('[PERM_DEBUG] shouldUseCanUseTool:', shouldUseCanUseTool);
-	    console.log('[PERM_DEBUG] canUseTool function defined:', typeof canUseTool);
+    // Prepare options
+    // Note: No longer passing pathToClaudeCodeExecutable; the SDK will use its built-in cli.js.
+    // This avoids system CLI path issues on Windows (ENOENT errors).
+    const effectivePermissionMode = (!permissionMode || permissionMode === '') ? 'default' : permissionMode;
+    // Always provide canUseTool to ensure interactive tools like AskUserQuestion can receive user input
+    const shouldUseCanUseTool = true;
+    console.log('[PERM_DEBUG] permissionMode:', permissionMode);
+    console.log('[PERM_DEBUG] effectivePermissionMode:', effectivePermissionMode);
+    console.log('[PERM_DEBUG] shouldUseCanUseTool:', shouldUseCanUseTool);
+    console.log('[PERM_DEBUG] canUseTool function defined:', typeof canUseTool);
 
     // Read Extended Thinking configuration from settings.json (reuse `settings` loaded above)
     const alwaysThinkingEnabled = settings?.alwaysThinkingEnabled ?? true;
@@ -641,67 +645,68 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     console.log('[STREAMING_DEBUG] settings.streamingEnabled:', settings?.streamingEnabled);
     console.log('[STREAMING_DEBUG] streamingEnabled (final):', streamingEnabled);
 
-	    // Decide whether to enable Extended Thinking based on configuration
-	    // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
-	    // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
-	    const maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
+    // Decide whether to enable Extended Thinking based on configuration
+    // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
+    // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
+    const maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
 
-	    console.log('[THINKING_DEBUG] alwaysThinkingEnabled:', alwaysThinkingEnabled);
-	    console.log('[THINKING_DEBUG] maxThinkingTokens:', maxThinkingTokens);
+    console.log('[THINKING_DEBUG] alwaysThinkingEnabled:', alwaysThinkingEnabled);
+    console.log('[THINKING_DEBUG] maxThinkingTokens:', maxThinkingTokens);
 
-	    const options = {
-	      cwd: workingDirectory,
-	      permissionMode: effectivePermissionMode,
-	      model: sdkModelName,
-	      maxTurns: 100,
-	      // Enable file checkpointing for rewind feature
-	      enableFileCheckpointing: true,
-	      // Extended Thinking config (controlled by alwaysThinkingEnabled in settings.json)
-	      // Thinking content is output via the [THINKING] tag for frontend display
-	      ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
-	      // Streaming config: enable includePartialMessages to receive incremental content
-	      // When streamingEnabled is true, the SDK returns partial messages with incremental content
-	      ...(streamingEnabled && { includePartialMessages: true }),
-	      additionalDirectories: Array.from(
-	        new Set(
-	          [workingDirectory, process.env.IDEA_PROJECT_PATH, process.env.PROJECT_PATH].filter(Boolean)
-	        )
-	      ),
-	      canUseTool: shouldUseCanUseTool ? canUseTool : undefined,
-	      hooks: {
-	        PreToolUse: [{
-	          hooks: [createPreToolUseHook(effectivePermissionMode)]
-	        }]
-	      },
-	      // Don't pass pathToClaudeCodeExecutable; SDK will use its built-in cli.js
-	      settingSources: ['user', 'project', 'local'],
-	      // Use the Claude Code preset system prompt so Claude knows the current working directory.
-	      // This is key to fixing path issues: without systemPrompt, Claude doesn't know the cwd.
-	      // If openedFiles is present, add the opened files context via the append field.
-	      systemPrompt: {
-	        type: 'preset',
-	        preset: 'claude_code',
-	        ...(systemPromptAppend && { append: systemPromptAppend })
-	      },
-	      // Capture SDK/CLI stderr output
-	      stderr: (data) => {
-	        try {
-	          const text = (data ?? '').toString().trim();
-	          if (text) {
-	            sdkStderrLines.push(text);
-	            if (sdkStderrLines.length > 50) sdkStderrLines.shift();
-	            console.error(`[SDK-STDERR] ${text}`);
-	          }
-	        } catch (_) {}
-	      }
-	    };
-	    console.log('[PERM_DEBUG] options.canUseTool:', options.canUseTool ? 'SET' : 'NOT SET');
-	    console.log('[PERM_DEBUG] options.hooks:', options.hooks ? 'SET (PreToolUse)' : 'NOT SET');
-	    console.log('[STREAMING_DEBUG] options.includePartialMessages:', options.includePartialMessages ? 'SET' : 'NOT SET');
+    const options = {
+      cwd: workingDirectory,
+      permissionMode: effectivePermissionMode,
+      model: sdkModelName,
+      maxTurns: 100,
+      // Enable file checkpointing for rewind feature
+      enableFileCheckpointing: true,
+      // Extended Thinking config (controlled by alwaysThinkingEnabled in settings.json)
+      // Thinking content is output via the [THINKING] tag for frontend display
+      ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
+      // Streaming config: enable includePartialMessages to receive incremental content
+      // When streamingEnabled is true, the SDK returns partial messages with incremental content
+      ...(streamingEnabled && { includePartialMessages: true }),
+      additionalDirectories: Array.from(
+        new Set(
+          [workingDirectory, process.env.IDEA_PROJECT_PATH, process.env.PROJECT_PATH].filter(Boolean)
+        )
+      ),
+      canUseTool: shouldUseCanUseTool ? canUseTool : undefined,
+      hooks: {
+        PreToolUse: [{
+          hooks: [createPreToolUseHook(effectivePermissionMode)]
+        }]
+      },
+      // Don't pass pathToClaudeCodeExecutable; SDK will use its built-in cli.js
+      settingSources: ['user', 'project', 'local'],
+      // Use the Claude Code preset system prompt so Claude knows the current working directory.
+      // This is key to fixing path issues: without systemPrompt, Claude doesn't know the cwd.
+      // If openedFiles is present, add the opened files context via the append field.
+      systemPrompt: {
+        type: 'preset',
+        preset: 'claude_code',
+        ...(systemPromptAppend && { append: systemPromptAppend })
+      },
+      // Capture SDK/CLI stderr output
+      stderr: (data) => {
+        try {
+          const text = (data ?? '').toString().trim();
+          if (text) {
+            sdkStderrLines.push(text);
+            if (sdkStderrLines.length > 50) sdkStderrLines.shift();
+            console.error(`[SDK-STDERR] ${text}`);
+          }
+        } catch (_) {
+        }
+      }
+    };
+    console.log('[PERM_DEBUG] options.canUseTool:', options.canUseTool ? 'SET' : 'NOT SET');
+    console.log('[PERM_DEBUG] options.hooks:', options.hooks ? 'SET (PreToolUse)' : 'NOT SET');
+    console.log('[STREAMING_DEBUG] options.includePartialMessages:', options.includePartialMessages ? 'SET' : 'NOT SET');
 
-		// AbortController-based 60s timeout (disabled due to critical issues; keeping normal query logic only)
-		// const abortController = new AbortController();
-		// options.abortController = abortController;
+    // AbortController-based 60s timeout (disabled due to critical issues; keeping normal query logic only)
+    // const abortController = new AbortController();
+    // options.abortController = abortController;
 
     console.log('[DEBUG] Using SDK built-in Claude CLI (cli.js)');
 
@@ -717,17 +722,17 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       }
     }
 
-	    console.log('[DEBUG] Query started, waiting for messages...');
+    console.log('[DEBUG] Query started, waiting for messages...');
 
-	    // Dynamically load Claude SDK and get the query function
-	    console.log('[DIAG] Loading Claude SDK...');
-	    const sdk = await ensureClaudeSdk();
-	    console.log('[DIAG] SDK loaded, exports:', sdk ? Object.keys(sdk) : 'null');
-	    const query = sdk?.query;
-	    if (typeof query !== 'function') {
-	      throw new Error('Claude SDK query function not available. Please reinstall dependencies.');
-	    }
-	    console.log('[DIAG] query function available, calling...');
+    // Dynamically load Claude SDK and get the query function
+    console.log('[DIAG] Loading Claude SDK...');
+    const sdk = await ensureClaudeSdk();
+    console.log('[DIAG] SDK loaded, exports:', sdk ? Object.keys(sdk) : 'null');
+    const query = sdk?.query;
+    if (typeof query !== 'function') {
+      throw new Error('Claude SDK query function not available. Please reinstall dependencies.');
+    }
+    console.log('[DIAG] query function available, calling...');
 
     // ========== Auto-retry loop for transient API errors ==========
     let retryAttempt = 0;
@@ -748,17 +753,17 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       }
 
       try {
-	    // Call the query function
+        // Call the query function
         let result;
         try {
-	        result = query({
-	          prompt: message,
-	          options
-	        });
+          result = query({
+            prompt: message,
+            options
+          });
         } catch (queryError) {
           const canRetry = isRetryableError(queryError) &&
-                           retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
-                           messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
+            retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
+            messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
           if (canRetry) {
             lastRetryError = queryError;
             retryAttempt++;
@@ -773,266 +778,270 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
           }
           throw queryError;
         }
-	    console.log('[DIAG] query() returned, starting message loop...');
+        console.log('[DIAG] query() returned, starting message loop...');
 
-		// 60s timeout via AbortController to cancel query (disabled due to critical issues)
-		// timeoutId = setTimeout(() => {
-		//   console.log('[DEBUG] Query timeout after 60 seconds, aborting...');
-		//   abortController.abort();
-		// }, 60000);
+        // 60s timeout via AbortController to cancel query (disabled due to critical issues)
+        // timeoutId = setTimeout(() => {
+        //   console.log('[DEBUG] Query timeout after 60 seconds, aborting...');
+        //   abortController.abort();
+        // }, 60000);
 
-	    console.log('[DEBUG] Starting message loop...');
+        console.log('[DEBUG] Starting message loop...');
 
-    // Streaming output
-    // Streaming state tracking (streamingEnabled, streamStarted, streamEnded declared at function top)
-    // Track whether stream_event has been received (to avoid duplicate fallback diff output)
-    // Diff fallback: track previous assistant content for computing incremental deltas
+        // Streaming output
+        // Streaming state tracking (streamingEnabled, streamStarted, streamEnded declared at function top)
+        // Track whether stream_event has been received (to avoid duplicate fallback diff output)
+        // Diff fallback: track previous assistant content for computing incremental deltas
 
-    try {
-    for await (const msg of result) {
-      messageCount++;
-      console.log(`[DEBUG] Received message #${messageCount}, type: ${msg.type}`);
+        try {
+          for await (const msg of result) {
+            messageCount++;
+            console.log(`[DEBUG] Received message #${messageCount}, type: ${msg.type}`);
 
-      // Streaming: output stream start marker (only once)
-      if (streamingEnabled && !streamStarted) {
-        process.stdout.write('[STREAM_START]\n');
-        streamStarted = true;
-      }
+            // Streaming: output stream start marker (only once)
+            if (streamingEnabled && !streamStarted) {
+              process.stdout.write('[STREAM_START]\n');
+              streamStarted = true;
+            }
 
-      // Streaming: handle SDKPartialAssistantMessage (type: 'stream_event')
-      // Stream events returned by SDK via includePartialMessages
-      // Relaxed matching: process any stream_event type
-      if (streamingEnabled && msg.type === 'stream_event') {
-        hasStreamEvents = true;
-        const event = msg.event;
+            // Streaming: handle SDKPartialAssistantMessage (type: 'stream_event')
+            // Stream events returned by SDK via includePartialMessages
+            // Relaxed matching: process any stream_event type
+            if (streamingEnabled && msg.type === 'stream_event') {
+              hasStreamEvents = true;
+              const event = msg.event;
 
-        if (event) {
-          // message_start: accumulate input_tokens, cache_*_tokens
-          if (event.type === 'message_start' && event.message?.usage) {
-            accumulatedUsage = mergeUsage(accumulatedUsage, event.message.usage);
+              if (event) {
+                // message_start: reset per-turn accumulator (matches CLI behavior)
+                if (event.type === 'message_start' && event.message?.usage) {
+                  accumulatedUsage = mergeUsage(null, event.message.usage);
+                }
+
+                // message_delta: accumulate output_tokens and emit [USAGE] tag
+                if (event.type === 'message_delta' && event.usage) {
+                  accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+                  emitAccumulatedUsage(accumulatedUsage);
+                }
+
+                // content_block_delta: text or JSON incremental update
+                if (event.type === 'content_block_delta' && event.delta) {
+                  if (event.delta.type === 'text_delta' && event.delta.text) {
+                    // Atomic write to prevent interleaved output
+                    process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(event.delta.text)}\n`);
+                    // Accumulate synchronously to prevent duplicate output from fallback diff
+                    lastAssistantContent += event.delta.text;
+                  } else if (event.delta.type === 'thinking_delta' && event.delta.thinking) {
+                    // Atomic write to prevent interleaved output
+                    process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(event.delta.thinking)}\n`);
+                    lastThinkingContent += event.delta.thinking;
+                  }
+                  // input_json_delta is for tool calls; not handled yet
+                }
+
+                // content_block_start: new content block started (can identify thinking blocks)
+                if (event.type === 'content_block_start' && event.content_block) {
+                  if (event.content_block.type === 'thinking') {
+                    console.log('[THINKING_START]');
+                  }
+                }
+              }
+
+              // Critical fix: don't output [MESSAGE] for stream_event to avoid polluting the Java-side parsing pipeline
+              // console.log('[STREAM_DEBUG]', JSON.stringify(msg));
+              continue; // Stream event processed; skip remaining logic
+            }
+
+            // Output raw message (for Java-side parsing)
+            // In streaming mode, assistant messages need special handling:
+            // - If it contains tool_use, output it so the frontend can render tool blocks
+            // - Pure text assistant messages are skipped to avoid overwriting streaming state
+            let shouldOutputMessage = true;
+            if (streamingEnabled && msg.type === 'assistant') {
+              const msgContent = msg.message?.content;
+              const hasToolUse = Array.isArray(msgContent) && msgContent.some(block => block.type === 'tool_use');
+              if (!hasToolUse) {
+                shouldOutputMessage = false;
+              }
+            }
+            if (shouldOutputMessage) {
+              console.log('[MESSAGE]', JSON.stringify(msg));
+            }
+
+            // Output assistant content in real-time (non-streaming or complete messages)
+            if (msg.type === 'assistant') {
+              const content = msg.message?.content;
+
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (block.type === 'text') {
+                    const currentText = block.text || '';
+                    // Streaming fallback: if streaming is enabled but SDK didn't send stream_event, compute delta via diff
+                    if (streamingEnabled && !hasStreamEvents && currentText.length > lastAssistantContent.length) {
+                      const delta = currentText.substring(lastAssistantContent.length);
+                      if (delta) {
+                        process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+                      }
+                      lastAssistantContent = currentText;
+                    } else if (streamingEnabled && hasStreamEvents) {
+                      // Already output incrementally via stream_event; just sync state to avoid duplicates
+                      if (currentText.length > lastAssistantContent.length) {
+                        lastAssistantContent = currentText;
+                      }
+                    } else if (!streamingEnabled) {
+                      // Non-streaming mode: output full content
+                      console.log('[CONTENT]', truncateErrorContent(currentText));
+                    }
+                  } else if (block.type === 'thinking') {
+                    // Output thinking process
+                    const thinkingText = block.thinking || block.text || '';
+                    // Streaming fallback: also use diff for thinking content
+                    if (streamingEnabled && !hasStreamEvents && thinkingText.length > lastThinkingContent.length) {
+                      const delta = thinkingText.substring(lastThinkingContent.length);
+                      if (delta) {
+                        process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
+                      }
+                      lastThinkingContent = thinkingText;
+                    } else if (streamingEnabled && hasStreamEvents) {
+                      if (thinkingText.length > lastThinkingContent.length) {
+                        lastThinkingContent = thinkingText;
+                      }
+                    } else if (!streamingEnabled) {
+                      console.log('[THINKING]', thinkingText);
+                    }
+                  } else if (block.type === 'tool_use') {
+                    console.log('[TOOL_USE]', JSON.stringify({ id: block.id, name: block.name }));
+                  }
+                }
+              } else if (typeof content === 'string') {
+                // Streaming fallback: also use diff for string content
+                if (streamingEnabled && !hasStreamEvents && content.length > lastAssistantContent.length) {
+                  const delta = content.substring(lastAssistantContent.length);
+                  if (delta) {
+                    process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+                  }
+                  lastAssistantContent = content;
+                } else if (streamingEnabled && hasStreamEvents) {
+                  if (content.length > lastAssistantContent.length) {
+                    lastAssistantContent = content;
+                  }
+                } else if (!streamingEnabled) {
+                  console.log('[CONTENT]', truncateErrorContent(content));
+                }
+              }
+            }
+
+            // Emit usage data for Java-side token tracking
+            emitUsageTag(msg);
+
+            // Output tool call results in real-time (tool_result in user messages)
+            if (msg.type === 'user') {
+              const content = msg.message?.content ?? msg.content;
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (block.type === 'tool_result') {
+                    console.log('[TOOL_RESULT]', JSON.stringify(truncateToolResultBlock(block)));
+                  }
+                }
+              }
+            }
+
+            // Capture and save session_id
+            if (msg.type === 'system' && msg.session_id) {
+              currentSessionId = msg.session_id;
+              console.log('[SESSION_ID]', msg.session_id);
+
+              // Store the query result for rewind operations
+              activeQueryResults.set(msg.session_id, result);
+              console.log('[REWIND_DEBUG] Stored query result for session:', msg.session_id);
+            }
+
+            // Check for error result messages (quick detection of API Key errors)
+            if (msg.type === 'result' && msg.is_error) {
+              console.error('[DEBUG] Received error result message:', JSON.stringify(msg));
+              const errorText = msg.result || msg.message || 'API request failed';
+              throw new Error(errorText);
+            }
+          }
+        } catch (loopError) {
+          // Catch errors in the for-await loop (including SDK internal subprocess spawn failures)
+          console.error('[DEBUG] Error in message loop:', loopError.message);
+          console.error('[DEBUG] Error name:', loopError.name);
+          console.error('[DEBUG] Error stack:', loopError.stack);
+          // Check for subprocess-related errors
+          if (loopError.code) {
+            console.error('[DEBUG] Error code:', loopError.code);
+          }
+          if (loopError.errno) {
+            console.error('[DEBUG] Error errno:', loopError.errno);
+          }
+          if (loopError.syscall) {
+            console.error('[DEBUG] Error syscall:', loopError.syscall);
+          }
+          if (loopError.path) {
+            console.error('[DEBUG] Error path:', loopError.path);
+          }
+          if (loopError.spawnargs) {
+            console.error('[DEBUG] Error spawnargs:', JSON.stringify(loopError.spawnargs));
           }
 
-          // message_delta: accumulate output_tokens and emit [USAGE] tag
-          if (event.type === 'message_delta' && event.usage) {
-            accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+          // ========== Auto-retry logic for transient API errors ==========
+          // Only retry if:
+          // 1. Error is retryable (transient network/API issue)
+          // 2. Haven't exceeded max retries
+          // 3. Few messages were processed (early failure, not mid-stream)
+          const canRetry = isRetryableError(loopError) &&
+            retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
+            messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
+
+          if (canRetry) {
+            lastRetryError = loopError;
+            retryAttempt++;
+            const retryDelayMs = getRetryDelayMs(loopError);
+            if (isNoConversationFoundError(loopError) && resumeSessionId && resumeSessionId !== '') {
+              await waitForClaudeProjectSessionFile(resumeSessionId, workingDirectory, 2500, 100);
+            }
+            console.log(`[RETRY] Will retry (attempt ${retryAttempt}/${AUTO_RETRY_CONFIG.maxRetries}) after ${retryDelayMs}ms delay`);
+            console.log(`[RETRY] Reason: ${loopError.message}, messageCount: ${messageCount}`);
+
+            // Reset streaming state for retry
+            if (streamingEnabled && streamStarted && !streamEnded) {
+              // Don't output STREAM_END here - we'll start fresh on retry
+              streamStarted = false;
+            }
+
+            // Wait before retry
+            await sleep(retryDelayMs);
+            continue; // Go to next retry attempt
+          }
+
+          // Not retryable or max retries exceeded - throw to outer catch
+          throw loopError;
+        }
+
+        // ========== Success - break out of retry loop ==========
+        console.log(`[DEBUG] Message loop completed. Total messages: ${messageCount}`);
+        if (retryAttempt > 0) {
+          console.log(`[RETRY] Success after ${retryAttempt} retry attempt(s)`);
+        }
+
+        // Streaming: output stream end marker
+        if (streamingEnabled && streamStarted) {
+          // Emit final accumulated usage before stream end
+          if (accumulatedUsage) {
             emitAccumulatedUsage(accumulatedUsage);
           }
-
-          // content_block_delta: text or JSON incremental update
-          if (event.type === 'content_block_delta' && event.delta) {
-            if (event.delta.type === 'text_delta' && event.delta.text) {
-              // Atomic write to prevent interleaved output
-              process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(event.delta.text)}\n`);
-              // Accumulate synchronously to prevent duplicate output from fallback diff
-              lastAssistantContent += event.delta.text;
-            } else if (event.delta.type === 'thinking_delta' && event.delta.thinking) {
-              // Atomic write to prevent interleaved output
-              process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(event.delta.thinking)}\n`);
-              lastThinkingContent += event.delta.thinking;
-            }
-            // input_json_delta is for tool calls; not handled yet
-          }
-
-          // content_block_start: new content block started (can identify thinking blocks)
-          if (event.type === 'content_block_start' && event.content_block) {
-            if (event.content_block.type === 'thinking') {
-              console.log('[THINKING_START]');
-            }
-          }
+          process.stdout.write('[STREAM_END]\n');
+          streamEnded = true;
         }
 
-        // Critical fix: don't output [MESSAGE] for stream_event to avoid polluting the Java-side parsing pipeline
-        // console.log('[STREAM_DEBUG]', JSON.stringify(msg));
-        continue; // Stream event processed; skip remaining logic
-      }
+        console.log('[MESSAGE_END]');
+        console.log(JSON.stringify({
+          success: true,
+          sessionId: currentSessionId
+        }));
 
-      // Output raw message (for Java-side parsing)
-      // In streaming mode, assistant messages need special handling:
-      // - If it contains tool_use, output it so the frontend can render tool blocks
-      // - Pure text assistant messages are skipped to avoid overwriting streaming state
-      let shouldOutputMessage = true;
-      if (streamingEnabled && msg.type === 'assistant') {
-        const msgContent = msg.message?.content;
-        const hasToolUse = Array.isArray(msgContent) && msgContent.some(block => block.type === 'tool_use');
-        if (!hasToolUse) {
-          shouldOutputMessage = false;
-        }
-      }
-      if (shouldOutputMessage) {
-        console.log('[MESSAGE]', JSON.stringify(msg));
-      }
-
-      // Output assistant content in real-time (non-streaming or complete messages)
-      if (msg.type === 'assistant') {
-        const content = msg.message?.content;
-
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'text') {
-              const currentText = block.text || '';
-              // Streaming fallback: if streaming is enabled but SDK didn't send stream_event, compute delta via diff
-              if (streamingEnabled && !hasStreamEvents && currentText.length > lastAssistantContent.length) {
-                const delta = currentText.substring(lastAssistantContent.length);
-                if (delta) {
-                  process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
-                }
-                lastAssistantContent = currentText;
-              } else if (streamingEnabled && hasStreamEvents) {
-                // Already output incrementally via stream_event; just sync state to avoid duplicates
-                if (currentText.length > lastAssistantContent.length) {
-                  lastAssistantContent = currentText;
-                }
-              } else if (!streamingEnabled) {
-                // Non-streaming mode: output full content
-                console.log('[CONTENT]', truncateErrorContent(currentText));
-              }
-            } else if (block.type === 'thinking') {
-              // Output thinking process
-              const thinkingText = block.thinking || block.text || '';
-              // Streaming fallback: also use diff for thinking content
-              if (streamingEnabled && !hasStreamEvents && thinkingText.length > lastThinkingContent.length) {
-                const delta = thinkingText.substring(lastThinkingContent.length);
-                if (delta) {
-                  process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
-                }
-                lastThinkingContent = thinkingText;
-              } else if (streamingEnabled && hasStreamEvents) {
-                if (thinkingText.length > lastThinkingContent.length) {
-                  lastThinkingContent = thinkingText;
-                }
-              } else if (!streamingEnabled) {
-                console.log('[THINKING]', thinkingText);
-              }
-            } else if (block.type === 'tool_use') {
-              console.log('[TOOL_USE]', JSON.stringify({ id: block.id, name: block.name }));
-            }
-          }
-        } else if (typeof content === 'string') {
-          // Streaming fallback: also use diff for string content
-          if (streamingEnabled && !hasStreamEvents && content.length > lastAssistantContent.length) {
-            const delta = content.substring(lastAssistantContent.length);
-            if (delta) {
-              process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
-            }
-            lastAssistantContent = content;
-          } else if (streamingEnabled && hasStreamEvents) {
-            if (content.length > lastAssistantContent.length) {
-              lastAssistantContent = content;
-            }
-          } else if (!streamingEnabled) {
-            console.log('[CONTENT]', truncateErrorContent(content));
-          }
-        }
-      }
-
-      // Emit usage data for Java-side token tracking
-      emitUsageTag(msg);
-
-      // Output tool call results in real-time (tool_result in user messages)
-      if (msg.type === 'user') {
-        const content = msg.message?.content ?? msg.content;
-        if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'tool_result') {
-              console.log('[TOOL_RESULT]', JSON.stringify(truncateToolResultBlock(block)));
-            }
-          }
-        }
-      }
-
-      // Capture and save session_id
-      if (msg.type === 'system' && msg.session_id) {
-        currentSessionId = msg.session_id;
-        console.log('[SESSION_ID]', msg.session_id);
-
-        // Store the query result for rewind operations
-        activeQueryResults.set(msg.session_id, result);
-        console.log('[REWIND_DEBUG] Stored query result for session:', msg.session_id);
-      }
-
-      // Check for error result messages (quick detection of API Key errors)
-      if (msg.type === 'result' && msg.is_error) {
-        console.error('[DEBUG] Received error result message:', JSON.stringify(msg));
-        const errorText = msg.result || msg.message || 'API request failed';
-        throw new Error(errorText);
-      }
-    }
-    } catch (loopError) {
-      // Catch errors in the for-await loop (including SDK internal subprocess spawn failures)
-      console.error('[DEBUG] Error in message loop:', loopError.message);
-      console.error('[DEBUG] Error name:', loopError.name);
-      console.error('[DEBUG] Error stack:', loopError.stack);
-      // Check for subprocess-related errors
-      if (loopError.code) {
-        console.error('[DEBUG] Error code:', loopError.code);
-      }
-      if (loopError.errno) {
-        console.error('[DEBUG] Error errno:', loopError.errno);
-      }
-      if (loopError.syscall) {
-        console.error('[DEBUG] Error syscall:', loopError.syscall);
-      }
-      if (loopError.path) {
-        console.error('[DEBUG] Error path:', loopError.path);
-      }
-      if (loopError.spawnargs) {
-        console.error('[DEBUG] Error spawnargs:', JSON.stringify(loopError.spawnargs));
-      }
-
-      // ========== Auto-retry logic for transient API errors ==========
-      // Only retry if:
-      // 1. Error is retryable (transient network/API issue)
-      // 2. Haven't exceeded max retries
-      // 3. Few messages were processed (early failure, not mid-stream)
-      const canRetry = isRetryableError(loopError) &&
-                       retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
-                       messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
-
-      if (canRetry) {
-        lastRetryError = loopError;
-        retryAttempt++;
-        const retryDelayMs = getRetryDelayMs(loopError);
-        if (isNoConversationFoundError(loopError) && resumeSessionId && resumeSessionId !== '') {
-          await waitForClaudeProjectSessionFile(resumeSessionId, workingDirectory, 2500, 100);
-        }
-        console.log(`[RETRY] Will retry (attempt ${retryAttempt}/${AUTO_RETRY_CONFIG.maxRetries}) after ${retryDelayMs}ms delay`);
-        console.log(`[RETRY] Reason: ${loopError.message}, messageCount: ${messageCount}`);
-
-        // Reset streaming state for retry
-        if (streamingEnabled && streamStarted && !streamEnded) {
-          // Don't output STREAM_END here - we'll start fresh on retry
-          streamStarted = false;
-        }
-
-        // Wait before retry
-        await sleep(retryDelayMs);
-        continue; // Go to next retry attempt
-      }
-
-      // Not retryable or max retries exceeded - throw to outer catch
-      throw loopError;
-    }
-
-    // ========== Success - break out of retry loop ==========
-    console.log(`[DEBUG] Message loop completed. Total messages: ${messageCount}`);
-    if (retryAttempt > 0) {
-      console.log(`[RETRY] Success after ${retryAttempt} retry attempt(s)`);
-    }
-
-    // Streaming: output stream end marker
-    if (streamingEnabled && streamStarted) {
-      console.log('[STREAM_END]');
-      streamEnded = true;
-    }
-
-	    console.log('[MESSAGE_END]');
-	    console.log(JSON.stringify({
-	      success: true,
-	      sessionId: currentSessionId
-	    }));
-
-    // Success - exit retry loop
-    break;
+        // Success - exit retry loop
+        break;
 
       } catch (retryError) {
         // Catch errors from within the retry attempt (outer try of retryLoop)
@@ -1041,13 +1050,14 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       }
     } // end retryLoop
 
-	  } catch (error) {
-	    // Streaming: also end stream on error to prevent the frontend from getting stuck in streaming state
-	    if (streamingEnabled && streamStarted && !streamEnded) {
-	      console.log('[STREAM_END]');
-	      streamEnded = true;
-	    }
-	    const payload = buildConfigErrorPayload(error);
+  } catch (error) {
+    // Streaming: also end stream on error to prevent the frontend from getting stuck in streaming state
+    if (streamingEnabled && streamStarted && !streamEnded) {
+      emitAccumulatedUsage(accumulatedUsage);
+      process.stdout.write('[STREAM_END]\n');
+      streamEnded = true;
+    }
+    const payload = buildConfigErrorPayload(error);
     if (sdkStderrLines.length > 0) {
       const sdkErrorText = sdkStderrLines.slice(-10).join('\n');
       // Prepend SDK-STDERR to the error message
@@ -1078,7 +1088,10 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
     const Anthropic = anthropicModule.default || anthropicModule.Anthropic || anthropicModule;
 
     const workingDirectory = selectWorkingDirectory(cwd);
-    try { process.chdir(workingDirectory); } catch {}
+    try {
+      process.chdir(workingDirectory);
+    } catch {
+    }
 
     const sessionId = (resumeSessionId && resumeSessionId !== '') ? resumeSessionId : randomUUID();
     const rawModelId = model || 'claude-sonnet-4-5';
@@ -1106,11 +1119,11 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
       delete process.env.ANTHROPIC_API_KEY;
       process.env.ANTHROPIC_AUTH_TOKEN = apiKey;
     } else if (authType === 'aws_bedrock') {
-        console.log('[DEBUG] Using AWS_BEDROCK authentication (AWS_BEDROCK)');
-        // Dynamically load Bedrock SDK
-        const bedrockModule = await ensureBedrockSdk();
-        const AnthropicBedrock = bedrockModule.AnthropicBedrock || bedrockModule.default || bedrockModule;
-        client = new AnthropicBedrock();
+      console.log('[DEBUG] Using AWS_BEDROCK authentication (AWS_BEDROCK)');
+      // Dynamically load Bedrock SDK
+      const bedrockModule = await ensureBedrockSdk();
+      const AnthropicBedrock = bedrockModule.AnthropicBedrock || bedrockModule.default || bedrockModule;
+      client = new AnthropicBedrock();
     } else {
       console.log('[DEBUG] Using API Key authentication (ANTHROPIC_API_KEY)');
       // Use apiKey parameter (x-api-key authentication)
@@ -1189,7 +1202,12 @@ Possible causes:
           role: 'assistant',
           stop_reason: 'error',
           type: 'message',
-          usage: { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0
+          },
           content: errorContent
         },
         session_id: sessionId,
@@ -1435,7 +1453,8 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
             if (sdkStderrLines.length > 50) sdkStderrLines.shift();
             console.error(`[SDK-STDERR] ${text}`);
           }
-        } catch (_) {}
+        } catch (_) {
+        }
       }
     };
     console.log('[PERM_DEBUG] (withAttachments) options.canUseTool:', options.canUseTool ? 'SET' : 'NOT SET');
@@ -1443,27 +1462,27 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     console.log('[PERM_DEBUG] (withAttachments) options.permissionMode:', options.permissionMode);
     console.log('[STREAMING_DEBUG] (withAttachments) options.includePartialMessages:', options.includePartialMessages ? 'SET' : 'NOT SET');
 
-	    // Previously this used AbortController + 30s auto-timeout to cancel attachment requests.
-	    // This caused misleading "Claude Code process aborted by user" errors even when config was correct.
-	    // To stay consistent with plain-text sendMessage, auto-timeout is disabled here; interruption is controlled by the IDE side.
-	    // const abortController = new AbortController();
-	    // options.abortController = abortController;
+    // Previously this used AbortController + 30s auto-timeout to cancel attachment requests.
+    // This caused misleading "Claude Code process aborted by user" errors even when config was correct.
+    // To stay consistent with plain-text sendMessage, auto-timeout is disabled here; interruption is controlled by the IDE side.
+    // const abortController = new AbortController();
+    // options.abortController = abortController;
 
-	    if (resumeSessionId && resumeSessionId !== '') {
-	      options.resume = resumeSessionId;
-	      console.log('[RESUMING]', resumeSessionId);
-	      if (!hasClaudeProjectSessionFile(resumeSessionId, workingDirectory)) {
-	        console.log('[RESUME_WAIT] Waiting for session file to appear before resuming...');
-	        await waitForClaudeProjectSessionFile(resumeSessionId, workingDirectory, 2500, 100);
-	      }
-	    }
+    if (resumeSessionId && resumeSessionId !== '') {
+      options.resume = resumeSessionId;
+      console.log('[RESUMING]', resumeSessionId);
+      if (!hasClaudeProjectSessionFile(resumeSessionId, workingDirectory)) {
+        console.log('[RESUME_WAIT] Waiting for session file to appear before resuming...');
+        await waitForClaudeProjectSessionFile(resumeSessionId, workingDirectory, 2500, 100);
+      }
+    }
 
-		    // Dynamically load Claude SDK
-		    const sdk = await ensureClaudeSdk();
-		    const queryFn = sdk?.query;
-            if (typeof queryFn !== 'function') {
-              throw new Error('Claude SDK query function not available. Please reinstall dependencies.');
-            }
+    // Dynamically load Claude SDK
+    const sdk = await ensureClaudeSdk();
+    const queryFn = sdk?.query;
+    if (typeof queryFn !== 'function') {
+      throw new Error('Claude SDK query function not available. Please reinstall dependencies.');
+    }
 
     // ========== Auto-retry loop for transient API errors ==========
     let retryAttempt = 0;
@@ -1492,14 +1511,14 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
 
         let result;
         try {
-		    result = queryFn({
-		      prompt: inputStream,
-		      options
-		    });
+          result = queryFn({
+            prompt: inputStream,
+            options
+          });
         } catch (queryError) {
           const canRetry = isRetryableError(queryError) &&
-                           retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
-                           messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
+            retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
+            messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
           if (canRetry) {
             lastRetryError = queryError;
             retryAttempt++;
@@ -1518,182 +1537,182 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
           throw queryError;
         }
 
-	    // To re-enable auto-timeout, implement it here via AbortController with a clear "response timeout" message
-	    // timeoutId = setTimeout(() => {
-	    //   console.log('[DEBUG] Query with attachments timeout after 30 seconds, aborting...');
-	    //   abortController.abort();
-	    // }, 30000);
+        // To re-enable auto-timeout, implement it here via AbortController with a clear "response timeout" message
+        // timeoutId = setTimeout(() => {
+        //   console.log('[DEBUG] Query with attachments timeout after 30 seconds, aborting...');
+        //   abortController.abort();
+        // }, 30000);
 
-		    // Streaming state tracking (streamingEnabled, streamStarted, streamEnded declared at function top)
-		    // Diff fallback: track previous assistant content for computing incremental deltas
+        // Streaming state tracking (streamingEnabled, streamStarted, streamEnded declared at function top)
+        // Diff fallback: track previous assistant content for computing incremental deltas
 
-		    try {
-		    for await (const msg of result) {
-		      messageCount++;
-		      // Streaming: output stream start marker (only once)
-		      if (streamingEnabled && !streamStarted) {
-		        process.stdout.write('[STREAM_START]\n');
-		        streamStarted = true;
-		      }
+        try {
+          for await (const msg of result) {
+            messageCount++;
+            // Streaming: output stream start marker (only once)
+            if (streamingEnabled && !streamStarted) {
+              process.stdout.write('[STREAM_START]\n');
+              streamStarted = true;
+            }
 
-		      // Streaming: handle SDKPartialAssistantMessage (type: 'stream_event')
-		      // Relaxed matching: process any stream_event type
-		      if (streamingEnabled && msg.type === 'stream_event') {
-		        hasStreamEvents = true;
-		        const event = msg.event;
+            // Streaming: handle SDKPartialAssistantMessage (type: 'stream_event')
+            // Relaxed matching: process any stream_event type
+            if (streamingEnabled && msg.type === 'stream_event') {
+              hasStreamEvents = true;
+              const event = msg.event;
 
-		        if (event) {
-		          // message_start: accumulate input_tokens, cache_*_tokens
-		          if (event.type === 'message_start' && event.message?.usage) {
-		            accumulatedUsage = mergeUsage(accumulatedUsage, event.message.usage);
-		          }
+              if (event) {
+                // message_start: reset per-turn accumulator (matches CLI behavior)
+                if (event.type === 'message_start' && event.message?.usage) {
+                  accumulatedUsage = mergeUsage(null, event.message.usage);
+                }
 
-		          // message_delta: accumulate output_tokens and emit [USAGE] tag
-		          if (event.type === 'message_delta' && event.usage) {
-		            accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
-		            emitAccumulatedUsage(accumulatedUsage);
-		          }
+                // message_delta: accumulate output_tokens and emit [USAGE] tag
+                if (event.type === 'message_delta' && event.usage) {
+                  accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+                  emitAccumulatedUsage(accumulatedUsage);
+                }
 
-		          // content_block_delta: text or JSON incremental update
-		          if (event.type === 'content_block_delta' && event.delta) {
-		            if (event.delta.type === 'text_delta' && event.delta.text) {
-		              process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(event.delta.text)}\n`);
-		              lastAssistantContent += event.delta.text;
-		            } else if (event.delta.type === 'thinking_delta' && event.delta.thinking) {
-		              process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(event.delta.thinking)}\n`);
-		              lastThinkingContent += event.delta.thinking;
-		            }
-		          }
+                // content_block_delta: text or JSON incremental update
+                if (event.type === 'content_block_delta' && event.delta) {
+                  if (event.delta.type === 'text_delta' && event.delta.text) {
+                    process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(event.delta.text)}\n`);
+                    lastAssistantContent += event.delta.text;
+                  } else if (event.delta.type === 'thinking_delta' && event.delta.thinking) {
+                    process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(event.delta.thinking)}\n`);
+                    lastThinkingContent += event.delta.thinking;
+                  }
+                }
 
-		          // content_block_start: new content block started
-		          if (event.type === 'content_block_start' && event.content_block) {
-		            if (event.content_block.type === 'thinking') {
-		              console.log('[THINKING_START]');
-		            }
-		          }
-		        }
+                // content_block_start: new content block started
+                if (event.type === 'content_block_start' && event.content_block) {
+                  if (event.content_block.type === 'thinking') {
+                    console.log('[THINKING_START]');
+                  }
+                }
+              }
 
-		        // Critical fix: don't output [MESSAGE] for stream_event
-		        // console.log('[STREAM_DEBUG]', JSON.stringify(msg));
-		        continue;
-		      }
+              // Critical fix: don't output [MESSAGE] for stream_event
+              // console.log('[STREAM_DEBUG]', JSON.stringify(msg));
+              continue;
+            }
 
-	    	      // In streaming mode, assistant messages need special handling
-	    	      let shouldOutputMessage2 = true;
-	    	      if (streamingEnabled && msg.type === 'assistant') {
-	    	        const msgContent2 = msg.message?.content;
-	    	        const hasToolUse2 = Array.isArray(msgContent2) && msgContent2.some(block => block.type === 'tool_use');
-	    	        if (!hasToolUse2) {
-	    	          shouldOutputMessage2 = false;
-	    	        }
-	    	      }
-	    	      if (shouldOutputMessage2) {
-	    	        console.log('[MESSAGE]', JSON.stringify(msg));
-	    	      }
+            // In streaming mode, assistant messages need special handling
+            let shouldOutputMessage2 = true;
+            if (streamingEnabled && msg.type === 'assistant') {
+              const msgContent2 = msg.message?.content;
+              const hasToolUse2 = Array.isArray(msgContent2) && msgContent2.some(block => block.type === 'tool_use');
+              if (!hasToolUse2) {
+                shouldOutputMessage2 = false;
+              }
+            }
+            if (shouldOutputMessage2) {
+              console.log('[MESSAGE]', JSON.stringify(msg));
+            }
 
-	    	      // Process complete assistant messages
-	    	      if (msg.type === 'assistant') {
-	    	        const content = msg.message?.content;
+            // Process complete assistant messages
+            if (msg.type === 'assistant') {
+              const content = msg.message?.content;
 
-	    	        if (Array.isArray(content)) {
-	    	          for (const block of content) {
-	    	            if (block.type === 'text') {
-	    	              const currentText = block.text || '';
-	    	              // Streaming fallback: if streaming is enabled but SDK didn't send stream_event, compute delta via diff
-	    	              if (streamingEnabled && !hasStreamEvents && currentText.length > lastAssistantContent.length) {
-	    	                const delta = currentText.substring(lastAssistantContent.length);
-	    	                if (delta) {
-	    	                  process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
-	    	                }
-	    	                lastAssistantContent = currentText;
-	    	              } else if (streamingEnabled && hasStreamEvents) {
-	    	                if (currentText.length > lastAssistantContent.length) {
-	    	                  lastAssistantContent = currentText;
-	    	                }
-	    	              } else if (!streamingEnabled) {
-	    	                console.log('[CONTENT]', truncateErrorContent(currentText));
-	    	              }
-	    	            } else if (block.type === 'thinking') {
-	    	              const thinkingText = block.thinking || block.text || '';
-	    	              // Streaming fallback: also use diff for thinking content
-	    	              if (streamingEnabled && !hasStreamEvents && thinkingText.length > lastThinkingContent.length) {
-	    	                const delta = thinkingText.substring(lastThinkingContent.length);
-	    	                if (delta) {
-	    	                  process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
-	    	                }
-	    	                lastThinkingContent = thinkingText;
-	    	              } else if (streamingEnabled && hasStreamEvents) {
-	    	                if (thinkingText.length > lastThinkingContent.length) {
-	    	                  lastThinkingContent = thinkingText;
-	    	                }
-	    	              } else if (!streamingEnabled) {
-	    	                console.log('[THINKING]', thinkingText);
-	    	              }
-	    	            } else if (block.type === 'tool_use') {
-	    	              console.log('[TOOL_USE]', JSON.stringify({ id: block.id, name: block.name }));
-	    	            } else if (block.type === 'tool_result') {
-	    	              console.log('[DEBUG] Tool result payload (withAttachments):', JSON.stringify(block));
-	    	            }
-	    	          }
-	    	        } else if (typeof content === 'string') {
-	    	          // Streaming fallback: also use diff for string content
-	    	          if (streamingEnabled && !hasStreamEvents && content.length > lastAssistantContent.length) {
-	    	            const delta = content.substring(lastAssistantContent.length);
-	    	            if (delta) {
-	    	              process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
-	    	            }
-	    	            lastAssistantContent = content;
-	    	          } else if (streamingEnabled && hasStreamEvents) {
-	    	            if (content.length > lastAssistantContent.length) {
-	    	              lastAssistantContent = content;
-	    	            }
-	    	          } else if (!streamingEnabled) {
-	    	            console.log('[CONTENT]', truncateErrorContent(content));
-	    	          }
-	    	        }
-	    	      }
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (block.type === 'text') {
+                    const currentText = block.text || '';
+                    // Streaming fallback: if streaming is enabled but SDK didn't send stream_event, compute delta via diff
+                    if (streamingEnabled && !hasStreamEvents && currentText.length > lastAssistantContent.length) {
+                      const delta = currentText.substring(lastAssistantContent.length);
+                      if (delta) {
+                        process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+                      }
+                      lastAssistantContent = currentText;
+                    } else if (streamingEnabled && hasStreamEvents) {
+                      if (currentText.length > lastAssistantContent.length) {
+                        lastAssistantContent = currentText;
+                      }
+                    } else if (!streamingEnabled) {
+                      console.log('[CONTENT]', truncateErrorContent(currentText));
+                    }
+                  } else if (block.type === 'thinking') {
+                    const thinkingText = block.thinking || block.text || '';
+                    // Streaming fallback: also use diff for thinking content
+                    if (streamingEnabled && !hasStreamEvents && thinkingText.length > lastThinkingContent.length) {
+                      const delta = thinkingText.substring(lastThinkingContent.length);
+                      if (delta) {
+                        process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
+                      }
+                      lastThinkingContent = thinkingText;
+                    } else if (streamingEnabled && hasStreamEvents) {
+                      if (thinkingText.length > lastThinkingContent.length) {
+                        lastThinkingContent = thinkingText;
+                      }
+                    } else if (!streamingEnabled) {
+                      console.log('[THINKING]', thinkingText);
+                    }
+                  } else if (block.type === 'tool_use') {
+                    console.log('[TOOL_USE]', JSON.stringify({ id: block.id, name: block.name }));
+                  } else if (block.type === 'tool_result') {
+                    console.log('[DEBUG] Tool result payload (withAttachments):', JSON.stringify(block));
+                  }
+                }
+              } else if (typeof content === 'string') {
+                // Streaming fallback: also use diff for string content
+                if (streamingEnabled && !hasStreamEvents && content.length > lastAssistantContent.length) {
+                  const delta = content.substring(lastAssistantContent.length);
+                  if (delta) {
+                    process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+                  }
+                  lastAssistantContent = content;
+                } else if (streamingEnabled && hasStreamEvents) {
+                  if (content.length > lastAssistantContent.length) {
+                    lastAssistantContent = content;
+                  }
+                } else if (!streamingEnabled) {
+                  console.log('[CONTENT]', truncateErrorContent(content));
+                }
+              }
+            }
 
-	    	      // Emit usage data for Java-side token tracking
-	    	      emitUsageTag(msg);
+            // Emit usage data for Java-side token tracking
+            emitUsageTag(msg);
 
-	    	      // Output tool call results in real-time (tool_result in user messages)
-	    	      if (msg.type === 'user') {
-	    	        const content = msg.message?.content ?? msg.content;
-	    	        if (Array.isArray(content)) {
-	    	          for (const block of content) {
-	    	            if (block.type === 'tool_result') {
-	    	              console.log('[TOOL_RESULT]', JSON.stringify(truncateToolResultBlock(block)));
-	    	            }
-	    	          }
-	    	        }
-	    	      }
+            // Output tool call results in real-time (tool_result in user messages)
+            if (msg.type === 'user') {
+              const content = msg.message?.content ?? msg.content;
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if (block.type === 'tool_result') {
+                    console.log('[TOOL_RESULT]', JSON.stringify(truncateToolResultBlock(block)));
+                  }
+                }
+              }
+            }
 
-	    	      if (msg.type === 'system' && msg.session_id) {
-	    	        currentSessionId = msg.session_id;
-	    	        console.log('[SESSION_ID]', msg.session_id);
+            if (msg.type === 'system' && msg.session_id) {
+              currentSessionId = msg.session_id;
+              console.log('[SESSION_ID]', msg.session_id);
 
-	    	        // Store the query result for rewind operations
-	    	        activeQueryResults.set(msg.session_id, result);
-	    	        console.log('[REWIND_DEBUG] (withAttachments) Stored query result for session:', msg.session_id);
-	    	      }
+              // Store the query result for rewind operations
+              activeQueryResults.set(msg.session_id, result);
+              console.log('[REWIND_DEBUG] (withAttachments) Stored query result for session:', msg.session_id);
+            }
 
-	    	      // Check for error result messages (quick detection of API Key errors)
-	    	      if (msg.type === 'result' && msg.is_error) {
-	    	        console.error('[DEBUG] (withAttachments) Received error result message:', JSON.stringify(msg));
-	    	        const errorText = msg.result || msg.message || 'API request failed';
-	    	        throw new Error(errorText);
-	    	      }
-	    	    }
-	    	    } catch (loopError) {
-	    	      // Catch errors in the for-await loop
-	    	      console.error('[DEBUG] Error in message loop (withAttachments):', loopError.message);
-	    	      console.error('[DEBUG] Error name:', loopError.name);
-	    	      console.error('[DEBUG] Error stack:', loopError.stack);
-	    	      if (loopError.code) console.error('[DEBUG] Error code:', loopError.code);
-	    	      if (loopError.errno) console.error('[DEBUG] Error errno:', loopError.errno);
-	    	      if (loopError.syscall) console.error('[DEBUG] Error syscall:', loopError.syscall);
-	    	      if (loopError.path) console.error('[DEBUG] Error path:', loopError.path);
-	    	      if (loopError.spawnargs) console.error('[DEBUG] Error spawnargs:', JSON.stringify(loopError.spawnargs));
+            // Check for error result messages (quick detection of API Key errors)
+            if (msg.type === 'result' && msg.is_error) {
+              console.error('[DEBUG] (withAttachments) Received error result message:', JSON.stringify(msg));
+              const errorText = msg.result || msg.message || 'API request failed';
+              throw new Error(errorText);
+            }
+          }
+        } catch (loopError) {
+          // Catch errors in the for-await loop
+          console.error('[DEBUG] Error in message loop (withAttachments):', loopError.message);
+          console.error('[DEBUG] Error name:', loopError.name);
+          console.error('[DEBUG] Error stack:', loopError.stack);
+          if (loopError.code) console.error('[DEBUG] Error code:', loopError.code);
+          if (loopError.errno) console.error('[DEBUG] Error errno:', loopError.errno);
+          if (loopError.syscall) console.error('[DEBUG] Error syscall:', loopError.syscall);
+          if (loopError.path) console.error('[DEBUG] Error path:', loopError.path);
+          if (loopError.spawnargs) console.error('[DEBUG] Error spawnargs:', JSON.stringify(loopError.spawnargs));
 
           // ========== Auto-retry logic for transient API errors ==========
           // Only retry if:
@@ -1701,8 +1720,8 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
           // 2. Haven't exceeded max retries
           // 3. Few messages were processed (early failure, not mid-stream)
           const canRetry = isRetryableError(loopError) &&
-                           retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
-                           messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
+            retryAttempt < AUTO_RETRY_CONFIG.maxRetries &&
+            messageCount <= AUTO_RETRY_CONFIG.maxMessagesForRetry;
 
           if (canRetry) {
             lastRetryError = loopError;
@@ -1725,28 +1744,32 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
           }
 
           // Not retryable or max retries exceeded - throw to outer catch
-	    	      throw loopError;
-	    	    }
+          throw loopError;
+        }
 
-    // ========== Success - break out of retry loop ==========
-    if (retryAttempt > 0) {
-      console.log(`[RETRY] (withAttachments) Success after ${retryAttempt} retry attempt(s)`);
-    }
+        // ========== Success - break out of retry loop ==========
+        if (retryAttempt > 0) {
+          console.log(`[RETRY] (withAttachments) Success after ${retryAttempt} retry attempt(s)`);
+        }
 
-	    // Streaming: output stream end marker
-	    if (streamingEnabled && streamStarted) {
-	      console.log('[STREAM_END]');
-	      streamEnded = true;
-	    }
+        // Streaming: output stream end marker
+        if (streamingEnabled && streamStarted) {
+          // Emit final accumulated usage before stream end
+          if (accumulatedUsage) {
+            emitAccumulatedUsage(accumulatedUsage);
+          }
+          process.stdout.write('[STREAM_END]\n');
+          streamEnded = true;
+        }
 
-	    console.log('[MESSAGE_END]');
-	    console.log(JSON.stringify({
-	      success: true,
-	      sessionId: currentSessionId
-	    }));
+        console.log('[MESSAGE_END]');
+        console.log(JSON.stringify({
+          success: true,
+          sessionId: currentSessionId
+        }));
 
-    // Success - exit retry loop
-    break;
+        // Success - exit retry loop
+        break;
 
       } catch (retryError) {
         // Catch errors from within the retry attempt (outer try of retryLoop)
@@ -1755,13 +1778,14 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
       }
     } // end retryLoop
 
-	  } catch (error) {
-	    // Streaming: also end stream on error to prevent the frontend from getting stuck in streaming state
-	    if (streamingEnabled && streamStarted && !streamEnded) {
-	      console.log('[STREAM_END]');
-	      streamEnded = true;
-	    }
-	    const payload = buildConfigErrorPayload(error);
+  } catch (error) {
+    // Streaming: also end stream on error to prevent the frontend from getting stuck in streaming state
+    if (streamingEnabled && streamStarted && !streamEnded) {
+      emitAccumulatedUsage(accumulatedUsage);
+      process.stdout.write('[STREAM_END]\n');
+      streamEnded = true;
+    }
+    const payload = buildConfigErrorPayload(error);
     if (sdkStderrLines.length > 0) {
       const sdkErrorText = sdkStderrLines.slice(-10).join('\n');
       // Prepend SDK-STDERR to the error message
@@ -1777,10 +1801,10 @@ ${payload.error}`;
     payload.error = truncateString(payload.error);
     console.error('[SEND_ERROR]', JSON.stringify(payload));
     console.log(JSON.stringify(payload));
-	  } finally {
-	    if (timeoutId) clearTimeout(timeoutId);
-	  }
-	}
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
 
 // NOTE: getSlashCommands() was removed — slash commands are now resolved
 // locally by Java SlashCommandRegistry (no SDK/bridge call needed).

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -3,18 +3,20 @@
  * Keeps Claude Query processes alive across turns to reduce per-request latency.
  */
 
-import {
-  loadClaudeSdk
-} from '../../utils/sdk-loader.js';
-import { setupApiKey, isCustomBaseUrl, loadClaudeSettings } from '../../config/api-config.js';
+import { loadClaudeSdk } from '../../utils/sdk-loader.js';
+import { isCustomBaseUrl, loadClaudeSettings, setupApiKey } from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
-import { mapModelIdToSdkName, resolveModelFromSettings, setModelEnvironmentVariables } from '../../utils/model-utils.js';
+import {
+  mapModelIdToSdkName,
+  resolveModelFromSettings,
+  setModelEnvironmentVariables
+} from '../../utils/model-utils.js';
 import { AsyncStream } from '../../utils/async-stream.js';
 import { canUseTool, requestPlanApproval } from '../../permission-handler.js';
-import { loadAttachments, buildContentBlocks } from './attachment-service.js';
+import { buildContentBlocks, loadAttachments } from './attachment-service.js';
 import { buildIDEContextPrompt } from '../system-prompts.js';
 import { buildQuickFixPrompt } from '../quickfix-prompts.js';
-import { mergeUsage, emitAccumulatedUsage } from '../../utils/usage-utils.js';
+import { emitAccumulatedUsage, mergeUsage } from '../../utils/usage-utils.js';
 import { registerActiveQueryResult, removeSession } from './message-service.js';
 
 const runtimesBySessionId = new Map();
@@ -591,9 +593,9 @@ function processStreamEvent(msg, turnState) {
   const event = msg.event;
   if (!event) return;
 
-  // Handle message_start: accumulate input_tokens, cache_*_tokens
+  // Handle message_start: reset per-turn accumulator (matches CLI behavior)
   if (event.type === 'message_start' && event.message?.usage) {
-    turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.message.usage);
+    turnState.accumulatedUsage = mergeUsage(null, event.message.usage);
   }
 
   // Handle message_delta: accumulate output_tokens and emit [USAGE] tag
@@ -767,7 +769,11 @@ async function executeTurn(runtime, requestContext, turnMeta) {
   }
 
   if (turnState.streamingEnabled && turnState.streamStarted && !turnState.streamEnded) {
-    console.log('[STREAM_END]');
+    // Emit final accumulated usage before stream end
+    if (turnState.accumulatedUsage) {
+      emitAccumulatedUsage(turnState.accumulatedUsage);
+    }
+    process.stdout.write('[STREAM_END]\n');
     turnState.streamEnded = true;
   }
 
@@ -826,7 +832,11 @@ async function sendInternal(params, withAttachments) {
       activeTurnRuntime = null;
     }
     if (turnMeta.state?.streamingEnabled && turnMeta.state?.streamStarted && !turnMeta.state?.streamEnded) {
-      console.log('[STREAM_END]');
+      // Emit final accumulated usage before stream end
+      if (turnMeta.state?.accumulatedUsage) {
+        emitAccumulatedUsage(turnMeta.state.accumulatedUsage);
+      }
+      process.stdout.write('[STREAM_END]\n');
       turnMeta.state.streamEnded = true;
     }
     emitSendError(runtime, error, requestContext);

--- a/ai-bridge/utils/usage-utils.js
+++ b/ai-bridge/utils/usage-utils.js
@@ -30,15 +30,14 @@ export function mergeUsage(accumulated, newUsage) {
 
 /**
  * Emit [USAGE] tag from accumulated usage data during streaming.
- * NOTE: The console.log below is intentional IPC — the Java backend parses
- * stdout lines starting with "[USAGE]" to extract token metrics.
+ * NOTE: Uses process.stdout.write for consistent buffering with other IPC messages.
  */
 export function emitAccumulatedUsage(accumulated) {
   if (!accumulated) return;
-  console.log('[USAGE]', JSON.stringify({
+  process.stdout.write('[USAGE] ' + JSON.stringify({
     input_tokens: accumulated.input_tokens || 0,
     output_tokens: accumulated.output_tokens || 0,
     cache_creation_input_tokens: accumulated.cache_creation_input_tokens || 0,
     cache_read_input_tokens: accumulated.cache_read_input_tokens || 0
-  }));
+  }) + '\n');
 }

--- a/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
@@ -51,8 +51,8 @@ public class ClaudeChatWindow {
 
     private JBCefBrowser browser;
     private ClaudeSession session;
-    private WebviewWatchdog webviewWatchdog;
-    private StreamMessageCoalescer streamCoalescer;
+    private final WebviewWatchdog webviewWatchdog;
+    private final StreamMessageCoalescer streamCoalescer;
 
     private volatile boolean disposed = false;
     private volatile boolean initialized = false;
@@ -64,12 +64,12 @@ public class ClaudeChatWindow {
     private MessageDispatcher messageDispatcher;
     private PermissionHandler permissionHandler;
     private HistoryHandler historyHandler;
-    private SessionLifecycleManager sessionLifecycleManager;
+    private final SessionLifecycleManager sessionLifecycleManager;
 
     // Delegates
     private WebviewInitializer webviewInitializer;
-    private EditorContextTracker editorContextTracker;
-    private ChatWindowDelegate chatWindowDelegate;
+    private final EditorContextTracker editorContextTracker;
+    private final ChatWindowDelegate chatWindowDelegate;
     private SessionCallbackAdapter sessionCallbackAdapter;
 
     public ClaudeChatWindow(Project project) {
@@ -110,36 +110,111 @@ public class ClaudeChatWindow {
 
         // Initialize stream message coalescer
         this.streamCoalescer = new StreamMessageCoalescer(new StreamMessageCoalescer.JsCallbackTarget() {
-            @Override public void callJavaScript(String functionName, String... args) {
+            @Override
+            public void callJavaScript(String functionName, String... args) {
                 ClaudeChatWindow.this.callJavaScript(functionName, args);
             }
-            @Override public JBCefBrowser getBrowser() { return browser; }
-            @Override public boolean isDisposed() { return disposed; }
-            @Override public HandlerContext getHandlerContext() { return handlerContext; }
+
+            @Override
+            public JBCefBrowser getBrowser() {
+                return browser;
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return disposed;
+            }
+
+            @Override
+            public HandlerContext getHandlerContext() {
+                return handlerContext;
+            }
         });
 
         // Initialize session lifecycle manager
         this.sessionLifecycleManager = new SessionLifecycleManager(new SessionLifecycleManager.SessionHost() {
-            @Override public Project getProject() { return project; }
-            @Override public ClaudeSDKBridge getClaudeSDKBridge() { return claudeSDKBridge; }
-            @Override public CodexSDKBridge getCodexSDKBridge() { return codexSDKBridge; }
-            @Override public ClaudeSession getSession() { return session; }
-            @Override public void setSession(ClaudeSession s) { session = s; }
-            @Override public HandlerContext getHandlerContext() { return handlerContext; }
-            @Override public StreamMessageCoalescer getStreamCoalescer() { return streamCoalescer; }
-            @Override public void clearPendingPermissionRequests() { permissionHandler.clearPendingRequests(); }
-            @Override public void callJavaScript(String fn, String... args) { ClaudeChatWindow.this.callJavaScript(fn, args); }
-            @Override public boolean isDisposed() { return disposed; }
-            @Override public JBCefBrowser getBrowser() { return browser; }
-            @Override public void setupSessionCallbacks() { ClaudeChatWindow.this.setupSessionCallbacks(); }
-            @Override public void setSlashCommandsFetched(boolean fetched) { slashCommandsFetched = fetched; }
-            @Override public void setFetchedSlashCommandsCount(int count) { fetchedSlashCommandsCount = count; }
+            @Override
+            public Project getProject() {
+                return project;
+            }
+
+            @Override
+            public ClaudeSDKBridge getClaudeSDKBridge() {
+                return claudeSDKBridge;
+            }
+
+            @Override
+            public CodexSDKBridge getCodexSDKBridge() {
+                return codexSDKBridge;
+            }
+
+            @Override
+            public ClaudeSession getSession() {
+                return session;
+            }
+
+            @Override
+            public void setSession(ClaudeSession s) {
+                session = s;
+            }
+
+            @Override
+            public HandlerContext getHandlerContext() {
+                return handlerContext;
+            }
+
+            @Override
+            public StreamMessageCoalescer getStreamCoalescer() {
+                return streamCoalescer;
+            }
+
+            @Override
+            public void clearPendingPermissionRequests() {
+                permissionHandler.clearPendingRequests();
+            }
+
+            @Override
+            public void callJavaScript(String fn, String... args) {
+                ClaudeChatWindow.this.callJavaScript(fn, args);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return disposed;
+            }
+
+            @Override
+            public JBCefBrowser getBrowser() {
+                return browser;
+            }
+
+            @Override
+            public void setupSessionCallbacks() {
+                ClaudeChatWindow.this.setupSessionCallbacks();
+            }
+
+            @Override
+            public void setSlashCommandsFetched(boolean fetched) {
+                slashCommandsFetched = fetched;
+            }
+
+            @Override
+            public void setFetchedSlashCommandsCount(int count) {
+                fetchedSlashCommandsCount = count;
+            }
         });
 
         // Initialize editor context tracker
         this.editorContextTracker = new EditorContextTracker(project, new EditorContextTracker.ContextCallback() {
-            @Override public void addSelectionInfo(String info) { callJavaScript("addSelectionInfo", info); }
-            @Override public void clearSelectionInfo() { callJavaScript("clearSelectionInfo"); }
+            @Override
+            public void addSelectionInfo(String info) {
+                callJavaScript("addSelectionInfo", info);
+            }
+
+            @Override
+            public void clearSelectionInfo() {
+                callJavaScript("clearSelectionInfo");
+            }
         });
         editorContextTracker.registerListeners();
 
@@ -188,8 +263,8 @@ public class ClaudeChatWindow {
             if (this.originalTabName == null) {
                 String displayName = content.getDisplayName();
                 this.originalTabName = displayName.endsWith("...")
-                    ? displayName.substring(0, displayName.length() - 3)
-                    : displayName;
+                        ? displayName.substring(0, displayName.length() - 3)
+                        : displayName;
                 LOG.debug("[TabLoading] Auto-initialized original tab name: " + this.originalTabName);
             }
         }
@@ -197,18 +272,38 @@ public class ClaudeChatWindow {
 
     public void setOriginalTabName(String name) {
         this.originalTabName = (name != null && name.endsWith("..."))
-            ? name.substring(0, name.length() - 3)
-            : name;
+                ? name.substring(0, name.length() - 3)
+                : name;
         LOG.debug("[TabLoading] Set original tab name: " + this.originalTabName);
     }
 
-    public boolean isDisposed() { return disposed; }
-    public boolean isInitialized() { return initialized; }
-    public Content getParentContent() { return parentContent; }
-    public JPanel getContent() { return mainPanel; }
-    public ClaudeSDKBridge getClaudeSDKBridge() { return claudeSDKBridge; }
-    public CodexSDKBridge getCodexSDKBridge() { return codexSDKBridge; }
-    public String getSessionId() { return sessionId; }
+    public boolean isDisposed() {
+        return disposed;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public Content getParentContent() {
+        return parentContent;
+    }
+
+    public JPanel getContent() {
+        return mainPanel;
+    }
+
+    public ClaudeSDKBridge getClaudeSDKBridge() {
+        return claudeSDKBridge;
+    }
+
+    public CodexSDKBridge getCodexSDKBridge() {
+        return codexSDKBridge;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
 
     public void addCodeSnippetFromExternal(String selectionInfo) {
         addCodeSnippet(selectionInfo);
@@ -241,7 +336,7 @@ public class ClaudeChatWindow {
     // ==================== JavaScript Bridge ====================
 
     private static final java.util.regex.Pattern SAFE_JS_FUNCTION_NAME =
-        java.util.regex.Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$.]*$");
+            java.util.regex.Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$.]*$");
 
     void callJavaScript(String functionName, String... args) {
         if (disposed || browser == null) {
@@ -275,15 +370,15 @@ public class ClaudeChatWindow {
                 }
 
                 String checkAndCall =
-                    "(function() {" +
-                    "  try {" +
-                    "    if (typeof " + callee + " === 'function') {" +
-                    "      " + callee + "(" + argsJs + ");" +
-                    "    }" +
-                    "  } catch (e) {" +
-                    "    console.error('[Backend->Frontend] Failed to call " + functionName + ":', e);" +
-                    "  }" +
-                    "})();";
+                        "(function() {" +
+                                "  try {" +
+                                "    if (typeof " + callee + " === 'function') {" +
+                                "      " + callee + "(" + argsJs + ");" +
+                                "    }" +
+                                "  } catch (e) {" +
+                                "    console.error('[Backend->Frontend] Failed to call " + functionName + ":', e);" +
+                                "  }" +
+                                "})();";
 
                 browser.getCefBrowser().executeJavaScript(checkAndCall, browser.getCefBrowser().getURL(), 0);
             } catch (Exception e) {
@@ -340,11 +435,21 @@ public class ClaudeChatWindow {
 
     private void setupSessionCallbacks() {
         this.sessionCallbackAdapter = new SessionCallbackAdapter(
-            streamCoalescer,
-            this::callJavaScript,
-            permissionHandler,
-            () -> slashCommandsFetched,
-            this::onStreamEnded
+                streamCoalescer,
+                new SessionCallbackAdapter.JsTarget() {
+                    @Override
+                    public void callJavaScript(String functionName, String... args) {
+                        ClaudeChatWindow.this.callJavaScript(functionName, args);
+                    }
+
+                    @Override
+                    public void executeJavaScriptCode(String jsCode) {
+                        ClaudeChatWindow.this.executeJavaScriptCode(jsCode);
+                    }
+                },
+                permissionHandler,
+                () -> slashCommandsFetched,
+                this::onStreamEnded
         );
         session.setCallback(sessionCallbackAdapter);
     }
@@ -371,7 +476,7 @@ public class ClaudeChatWindow {
     private void registerSessionLoadListener() {
         SessionLoadService.getInstance().setListener((sessionId, projectPath) -> {
             ApplicationManager.getApplication().invokeLater(() ->
-                sessionLifecycleManager.loadHistorySession(sessionId, projectPath));
+                    sessionLifecycleManager.loadHistorySession(sessionId, projectPath));
         });
     }
 
@@ -483,59 +588,209 @@ public class ClaudeChatWindow {
 
     private WebviewInitializer.WebviewHost createWebviewHost() {
         return new WebviewInitializer.WebviewHost() {
-            @Override public Project getProject() { return project; }                       // Current IDEA project
-            @Override public ClaudeSDKBridge getClaudeSDKBridge() { return claudeSDKBridge; } // Claude SDK bridge for AI communication
-            @Override public CodexSDKBridge getCodexSDKBridge() { return codexSDKBridge; }   // Codex SDK bridge for AI communication
-            @Override public JPanel getMainPanel() { return mainPanel; }                     // Root UI panel for webview embedding
-            @Override public HtmlLoader getHtmlLoader() { return htmlLoader; }               // HTML resource loader for webview content
-            @Override public HandlerContext getHandlerContext() { return handlerContext; }    // Shared handler context (JS query, bridges, etc.)
-            @Override public JBCefBrowser getBrowser() { return browser; }                   // Current JCEF browser instance
-            @Override public void setBrowser(JBCefBrowser b) { browser = b; }                // Replace browser instance on recreate
-            @Override public boolean isDisposed() { return disposed; }                       // Check if window has been disposed
-            @Override public void handleJavaScriptMessage(String msg) { ClaudeChatWindow.this.handleJavaScriptMessage(msg); } // Route JS→Java messages
-            @Override public WebviewWatchdog getWebviewWatchdog() { return webviewWatchdog; } // Watchdog for webview health monitoring
-            @Override public void setFrontendReady(boolean ready) { frontendReady = ready; } // Mark frontend load state (reset on reload/recreate)
+            @Override
+            public Project getProject() {
+                return project;
+            }                       // Current IDEA project
+
+            @Override
+            public ClaudeSDKBridge getClaudeSDKBridge() {
+                return claudeSDKBridge;
+            } // Claude SDK bridge for AI communication
+
+            @Override
+            public CodexSDKBridge getCodexSDKBridge() {
+                return codexSDKBridge;
+            }   // Codex SDK bridge for AI communication
+
+            @Override
+            public JPanel getMainPanel() {
+                return mainPanel;
+            }                     // Root UI panel for webview embedding
+
+            @Override
+            public HtmlLoader getHtmlLoader() {
+                return htmlLoader;
+            }               // HTML resource loader for webview content
+
+            @Override
+            public HandlerContext getHandlerContext() {
+                return handlerContext;
+            }    // Shared handler context (JS query, bridges, etc.)
+
+            @Override
+            public JBCefBrowser getBrowser() {
+                return browser;
+            }                   // Current JCEF browser instance
+
+            @Override
+            public void setBrowser(JBCefBrowser b) {
+                browser = b;
+            }                // Replace browser instance on recreate
+
+            @Override
+            public boolean isDisposed() {
+                return disposed;
+            }                       // Check if window has been disposed
+
+            @Override
+            public void handleJavaScriptMessage(String msg) {
+                ClaudeChatWindow.this.handleJavaScriptMessage(msg);
+            } // Route JS→Java messages
+
+            @Override
+            public WebviewWatchdog getWebviewWatchdog() {
+                return webviewWatchdog;
+            } // Watchdog for webview health monitoring
+
+            @Override
+            public void setFrontendReady(boolean ready) {
+                frontendReady = ready;
+            } // Mark frontend load state (reset on reload/recreate)
         };
     }
 
     private ChatWindowDelegate.DelegateHost createDelegateHost() {
         return new ChatWindowDelegate.DelegateHost() {
             // --- Read-only accessors ---
-            @Override public Project getProject() { return project; }                       // Current IDEA project
-            @Override public ClaudeSDKBridge getClaudeSDKBridge() { return claudeSDKBridge; } // Claude SDK bridge for AI communication
-            @Override public CodexSDKBridge getCodexSDKBridge() { return codexSDKBridge; }   // Codex SDK bridge for AI communication
-            @Override public ClaudeSession getSession() { return session; }                  // Active Claude session instance
-            @Override public CodemossSettingsService getSettingsService() { return settingsService; } // Plugin settings (provider, API key, etc.)
-            @Override public JPanel getMainPanel() { return mainPanel; }                     // Root UI panel
-            @Override public JBCefBrowser getBrowser() { return browser; }                   // Current JCEF browser instance
-            @Override public boolean isDisposed() { return disposed; }                       // Check if window has been disposed
-            @Override public Content getParentContent() { return parentContent; }            // Tab content this window belongs to
-            @Override public String getOriginalTabName() { return originalTabName; }         // Original tab name before any rename
-            @Override public void setOriginalTabName(String name) { ClaudeChatWindow.this.setOriginalTabName(name); }
-            @Override public String getSessionId() { return sessionId; }                     // Unique session identifier
+            @Override
+            public Project getProject() {
+                return project;
+            }                       // Current IDEA project
+
+            @Override
+            public ClaudeSDKBridge getClaudeSDKBridge() {
+                return claudeSDKBridge;
+            } // Claude SDK bridge for AI communication
+
+            @Override
+            public CodexSDKBridge getCodexSDKBridge() {
+                return codexSDKBridge;
+            }   // Codex SDK bridge for AI communication
+
+            @Override
+            public ClaudeSession getSession() {
+                return session;
+            }                  // Active Claude session instance
+
+            @Override
+            public CodemossSettingsService getSettingsService() {
+                return settingsService;
+            } // Plugin settings (provider, API key, etc.)
+
+            @Override
+            public JPanel getMainPanel() {
+                return mainPanel;
+            }                     // Root UI panel
+
+            @Override
+            public JBCefBrowser getBrowser() {
+                return browser;
+            }                   // Current JCEF browser instance
+
+            @Override
+            public boolean isDisposed() {
+                return disposed;
+            }                       // Check if window has been disposed
+
+            @Override
+            public Content getParentContent() {
+                return parentContent;
+            }            // Tab content this window belongs to
+
+            @Override
+            public String getOriginalTabName() {
+                return originalTabName;
+            }         // Original tab name before any rename
+
+            @Override
+            public void setOriginalTabName(String name) {
+                ClaudeChatWindow.this.setOriginalTabName(name);
+            }
+
+            @Override
+            public String getSessionId() {
+                return sessionId;
+            }                     // Unique session identifier
 
             // --- Handler context & wiring (initialized during startup) ---
-            @Override public HandlerContext getHandlerContext() { return handlerContext; }    // Shared handler context (JS query, bridges, etc.)
-            @Override public void setHandlerContext(HandlerContext ctx) { handlerContext = ctx; }       // Set by initializeHandlers()
-            @Override public void setMessageDispatcher(MessageDispatcher d) { messageDispatcher = d; } // Set by initializeHandlers()
-            @Override public void setPermissionHandler(PermissionHandler h) { permissionHandler = h; } // Set by initializeHandlers()
-            @Override public void setHistoryHandler(HistoryHandler h) { historyHandler = h; }          // Set by initializeHandlers()
+            @Override
+            public HandlerContext getHandlerContext() {
+                return handlerContext;
+            }    // Shared handler context (JS query, bridges, etc.)
+
+            @Override
+            public void setHandlerContext(HandlerContext ctx) {
+                handlerContext = ctx;
+            }       // Set by initializeHandlers()
+
+            @Override
+            public void setMessageDispatcher(MessageDispatcher d) {
+                messageDispatcher = d;
+            } // Set by initializeHandlers()
+
+            @Override
+            public void setPermissionHandler(PermissionHandler h) {
+                permissionHandler = h;
+            } // Set by initializeHandlers()
+
+            @Override
+            public void setHistoryHandler(HistoryHandler h) {
+                historyHandler = h;
+            }          // Set by initializeHandlers()
 
             // --- Session & stream management ---
-            @Override public SessionLifecycleManager getSessionLifecycleManager() { return sessionLifecycleManager; } // Manages session start/stop lifecycle
-            @Override public StreamMessageCoalescer getStreamCoalescer() { return streamCoalescer; }                  // Throttles webview stream updates
-            @Override public WebviewWatchdog getWebviewWatchdog() { return webviewWatchdog; }                          // Watchdog for webview health monitoring
-            @Override public PermissionHandler getPermissionHandler() { return permissionHandler; }                    // Lazy access — may be null before initializeHandlers()
+            @Override
+            public SessionLifecycleManager getSessionLifecycleManager() {
+                return sessionLifecycleManager;
+            } // Manages session start/stop lifecycle
+
+            @Override
+            public StreamMessageCoalescer getStreamCoalescer() {
+                return streamCoalescer;
+            }                  // Throttles webview stream updates
+
+            @Override
+            public WebviewWatchdog getWebviewWatchdog() {
+                return webviewWatchdog;
+            }                          // Watchdog for webview health monitoring
+
+            @Override
+            public PermissionHandler getPermissionHandler() {
+                return permissionHandler;
+            }                    // Lazy access — may be null before initializeHandlers()
 
             // --- Actions & callbacks ---
-            @Override public void callJavaScript(String fn, String... args) { ClaudeChatWindow.this.callJavaScript(fn, args); } // Java→JS bridge call
-            @Override public void interruptDueToPermissionDenial() { ClaudeChatWindow.this.interruptDueToPermissionDenial(); }  // Abort session on permission deny
+            @Override
+            public void callJavaScript(String fn, String... args) {
+                ClaudeChatWindow.this.callJavaScript(fn, args);
+            } // Java→JS bridge call
+
+            @Override
+            public void interruptDueToPermissionDenial() {
+                ClaudeChatWindow.this.interruptDueToPermissionDenial();
+            }  // Abort session on permission deny
 
             // --- Mutable state flags ---
-            @Override public boolean isFrontendReady() { return frontendReady; }                       // Whether webview has finished loading
-            @Override public void setFrontendReady(boolean ready) { frontendReady = ready; }           // Updated on load complete / reload
-            @Override public void setSlashCommandsFetched(boolean fetched) { slashCommandsFetched = fetched; }       // Slash commands loaded from backend
-            @Override public void setFetchedSlashCommandsCount(int count) { fetchedSlashCommandsCount = count; }     // Number of slash commands fetched
+            @Override
+            public boolean isFrontendReady() {
+                return frontendReady;
+            }                       // Whether webview has finished loading
+
+            @Override
+            public void setFrontendReady(boolean ready) {
+                frontendReady = ready;
+            }           // Updated on load complete / reload
+
+            @Override
+            public void setSlashCommandsFetched(boolean fetched) {
+                slashCommandsFetched = fetched;
+            }       // Slash commands loaded from backend
+
+            @Override
+            public void setFetchedSlashCommandsCount(int count) {
+                fetchedSlashCommandsCount = count;
+            }     // Number of slash commands fetched
         };
     }
 }

--- a/src/main/java/com/github/claudecodegui/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSession.java
@@ -1,29 +1,26 @@
 package com.github.claudecodegui;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.intellij.openapi.diagnostic.Logger;
 import com.github.claudecodegui.handler.SettingsHandler;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.permission.PermissionManager;
 import com.github.claudecodegui.permission.PermissionRequest;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.service.RunConfigMonitorService;
 import com.github.claudecodegui.session.ClaudeMessageHandler;
 import com.github.claudecodegui.session.CodexMessageHandler;
 import com.github.claudecodegui.session.SessionState;
-import com.github.claudecodegui.util.EditorFileUtils;
-import com.github.claudecodegui.util.TokenUsageUtils;
-import com.intellij.openapi.application.ReadAction;
-import com.intellij.openapi.project.Project;
-import com.intellij.util.concurrency.AppExecutorUtil;
 import com.github.claudecodegui.terminal.TerminalMonitorService;
-import org.jetbrains.annotations.Nullable;
+import com.github.claudecodegui.util.TokenUsageUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 
 import java.util.ArrayList;
-import com.github.claudecodegui.service.RunConfigMonitorService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +38,9 @@ public class ClaudeSession {
 
     private static final Logger LOG = Logger.getInstance(ClaudeSession.class);
 
-    /** Maximum file size for Codex context injection (100KB) */
+    /**
+     * Maximum file size for Codex context injection (100KB)
+     */
     private static final int MAX_FILE_SIZE_BYTES = 100 * 1024;
 
     private final Gson gson = new Gson();
@@ -67,7 +66,9 @@ public class ClaudeSession {
     // Permission manager
     private final PermissionManager permissionManager = new PermissionManager();
 
-    /** Represents a single message in the conversation. */
+    /**
+     * Represents a single message in the conversation.
+     */
     public static class Message {
         public enum Type {
             USER, ASSISTANT, SYSTEM, ERROR
@@ -90,23 +91,44 @@ public class ClaudeSession {
         }
     }
 
-    /** Callback interface for session events. */
+    /**
+     * Callback interface for session events.
+     */
     public interface SessionCallback {
         void onMessageUpdate(List<Message> messages);
+
         void onStateChange(boolean busy, boolean loading, String error);
-        default void onStatusMessage(String message) {}
+
+        default void onStatusMessage(String message) {
+        }
+
         void onSessionIdReceived(String sessionId);
+
         void onPermissionRequested(PermissionRequest request);
+
         void onThinkingStatusChanged(boolean isThinking);
+
         void onSlashCommandsReceived(List<String> slashCommands);
+
         void onNodeLog(String log);
+
         void onSummaryReceived(String summary);
 
         // Streaming callback methods (with default implementations for backward compatibility)
-        default void onStreamStart() {}
-        default void onStreamEnd() {}
-        default void onContentDelta(String delta) {}
-        default void onThinkingDelta(String delta) {}
+        default void onStreamStart() {
+        }
+
+        default void onStreamEnd() {
+        }
+
+        default void onContentDelta(String delta) {
+        }
+
+        default void onThinkingDelta(String delta) {
+        }
+
+        default void onUsageUpdate(int usedTokens, int maxTokens) {
+        }
     }
 
     public ClaudeSession(Project project, ClaudeSDKBridge claudeSDKBridge, CodexSDKBridge codexSDKBridge) {
@@ -168,7 +190,9 @@ public class ClaudeSession {
         return state.getLastModifiedTime();
     }
 
-    /** Set session ID and working directory (used for session restoration). */
+    /**
+     * Set session ID and working directory (used for session restoration).
+     */
     public void setSessionInfo(String sessionId, String cwd) {
         state.setSessionId(sessionId);
         if (cwd != null) {
@@ -178,12 +202,16 @@ public class ClaudeSession {
         }
     }
 
-    /** Get the current working directory. */
+    /**
+     * Get the current working directory.
+     */
     public String getCwd() {
         return state.getCwd();
     }
 
-    /** Set the working directory. */
+    /**
+     * Set the working directory.
+     */
     public void setCwd(String cwd) {
         state.setCwd(cwd);
         LOG.info("Working directory updated to: " + cwd);
@@ -202,63 +230,64 @@ public class ClaudeSession {
         state.setChannelId(UUID.randomUUID().toString());
 
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                // Validate and clean invalid sessionId (e.g., path instead of UUID)
-                String currentSessionId = state.getSessionId();
-                if (currentSessionId != null && (currentSessionId.contains("/") || currentSessionId.contains("\\"))) {
-                    LOG.warn("sessionId looks like a path, resetting: " + currentSessionId);
-                    state.setSessionId(null);
-                    currentSessionId = null;
-                }
+                    try {
+                        // Validate and clean invalid sessionId (e.g., path instead of UUID)
+                        String currentSessionId = state.getSessionId();
+                        if (currentSessionId != null && (currentSessionId.contains("/") || currentSessionId.contains("\\"))) {
+                            LOG.warn("sessionId looks like a path, resetting: " + currentSessionId);
+                            state.setSessionId(null);
+                            currentSessionId = null;
+                        }
 
-                // Select SDK based on provider
-                JsonObject result;
-                String currentProvider = state.getProvider();
-                String currentChannelId = state.getChannelId();
-                String currentCwd = state.getCwd();
-                if ("codex".equals(currentProvider)) {
-                    result = codexSDKBridge.launchChannel(currentChannelId, currentSessionId, currentCwd);
-                } else {
-                    result = claudeSDKBridge.launchChannel(currentChannelId, currentSessionId, currentCwd);
-                }
+                        // Select SDK based on provider
+                        JsonObject result;
+                        String currentProvider = state.getProvider();
+                        String currentChannelId = state.getChannelId();
+                        String currentCwd = state.getCwd();
+                        if ("codex".equals(currentProvider)) {
+                            result = codexSDKBridge.launchChannel(currentChannelId, currentSessionId, currentCwd);
+                        } else {
+                            result = claudeSDKBridge.launchChannel(currentChannelId, currentSessionId, currentCwd);
+                        }
 
-                // Check if sessionId exists and is not null
-                if (result.has("sessionId") && !result.get("sessionId").isJsonNull()) {
-                    String newSessionId = result.get("sessionId").getAsString();
-                    // Validate sessionId format (should be UUID format)
-                    if (!newSessionId.contains("/") && !newSessionId.contains("\\")) {
-                        state.setSessionId(newSessionId);
-                        callbackHandler.notifySessionIdReceived(newSessionId);
-                    } else {
-                        LOG.warn("Ignoring invalid sessionId: " + newSessionId);
+                        // Check if sessionId exists and is not null
+                        if (result.has("sessionId") && !result.get("sessionId").isJsonNull()) {
+                            String newSessionId = result.get("sessionId").getAsString();
+                            // Validate sessionId format (should be UUID format)
+                            if (!newSessionId.contains("/") && !newSessionId.contains("\\")) {
+                                state.setSessionId(newSessionId);
+                                callbackHandler.notifySessionIdReceived(newSessionId);
+                            } else {
+                                LOG.warn("Ignoring invalid sessionId: " + newSessionId);
+                            }
+                        }
+
+                        return currentChannelId;
+                    } catch (Exception e) {
+                        state.setError(e.getMessage());
+                        state.setChannelId(null);
+                        updateState();
+                        throw new RuntimeException("Failed to launch: " + e.getMessage(), e);
                     }
-                }
-
-                return currentChannelId;
-            } catch (Exception e) {
-                state.setError(e.getMessage());
-                state.setChannelId(null);
-                updateState();
-                throw new RuntimeException("Failed to launch: " + e.getMessage(), e);
-            }
-        }).orTimeout(com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_TIMEOUT,
-                     com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_UNIT)
-          .exceptionally(ex -> {
-              if (ex instanceof java.util.concurrent.TimeoutException) {
-                  String timeoutMsg = "Channel launch timed out (" +
-                      com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_TIMEOUT + "s), please retry";
-                  LOG.warn(timeoutMsg);
-                  state.setError(timeoutMsg);
-                  state.setChannelId(null);
-                  updateState();
-                  throw new RuntimeException(timeoutMsg);
-              }
-              throw new RuntimeException(ex.getCause());
-          });
+                }).orTimeout(com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_TIMEOUT,
+                        com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_UNIT)
+                .exceptionally(ex -> {
+                    if (ex instanceof java.util.concurrent.TimeoutException) {
+                        String timeoutMsg = "Channel launch timed out (" +
+                                com.github.claudecodegui.config.TimeoutConfig.QUICK_OPERATION_TIMEOUT + "s), please retry";
+                        LOG.warn(timeoutMsg);
+                        state.setError(timeoutMsg);
+                        state.setChannelId(null);
+                        updateState();
+                        throw new RuntimeException(timeoutMsg);
+                    }
+                    throw new RuntimeException(ex.getCause());
+                });
     }
 
     /**
      * Send a message using global agent settings.
+     *
      * @deprecated Use {@link #send(String, String)} with explicit agent prompt instead.
      */
     @Deprecated
@@ -292,6 +321,7 @@ public class ClaudeSession {
 
     /**
      * Send a message with attachments using global agent settings.
+     *
      * @deprecated Use {@link #send(String, List, String)} with explicit agent prompt instead.
      */
     @Deprecated
@@ -302,7 +332,8 @@ public class ClaudeSession {
     /**
      * Send a message with attachments and a specific agent prompt.
      * Used for per-tab independent agent selection.
-     * @param input User input text
+     *
+     * @param input       User input text
      * @param attachments List of attachments (nullable)
      * @param agentPrompt Agent prompt (falls back to global setting if null)
      */
@@ -313,9 +344,10 @@ public class ClaudeSession {
     /**
      * Send a message with attachments, agent prompt, and file tags.
      * Used for Codex context injection.
-     * @param input User input text
-     * @param attachments List of attachments (nullable)
-     * @param agentPrompt Agent prompt (falls back to global setting if null)
+     *
+     * @param input        User input text
+     * @param attachments  List of attachments (nullable)
+     * @param agentPrompt  Agent prompt (falls back to global setting if null)
      * @param fileTagPaths File tag paths for Codex context injection
      */
     public CompletableFuture<Void> send(String input, List<Attachment> attachments, String agentPrompt, List<String> fileTagPaths) {
@@ -328,11 +360,11 @@ public class ClaudeSession {
      * requestedPermissionMode > sessionMode > default, with codex forced to bypassPermissions.
      */
     public CompletableFuture<Void> send(
-        String input,
-        List<Attachment> attachments,
-        String agentPrompt,
-        List<String> fileTagPaths,
-        String requestedPermissionMode
+            String input,
+            List<Attachment> attachments,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode
     ) {
         // Prepare user message
         String normalizedInput = (input != null) ? input.trim() : "";
@@ -366,15 +398,15 @@ public class ClaudeSession {
             contextCollector.setAutoOpenFileEnabled(autoOpenFileEnabled);
 
             return contextCollector.collectContext().thenCompose(openedFilesJson ->
-                sendMessageToProvider(
-                    chId,
-                    userMessage.content,
-                    attachments,
-                    openedFilesJson,
-                    finalAgentPrompt,
-                    finalFileTagPaths,
-                    finalRequestedPermissionMode
-                )
+                    sendMessageToProvider(
+                            chId,
+                            userMessage.content,
+                            attachments,
+                            openedFilesJson,
+                            finalAgentPrompt,
+                            finalFileTagPaths,
+                            finalRequestedPermissionMode
+                    )
             );
         }).exceptionally(ex -> {
             state.setError(ex.getMessage());
@@ -385,7 +417,9 @@ public class ClaudeSession {
         });
     }
 
-    /** Build a user message from input text and attachments. */
+    /**
+     * Build a user message from input text and attachments.
+     */
     private Message buildUserMessage(String normalizedInput, List<Attachment> attachments) {
         Message userMessage = new Message(Message.Type.USER, normalizedInput);
 
@@ -435,14 +469,15 @@ public class ClaudeSession {
 
     /**
      * Process @protocol://name reference patterns in the input text.
-     * @param input Input text
-     * @param protocol Protocol name (e.g., "terminal", "service")
-     * @param blockTitle Output block title (e.g., "Terminal Output")
+     *
+     * @param input           Input text
+     * @param protocol        Protocol name (e.g., "terminal", "service")
+     * @param blockTitle      Output block title (e.g., "Terminal Output")
      * @param contentResolver Content resolution function
      * @return Processed text with references replaced
      */
     private String processReferences(String input, String protocol, String blockTitle,
-                                      Function<String, String> contentResolver) {
+            Function<String, String> contentResolver) {
         Pattern pattern = Pattern.compile("@" + protocol + "://([a-zA-Z0-9_]+)");
         Matcher matcher = pattern.matcher(input);
         StringBuffer result = new StringBuffer();
@@ -531,14 +566,18 @@ public class ClaudeSession {
         });
     }
 
-    /** Check if the attachment is an image. */
+    /**
+     * Check if the attachment is an image.
+     */
     private boolean isImageAttachment(Attachment att) {
         if (att == null) return false;
         String mt = (att.mediaType != null) ? att.mediaType : "";
         return mt.startsWith("image/") && att.data != null;
     }
 
-    /** Create an image content block for the API request. */
+    /**
+     * Create an image content block for the API request.
+     */
     private JsonObject createImageBlock(Attachment att) {
         JsonObject imageBlock = new JsonObject();
         imageBlock.addProperty("type", "image");
@@ -552,7 +591,9 @@ public class ClaudeSession {
         return imageBlock;
     }
 
-    /** Create a text content block for the API request. */
+    /**
+     * Create a text content block for the API request.
+     */
     private JsonObject createTextBlock(String text) {
         JsonObject textBlock = new JsonObject();
         textBlock.addProperty("type", "text");
@@ -560,7 +601,9 @@ public class ClaudeSession {
         return textBlock;
     }
 
-    /** Generate a summary text for image-only messages. */
+    /**
+     * Generate a summary text for image-only messages.
+     */
     private String generateAttachmentSummary(List<Attachment> attachments) {
         int imageCount = 0;
         List<String> names = new ArrayList<>();
@@ -590,7 +633,9 @@ public class ClaudeSession {
         return "[Uploaded Attachments: " + String.join(", ", names) + "]";
     }
 
-    /** Update session state when sending a message. */
+    /**
+     * Update session state when sending a message.
+     */
     private void updateSessionStateForSend(Message userMessage, String normalizedInput) {
         // Add message to history
         state.addMessage(userMessage);
@@ -599,8 +644,8 @@ public class ClaudeSession {
         // Update summary (first message only)
         if (state.getSummary() == null) {
             String baseSummary = (userMessage.content != null && !userMessage.content.isEmpty())
-                ? userMessage.content
-                : normalizedInput;
+                    ? userMessage.content
+                    : normalizedInput;
             String newSummary = baseSummary.length() > 45 ? baseSummary.substring(0, 45) + "..." : baseSummary;
             state.setSummary(newSummary);
             callbackHandler.notifySummaryReceived(newSummary);
@@ -617,21 +662,22 @@ public class ClaudeSession {
 
     /**
      * Send message to the AI provider.
-     * @param channelId Channel ID
-     * @param input User input
-     * @param attachments Attachment list
-     * @param openedFilesJson Opened files context from IDE
+     *
+     * @param channelId           Channel ID
+     * @param input               User input
+     * @param attachments         Attachment list
+     * @param openedFilesJson     Opened files context from IDE
      * @param externalAgentPrompt External agent prompt (falls back to global setting if null)
-     * @param fileTagPaths File tag paths for Codex context injection
+     * @param fileTagPaths        File tag paths for Codex context injection
      */
     private CompletableFuture<Void> sendMessageToProvider(
-        String channelId,
-        String input,
-        List<Attachment> attachments,
-        JsonObject openedFilesJson,
-        String externalAgentPrompt,
-        List<String> fileTagPaths,
-        String requestedPermissionMode
+            String channelId,
+            String input,
+            List<Attachment> attachments,
+            JsonObject openedFilesJson,
+            String externalAgentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode
     ) {
         // Prefer external agent prompt; fall back to global setting if not provided
         String agentPrompt = externalAgentPrompt;
@@ -648,27 +694,27 @@ public class ClaudeSession {
         String sessionModeBeforeSend = state.getPermissionMode();
         String normalizedRequestedMode = normalizeRequestedPermissionMode(requestedPermissionMode);
         String effectivePermissionMode = resolveEffectivePermissionMode(
-            currentProvider,
-            normalizedRequestedMode,
-            sessionModeBeforeSend
+                currentProvider,
+                normalizedRequestedMode,
+                sessionModeBeforeSend
         );
 
         LOG.info(
-            "[ModeSync][Backend] provider=" + currentProvider
-                + ", requested=" + (normalizedRequestedMode != null ? normalizedRequestedMode : "(none)")
-                + ", session=" + (sessionModeBeforeSend != null ? sessionModeBeforeSend : "(none)")
-                + ", effective=" + effectivePermissionMode
+                "[ModeSync][Backend] provider=" + currentProvider
+                        + ", requested=" + (normalizedRequestedMode != null ? normalizedRequestedMode : "(none)")
+                        + ", session=" + (sessionModeBeforeSend != null ? sessionModeBeforeSend : "(none)")
+                        + ", effective=" + effectivePermissionMode
         );
 
         if ("codex".equals(currentProvider)) {
             return sendToCodex(
-                channelId,
-                input,
-                attachments,
-                openedFilesJson,
-                agentPrompt,
-                fileTagPaths,
-                effectivePermissionMode
+                    channelId,
+                    input,
+                    attachments,
+                    openedFilesJson,
+                    agentPrompt,
+                    fileTagPaths,
+                    effectivePermissionMode
             );
         } else {
             return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt, effectivePermissionMode);
@@ -677,16 +723,17 @@ public class ClaudeSession {
 
     /**
      * Send message via Codex SDK.
+     *
      * @param fileTagPaths File tag paths for context injection
      */
     private CompletableFuture<Void> sendToCodex(
-        String channelId,
-        String input,
-        List<Attachment> attachments,
-        JsonObject openedFilesJson,
-        String agentPrompt,
-        List<String> fileTagPaths,
-        String effectivePermissionMode
+            String channelId,
+            String input,
+            List<Attachment> attachments,
+            JsonObject openedFilesJson,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String effectivePermissionMode
     ) {
         CodexMessageHandler handler = new CodexMessageHandler(state, callbackHandler);
 
@@ -694,24 +741,25 @@ public class ClaudeSession {
         String finalInput = (input != null ? input : "") + contextAppend;
 
         return codexSDKBridge.sendMessage(
-            channelId,
-            finalInput,
-            state.getSessionId(),
-            state.getCwd(),
-            attachments,
-            effectivePermissionMode,
-            state.getModel(),
-            agentPrompt,
-            state.getReasoningEffort(),
-            handler
+                channelId,
+                finalInput,
+                state.getSessionId(),
+                state.getCwd(),
+                attachments,
+                effectivePermissionMode,
+                state.getModel(),
+                agentPrompt,
+                state.getReasoningEffort(),
+                handler
         ).thenApply(result -> null);
     }
 
     /**
      * Build context content to append to Codex messages.
      * Handles IDE open files, selected code, and user file tags for context injection.
+     *
      * @param openedFilesJson IDE open file info (includes active file and selection)
-     * @param fileTagPaths User-added file tag paths from the input box
+     * @param fileTagPaths    User-added file tag paths from the input box
      */
     private String buildCodexContextAppend(JsonObject openedFilesJson, List<String> fileTagPaths) {
         StringBuilder sb = new StringBuilder();
@@ -836,6 +884,7 @@ public class ClaudeSession {
 
     /**
      * Read file content with size limit.
+     *
      * @param filePath File path
      * @return File content, or null if reading fails
      */
@@ -856,7 +905,7 @@ public class ClaudeSession {
                     int bytesRead = fis.read(buffer);
                     if (bytesRead > 0) {
                         return new String(buffer, 0, bytesRead, java.nio.charset.StandardCharsets.UTF_8)
-                            + "\n\n... (file truncated, showing first 100KB of " + (fileSize / 1024) + "KB)";
+                                + "\n\n... (file truncated, showing first 100KB of " + (fileSize / 1024) + "KB)";
                     }
                 }
                 return null;
@@ -871,7 +920,9 @@ public class ClaudeSession {
         }
     }
 
-    /** Get file extension for code block syntax highlighting. */
+    /**
+     * Get file extension for code block syntax highlighting.
+     */
     private String getFileExtension(String filePath) {
         if (filePath == null) return "";
         int lastDot = filePath.lastIndexOf('.');
@@ -881,22 +932,24 @@ public class ClaudeSession {
         return "";
     }
 
-    /** Send message via Claude SDK. */
+    /**
+     * Send message via Claude SDK.
+     */
     private CompletableFuture<Void> sendToClaude(
-        String channelId,
-        String input,
-        List<Attachment> attachments,
-        JsonObject openedFilesJson,
-        String agentPrompt,
-        String effectivePermissionMode
+            String channelId,
+            String input,
+            List<Attachment> attachments,
+            JsonObject openedFilesJson,
+            String agentPrompt,
+            String effectivePermissionMode
     ) {
         ClaudeMessageHandler handler = new ClaudeMessageHandler(
-            project,
-            state,
-            callbackHandler,
-            messageParser,
-            messageMerger,
-            gson
+                project,
+                state,
+                callbackHandler,
+                messageParser,
+                messageMerger,
+                gson
         );
 
         // Read streaming configuration
@@ -915,40 +968,40 @@ public class ClaudeSession {
         final String previousSessionId = state.getSessionId();
 
         return claudeSDKBridge.sendMessage(
-            channelId,
-            input,
-            state.getSessionId(),
-            state.getCwd(),
-            attachments,
-            effectivePermissionMode,
-            state.getModel(),
-            openedFilesJson,
-            agentPrompt,
-            streaming,
-            handler
-        ).thenApply(result -> null)
-        .thenCompose(v -> {
-            // Add a small delay to ensure JSONL file is written and flushed
-            // Non-streaming responses return very fast, and filesystem I/O may not be complete yet
-            return CompletableFuture.runAsync(() -> {
-                try {
-                    Thread.sleep(100); // 100ms delay to allow file system flush
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-                updateUserMessageUuids();
-            });
-        }).whenComplete((unused, throwable) -> {
-            if (throwable == null
-                    && (previousSessionId == null || previousSessionId.isEmpty())
-                    && state.getSessionId() != null && !state.getSessionId().isEmpty()) {
-                // Refill anonymous warm runtime after first turn captures a session ID,
-                // so the next new chat can also hit a pre-warmed path.
-                // NOTE: Idle anonymous runtimes are cleaned up by persistent-query-service's
-                // cleanupStaleAnonymousRuntimes() (ANONYMOUS_RUNTIME_MAX_IDLE_MS = 10min).
-                claudeSDKBridge.prewarmDaemonAsync(state.getCwd());
-            }
-        });
+                        channelId,
+                        input,
+                        state.getSessionId(),
+                        state.getCwd(),
+                        attachments,
+                        effectivePermissionMode,
+                        state.getModel(),
+                        openedFilesJson,
+                        agentPrompt,
+                        streaming,
+                        handler
+                ).thenApply(result -> null)
+                .thenCompose(v -> {
+                    // Add a small delay to ensure JSONL file is written and flushed
+                    // Non-streaming responses return very fast, and filesystem I/O may not be complete yet
+                    return CompletableFuture.runAsync(() -> {
+                        try {
+                            Thread.sleep(100); // 100ms delay to allow file system flush
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        updateUserMessageUuids();
+                    });
+                }).whenComplete((unused, throwable) -> {
+                    if (throwable == null
+                            && (previousSessionId == null || previousSessionId.isEmpty())
+                            && state.getSessionId() != null && !state.getSessionId().isEmpty()) {
+                        // Refill anonymous warm runtime after first turn captures a session ID,
+                        // so the next new chat can also hit a pre-warmed path.
+                        // NOTE: Idle anonymous runtimes are cleaned up by persistent-query-service's
+                        // cleanupStaleAnonymousRuntimes() (ANONYMOUS_RUNTIME_MAX_IDLE_MS = 10min).
+                        claudeSDKBridge.prewarmDaemonAsync(state.getCwd());
+                    }
+                });
     }
 
     private String normalizeRequestedPermissionMode(String mode) {
@@ -1109,7 +1162,9 @@ public class ClaudeSession {
         return null;
     }
 
-    /** Get the agent prompt from settings. */
+    /**
+     * Get the agent prompt from settings.
+     */
     private String getAgentPrompt() {
         try {
             CodemossSettingsService settingsService = new CodemossSettingsService();
@@ -1137,7 +1192,9 @@ public class ClaudeSession {
         return null;
     }
 
-    /** Interrupt the current execution. */
+    /**
+     * Interrupt the current execution.
+     */
     public CompletableFuture<Void> interrupt() {
         if (state.getChannelId() == null) {
             return CompletableFuture.completedFuture(null);
@@ -1171,7 +1228,9 @@ public class ClaudeSession {
         });
     }
 
-    /** Restart the Claude agent. */
+    /**
+     * Restart the Claude agent.
+     */
     public CompletableFuture<Void> restart() {
         return interrupt().thenCompose(v -> {
             state.setChannelId(null);
@@ -1181,7 +1240,9 @@ public class ClaudeSession {
         });
     }
 
-    /** Load message history from the server. */
+    /**
+     * Load message history from the server.
+     */
     public CompletableFuture<Void> loadFromServer() {
         if (state.getSessionId() == null) {
             return CompletableFuture.completedFuture(null);
@@ -1250,15 +1311,19 @@ public class ClaudeSession {
         }
     }
 
-    /** Notify callback of message updates. */
+    /**
+     * Notify callback of message updates.
+     */
     private void notifyMessageUpdate() {
         callbackHandler.notifyMessageUpdate(getMessages());
     }
 
-    /** Notify callback of state changes. */
+    /**
+     * Notify callback of state changes.
+     */
     private void updateState() {
         callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
-        
+
         // Show error in status bar
         String error = state.getError();
         if (error != null && !error.isEmpty()) {
@@ -1266,7 +1331,9 @@ public class ClaudeSession {
         }
     }
 
-    /** Represents a file attachment (e.g., image). */
+    /**
+     * Represents a file attachment (e.g., image).
+     */
     public static class Attachment {
         public String fileName;
         public String mediaType;
@@ -1279,7 +1346,9 @@ public class ClaudeSession {
         }
     }
 
-    /** Get the permission manager. */
+    /**
+     * Get the permission manager.
+     */
     public PermissionManager getPermissionManager() {
         return permissionManager;
     }
@@ -1315,62 +1384,83 @@ public class ClaudeSession {
         permissionManager.setPermissionMode(pmMode);
     }
 
-    /** Get the permission mode. */
+    /**
+     * Get the permission mode.
+     */
     public String getPermissionMode() {
         return state.getPermissionMode();
     }
 
-    /** Set the model. */
+    /**
+     * Set the model.
+     */
     public void setModel(String model) {
         state.setModel(model);
         LOG.info("Model updated to: " + model);
     }
 
-    /** Get the model. */
+    /**
+     * Get the model.
+     */
     public String getModel() {
         return state.getModel();
     }
 
-    /** Set the AI provider. */
+    /**
+     * Set the AI provider.
+     */
     public void setProvider(String provider) {
         state.setProvider(provider);
         LOG.info("Provider updated to: " + provider);
     }
 
-    /** Get the AI provider. */
+    /**
+     * Get the AI provider.
+     */
     public String getProvider() {
         return state.getProvider();
     }
 
-    /** Set the reasoning effort level. */
+    /**
+     * Set the reasoning effort level.
+     */
     public void setReasoningEffort(String effort) {
         state.setReasoningEffort(effort);
         LOG.info("Reasoning effort updated to: " + effort);
     }
 
-    /** Get the reasoning effort level. */
+    /**
+     * Get the reasoning effort level.
+     */
     public String getReasoningEffort() {
         return state.getReasoningEffort();
     }
 
-    /** Get the list of available slash commands. */
+    /**
+     * Get the list of available slash commands.
+     */
     public List<String> getSlashCommands() {
         return state.getSlashCommands();
     }
 
 
-
-    /** Create a permission request (called by the SDK). */
+    /**
+     * Create a permission request (called by the SDK).
+     */
     public PermissionRequest createPermissionRequest(String toolName, Map<String, Object> inputs, JsonObject suggestions, Project project) {
         return permissionManager.createRequest(state.getChannelId(), toolName, inputs, suggestions, project);
     }
 
-    /** Handle a permission decision. */
+    /**
+     * Handle a permission decision.
+     */
     public void handlePermissionDecision(String channelId, boolean allow, boolean remember, String rejectMessage) {
         permissionManager.handlePermissionDecision(channelId, allow, remember, rejectMessage);
     }
 
-    /** Handle an "always allow" permission decision. */
+    /**
+     * Handle an "always allow" permission decision.
+     */
     public void handlePermissionDecisionAlways(String channelId, boolean allow) {
         permissionManager.handlePermissionDecisionAlways(channelId, allow);
     }

--- a/src/main/java/com/github/claudecodegui/notifications/ClaudeStatusBarWidget.java
+++ b/src/main/java/com/github/claudecodegui/notifications/ClaudeStatusBarWidget.java
@@ -7,8 +7,8 @@ import com.intellij.openapi.wm.CustomStatusBarWidget;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
 import com.intellij.openapi.wm.StatusBarWidgetFactory;
-import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.WindowManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,13 +47,24 @@ public class ClaudeStatusBarWidget implements CustomStatusBarWidget, StatusBarWi
     }
 
     @Override
-    public @NotNull String ID() { return "ClaudeStatusBarWidget"; }
+    public @NotNull String ID() {
+        return "ClaudeStatusBarWidget";
+    }
 
     @Override
     public @NotNull WidgetPresentation getPresentation() {
         return new WidgetPresentation() {
-            @Nullable @Override public String getTooltipText() { return tooltipRef.get(); }
-            @Nullable @Override public com.intellij.util.Consumer<MouseEvent> getClickConsumer() { return null; }
+            @Nullable
+            @Override
+            public String getTooltipText() {
+                return tooltipRef.get();
+            }
+
+            @Nullable
+            @Override
+            public com.intellij.util.Consumer<MouseEvent> getClickConsumer() {
+                return null;
+            }
         };
     }
 
@@ -78,7 +89,9 @@ public class ClaudeStatusBarWidget implements CustomStatusBarWidget, StatusBarWi
     }
 
     @Override
-    public void install(@NotNull StatusBar statusBar) { this.statusBar = statusBar; }
+    public void install(@NotNull StatusBar statusBar) {
+        this.statusBar = statusBar;
+    }
 
     @Override
     public void dispose() {
@@ -168,6 +181,11 @@ public class ClaudeStatusBarWidget implements CustomStatusBarWidget, StatusBarWi
             text.append(" ").append(statusText);
         }
 
+        // Add Token Info
+        if (tokenInfo != null && !tokenInfo.isEmpty()) {
+            text.append(" ").append(tokenInfo);
+        }
+
         StringBuilder tooltip = new StringBuilder(ClaudeCodeGuiBundle.message("status.tooltip.status", status));
         if (model != null && !model.isEmpty()) {
             tooltip.append(ClaudeCodeGuiBundle.message("status.tooltip.model", model));
@@ -219,11 +237,30 @@ public class ClaudeStatusBarWidget implements CustomStatusBarWidget, StatusBarWi
     }
 
     public static class Factory implements StatusBarWidgetFactory {
-        @Override public @NotNull String getId() { return "ClaudeStatusBarWidget"; }
-        @Override public @NotNull String getDisplayName() { return ClaudeCodeGuiBundle.message("status.widgetName"); }
-        @Override public boolean isAvailable(@NotNull Project project) { return project != null; }
-        @Override public @NotNull StatusBarWidget createWidget(@NotNull Project project) { return new ClaudeStatusBarWidget(project); }
-        @Override public void disposeWidget(@NotNull StatusBarWidget widget) { widget.dispose(); }
+        @Override
+        public @NotNull String getId() {
+            return "ClaudeStatusBarWidget";
+        }
+
+        @Override
+        public @NotNull String getDisplayName() {
+            return ClaudeCodeGuiBundle.message("status.widgetName");
+        }
+
+        @Override
+        public boolean isAvailable(@NotNull Project project) {
+            return project != null;
+        }
+
+        @Override
+        public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+            return new ClaudeStatusBarWidget(project);
+        }
+
+        @Override
+        public void disposeWidget(@NotNull StatusBarWidget widget) {
+            widget.dispose();
+        }
 
         @Nullable
         public static ClaudeStatusBarWidget getWidget(@NotNull Project project) {

--- a/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
@@ -87,6 +87,7 @@ public class CallbackHandler {
             callback.onNodeLog(log);
         }
     }
+
     public void notifySummaryReceived(String summary) {
         if (callback != null) {
             callback.onSummaryReceived(summary);
@@ -127,6 +128,15 @@ public class CallbackHandler {
     public void notifyThinkingDelta(String delta) {
         if (callback != null) {
             callback.onThinkingDelta(delta);
+        }
+    }
+
+    /**
+     * Notify of a usage update.
+     */
+    public void notifyUsageUpdate(int usedTokens, int maxTokens) {
+        if (callback != null) {
+            callback.onUsageUpdate(usedTokens, maxTokens);
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -1,11 +1,10 @@
 package com.github.claudecodegui.session;
 
-import com.github.claudecodegui.provider.common.MessageCallback;
-import com.github.claudecodegui.provider.common.SDKResult;
-import com.github.claudecodegui.ClaudeSession;
 import com.github.claudecodegui.ClaudeSession.Message;
 import com.github.claudecodegui.handler.SettingsHandler;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
+import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.util.TokenUsageUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -53,12 +52,12 @@ public class ClaudeMessageHandler implements MessageCallback {
      * Constructor.
      */
     public ClaudeMessageHandler(
-        Project project,
-        SessionState state,
-        CallbackHandler callbackHandler,
-        MessageParser messageParser,
-        MessageMerger messageMerger,
-        Gson gson
+            Project project,
+            SessionState state,
+            CallbackHandler callbackHandler,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson
     ) {
         this.project = project;
         this.state = state;
@@ -113,7 +112,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                 handleMessageEnd();
                 break;
             case "result":
-                handleResult(content);
+                handleResult();
                 break;
             case "usage":
                 handleUsage(content);
@@ -238,6 +237,20 @@ public class ClaudeMessageHandler implements MessageCallback {
                 }
             } else {
                 LOG.debug("Streaming active, skipping full message update in handleAssistantMessage");
+            }
+
+            // Update status bar with usage from the final assistant message (matches CLI's PP1 behavior)
+            // This ensures the displayed value matches what resume shows from JSONL history
+            if (mergedRaw.has("message") && mergedRaw.get("message").isJsonObject()) {
+                JsonObject messageObj = mergedRaw.getAsJsonObject("message");
+                if (messageObj.has("usage") && messageObj.get("usage").isJsonObject()) {
+                    JsonObject usage = messageObj.getAsJsonObject("usage");
+                    int usedTokens = TokenUsageUtils.extractUsedTokens(usage, state.getProvider());
+                    int maxTokens = SettingsHandler.getModelContextLimit(state.getModel());
+                    ClaudeNotifier.setTokenUsage(project, usedTokens, maxTokens);
+                    callbackHandler.notifyUsageUpdate(usedTokens, maxTokens);
+                    LOG.debug("Updated token usage from assistant message: " + usedTokens);
+                }
             }
         } catch (Exception e) {
             LOG.warn("Failed to parse assistant message JSON: " + e.getMessage());
@@ -390,8 +403,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         try {
             JsonObject toolResultBlock = gson.fromJson(content, JsonObject.class);
             String toolUseId = toolResultBlock.has("tool_use_id")
-                ? toolResultBlock.get("tool_use_id").getAsString()
-                : null;
+                    ? toolResultBlock.get("tool_use_id").getAsString()
+                    : null;
 
             if (toolUseId != null) {
                 // Build a user message containing the tool_result
@@ -436,56 +449,14 @@ public class ClaudeMessageHandler implements MessageCallback {
     }
 
     /**
-     * Handle the result message containing usage statistics.
+     * Handle the result message (intentionally no-op for status bar).
+     * result.usage is the cumulative total across all tool-call turns in the session
+     * (used for billing, not context window display). The status bar is correctly
+     * updated by handleUsage() from each turn's [USAGE] tag, which reflects
+     * per-turn context window usage — matching CLI's PP1() behavior.
      */
-    private void handleResult(String content) {
-        if (!content.startsWith("{")) {
-            return;
-        }
-
-        try {
-            JsonObject resultJson = gson.fromJson(content, JsonObject.class);
-            LOG.debug("Result message received");
-
-            // Always update status bar with token usage if available in result
-            if (resultJson.has("usage")) {
-                JsonObject resultUsage = resultJson.getAsJsonObject("usage");
-                int usedTokens = TokenUsageUtils.extractUsedTokens(resultUsage, state.getProvider());
-                int maxTokens = SettingsHandler.getModelContextLimit(state.getModel());
-                ClaudeNotifier.setTokenUsage(project, usedTokens, maxTokens);
-            }
-
-            // If the current message's raw usage is all zeros, update it with the result's usage
-            if (currentAssistantMessage != null && currentAssistantMessage.raw != null) {
-                JsonObject message = currentAssistantMessage.raw.has("message") && currentAssistantMessage.raw.get("message").isJsonObject()
-                    ? currentAssistantMessage.raw.getAsJsonObject("message")
-                    : null;
-
-                // Check if the current message's usage is all zeros
-                boolean needsUsageUpdate = false;
-                if (message != null && message.has("usage")) {
-                    JsonObject usage = message.getAsJsonObject("usage");
-                    int inputTokens = usage.has("input_tokens") ? usage.get("input_tokens").getAsInt() : 0;
-                    int outputTokens = usage.has("output_tokens") ? usage.get("output_tokens").getAsInt() : 0;
-                    if (inputTokens == 0 && outputTokens == 0) {
-                        needsUsageUpdate = true;
-                    }
-                } else {
-                    needsUsageUpdate = true;
-                }
-
-                if (needsUsageUpdate && resultJson.has("usage")) {
-                    JsonObject resultUsage = resultJson.getAsJsonObject("usage");
-                    if (message != null) {
-                        message.add("usage", resultUsage);
-                        callbackHandler.notifyMessageUpdate(state.getMessages());
-                        LOG.debug("Updated assistant message usage from result message");
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to parse result message: " + e.getMessage());
-        }
+    private void handleResult() {
+        LOG.debug("Result message received");
     }
 
     /**
@@ -608,11 +579,11 @@ public class ClaudeMessageHandler implements MessageCallback {
         ensureCurrentAssistantMessageExists();
         JsonObject raw = currentAssistantMessage.raw;
         JsonObject message = raw.has("message") && raw.get("message").isJsonObject()
-            ? raw.getAsJsonObject("message")
-            : new JsonObject();
+                ? raw.getAsJsonObject("message")
+                : new JsonObject();
         JsonArray content = message.has("content") && message.get("content").isJsonArray()
-            ? message.getAsJsonArray("content")
-            : new JsonArray();
+                ? message.getAsJsonArray("content")
+                : new JsonArray();
         message.add("content", content);
         raw.add("message", message);
         currentAssistantMessage.raw = raw;
@@ -647,8 +618,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         }
 
         String existing = target.has("text") && !target.get("text").isJsonNull()
-            ? target.get("text").getAsString()
-            : "";
+                ? target.get("text").getAsString()
+                : "";
         target.addProperty("text", existing + delta);
     }
 
@@ -662,36 +633,30 @@ public class ClaudeMessageHandler implements MessageCallback {
             int usedTokens = TokenUsageUtils.extractUsedTokens(usageJson, state.getProvider());
             int maxTokens = SettingsHandler.getModelContextLimit(state.getModel());
             ClaudeNotifier.setTokenUsage(project, usedTokens, maxTokens);
+            // Notify webview of usage update
+            callbackHandler.notifyUsageUpdate(usedTokens, maxTokens);
+            // Ensure assistant message exists before backfilling usage
+            ensureCurrentAssistantMessageExists();
             backfillUsageToAssistantMessage(usageJson);
+            LOG.debug("Updated token usage from [USAGE] tag: " + usedTokens);
         } catch (Exception e) {
             LOG.warn("Failed to parse usage data: " + e.getMessage());
         }
     }
 
     /**
-     * Backfill usage data into the current assistant message's raw JSON if it has zero/missing usage.
+     * Backfill usage data into the current assistant message's raw JSON.
+     * Always updates during streaming to capture accumulating usage data.
      */
     private void backfillUsageToAssistantMessage(JsonObject usageJson) {
         if (currentAssistantMessage == null || currentAssistantMessage.raw == null) return;
         JsonObject message = currentAssistantMessage.raw.has("message") && currentAssistantMessage.raw.get("message").isJsonObject()
-            ? currentAssistantMessage.raw.getAsJsonObject("message") : null;
+                ? currentAssistantMessage.raw.getAsJsonObject("message") : null;
         if (message == null) return;
 
-        boolean needsUpdate;
-        if (message.has("usage") && message.get("usage").isJsonObject()) {
-            JsonObject usage = message.getAsJsonObject("usage");
-            int existingInput = usage.has("input_tokens") ? usage.get("input_tokens").getAsInt() : 0;
-            int existingOutput = usage.has("output_tokens") ? usage.get("output_tokens").getAsInt() : 0;
-            needsUpdate = (existingInput == 0 && existingOutput == 0);
-        } else {
-            needsUpdate = true;
-        }
-
-        if (needsUpdate) {
-            message.add("usage", usageJson);
-            callbackHandler.notifyMessageUpdate(state.getMessages());
-            LOG.debug("Updated assistant message usage from [USAGE] tag");
-        }
+        // Always update usage during streaming to capture accumulating values
+        message.add("usage", usageJson);
+        LOG.debug("Updated assistant message usage from [USAGE] tag");
     }
 
     private void applyThinkingDeltaToRaw(String delta) {
@@ -722,8 +687,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         }
 
         String existing = target.has("thinking") && !target.get("thinking").isJsonNull()
-            ? target.get("thinking").getAsString()
-            : "";
+                ? target.get("thinking").getAsString()
+                : "";
         target.addProperty("thinking", existing + delta);
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -25,6 +25,8 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
      */
     public interface JsTarget {
         void callJavaScript(String functionName, String... args);
+
+        void executeJavaScriptCode(String jsCode);
     }
 
     private final StreamMessageCoalescer streamCoalescer;
@@ -165,6 +167,22 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     @Override
     public void onThinkingDelta(String delta) {
         jsTarget.callJavaScript("onThinkingDelta", JsUtils.escapeJs(delta));
+    }
+
+    @Override
+    public void onUsageUpdate(int usedTokens, int maxTokens) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            double percentage = maxTokens > 0 ? (usedTokens * 100.0 / maxTokens) : 0.0;
+            String json = String.format("{\"percentage\":%.2f,\"usedTokens\":%d,\"maxTokens\":%d}",
+                    percentage, usedTokens, maxTokens);
+            String js = "(function() {" +
+                    "  if (typeof window.onUsageUpdate === 'function') {" +
+                    "    window.onUsageUpdate('" + JsUtils.escapeJs(json) + "');" +
+                    "  }" +
+                    "})();";
+            jsTarget.executeJavaScriptCode(js);
+            LOG.debug("Usage update sent to frontend: " + usedTokens + "/" + maxTokens);
+        });
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/TokenUsageUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/TokenUsageUtils.java
@@ -12,32 +12,33 @@ import java.util.List;
  */
 public final class TokenUsageUtils {
 
-    private TokenUsageUtils() {} // utility class, no instances
+    private TokenUsageUtils() {
+    } // utility class, no instances
 
     /**
-     * Calculate context window token usage for Claude provider.
-     * Formula: input_tokens + cache_creation_input_tokens + cache_read_input_tokens
-     * (output_tokens excluded — they don't count toward context window until next turn)
+     * Calculate total token usage for display in status bar.
+     * Formula: input_tokens + cache_creation_input_tokens + cache_read_input_tokens + output_tokens
+     * This matches CLI's status bar display which shows total tokens used (not just context window).
      */
-    public static int calculateContextWindowTokens(int inputTokens, int cacheCreationTokens, int cacheReadTokens) {
-        return inputTokens + cacheCreationTokens + cacheReadTokens;
+    public static int calculateContextWindowTokens(int inputTokens, int cacheCreationTokens, int cacheReadTokens, int outputTokens) {
+        return inputTokens + cacheCreationTokens + cacheReadTokens + outputTokens;
     }
 
     /**
      * Extract used token count from a usage JSON object, respecting provider differences.
-     * - Claude: input + cache_creation + cache_read (output excluded)
+     * - Claude: input + cache_creation + cache_read + output (total tokens, matches CLI status bar)
      * - Codex: input + output (input already includes cached tokens)
      */
     public static int extractUsedTokens(JsonObject usage, String provider) {
         if (usage == null) return 0;
         int input = usage.has("input_tokens") ? usage.get("input_tokens").getAsInt() : 0;
+        int output = usage.has("output_tokens") ? usage.get("output_tokens").getAsInt() : 0;
         if ("codex".equals(provider)) {
-            int output = usage.has("output_tokens") ? usage.get("output_tokens").getAsInt() : 0;
             return input + output;
         }
         int cacheCreation = usage.has("cache_creation_input_tokens") ? usage.get("cache_creation_input_tokens").getAsInt() : 0;
         int cacheRead = usage.has("cache_read_input_tokens") ? usage.get("cache_read_input_tokens").getAsInt() : 0;
-        return calculateContextWindowTokens(input, cacheCreation, cacheRead);
+        return calculateContextWindowTokens(input, cacheCreation, cacheRead, output);
     }
 
     /**

--- a/webview/src/components/ChatInputBox/TokenIndicator.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.tsx
@@ -22,11 +22,10 @@ export const TokenIndicator = ({
   // Calculate offset (fill clockwise from top)
   const strokeOffset = circumference * (1 - percentage / 100);
 
-  // Round percentage to one decimal place, but hide trailing .0
-  const rounded = Math.round(percentage * 10) / 10;
-  const formattedPercentage = Number.isInteger(rounded)
-    ? `${Math.round(rounded)}%`
-    : `${rounded.toFixed(1)}%`;
+  // Indicator label: integer percentage (no decimal)
+  const labelPercentage = `${Math.round(percentage)}%`;
+  // Tooltip: one decimal place for precision
+  const tooltipPercentage = `${(Math.round(percentage * 10) / 10).toFixed(1)}%`;
 
   const formatTokens = (value?: number) => {
     if (typeof value !== 'number' || !isFinite(value)) return undefined;
@@ -43,8 +42,8 @@ export const TokenIndicator = ({
   const usedText = formatTokens(usedTokens);
   const maxText = formatTokens(maxTokens);
   const tooltip = usedText && maxText
-    ? `${formattedPercentage} · ${usedText} / ${maxText} ${' '}${t('chat.context')}`
-    : t('chat.usagePercentage', { percentage: formattedPercentage });
+    ? `${tooltipPercentage} · ${usedText} / ${maxText} ${' '}${t('chat.context')}`
+    : t('chat.usagePercentage', { percentage: tooltipPercentage });
 
   return (
     <div className="token-indicator">
@@ -77,7 +76,7 @@ export const TokenIndicator = ({
           {tooltip}
         </div>
       </div>
-      <span className="token-percentage-label">{formattedPercentage}</span>
+      <span className="token-percentage-label">{labelPercentage}</span>
     </div>
   );
 };


### PR DESCRIPTION
- Reset per-turn token accumulator on message_start (matches CLI's unconditional reset)
- Unify IPC output to process.stdout.write for consistent buffering
- Emit final accumulated usage before [STREAM_END] marker
- Add onUsageUpdate callback chain to notify webview TokenIndicator
- Include output_tokens in total token calculation to match CLI display
- Simplify handleResult to no-op (result.usage is cumulative billing, not context window)
- Show token info in IDEA status bar widget