### PR TITLE
feat: improve Codex tool rendering with smart classification and file navigation

### DIFF
--- a/ai-bridge/services/codex/message-service.js
+++ b/ai-bridge/services/codex/message-service.js
@@ -525,8 +525,13 @@ export async function sendMessage(
       // Extract actual command from shell wrapper
       const actualCmd = extractActualCommand(command);
 
+      // List/find commands -> glob
+      if (/^(ls|find|tree)\b/.test(actualCmd)) {
+        return 'glob';
+      }
+
       // File viewing commands -> read
-      if (/^(ls|pwd|find|cat|head|tail|file|stat|tree)\b/.test(actualCmd)) {
+      if (/^(pwd|cat|head|tail|file|stat)\b/.test(actualCmd)) {
         return 'read';
       }
 
@@ -940,7 +945,7 @@ export async function sendMessage(
         '\n⚠️ Codex completed tool executions but did not generate a text response.',
         'This may happen when:',
         '- The task was purely about gathering information',
-        '- Codex reached maxTurns limit (100 turns)',
+        '- Codex reached maxTurns limit (200 turns)',
         '- The query required only command execution',
         '\nPlease try:',
         '- Asking a more specific question',

--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -5,6 +5,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Codex message format conversion utilities.
  * <p>
@@ -15,8 +20,16 @@ import com.google.gson.JsonParser;
  */
 public class CodexMessageConverter {
 
+    // Tracks file-writing sessions so later write_stdin events can display the target file.
+    private static final Map<Integer, String> SESSION_FILE_MAP = new ConcurrentHashMap<>();
+
+    // Extracts a destination path from common shell write patterns.
+    private static final Pattern WRITE_CMD_PATTERN = Pattern.compile(
+        "cat\\s*>\\s*([^\\s;|&]+)|tee\\s+(?:-[a-zA-Z]+\\s+)*([^\\s;|&]+)|(?:echo|printf)\\s+.*>\\s*([^\\s;|&]+)"
+    );
+
     private CodexMessageConverter() {
-        // Utility class, no instantiation
+        // Utility class, no instantiation.
     }
 
     /**
@@ -156,7 +169,7 @@ public class CodexMessageConverter {
                 if (item.isJsonObject()) {
                     JsonObject itemObj = item.getAsJsonObject();
 
-                    // Extract text type
+                    // Flatten supported text-like blocks into a single preview string for the frontend.
                     if (itemObj.has("type") && "text".equals(itemObj.get("type").getAsString())) {
                         if (itemObj.has("text")) {
                             if (sb.length() > 0) {
@@ -250,15 +263,21 @@ public class CodexMessageConverter {
      * Convert Codex function_call to Claude tool_use format.
      */
     public static JsonObject convertFunctionCallToToolUse(JsonObject payload, String timestamp) {
-        JsonObject frontendMsg = new JsonObject();
-        frontendMsg.addProperty("type", "assistant");
-
         String toolName = payload.has("name") ? payload.get("name").getAsString() : "unknown";
         JsonElement toolInput = parseToolArguments(payload);
 
-        // Smart tool name conversion
+        // Normalize tool identities first so downstream input conversion can target the displayed tool name.
         toolName = convertToolName(toolName, toolInput);
+
+        // Filter out ignored tools (e.g., write_stdin)
+        if (toolName == null) {
+            return null;
+        }
+
         toolInput = convertToolInput(toolName, toolInput);
+
+        JsonObject frontendMsg = new JsonObject();
+        frontendMsg.addProperty("type", "assistant");
 
         // Build tool_use format
         JsonObject toolUse = new JsonObject();
@@ -303,15 +322,24 @@ public class CodexMessageConverter {
 
     /**
      * Smart tool name conversion (shell_command -> read/glob, update_plan -> todowrite).
+     *
+     * @return converted tool name, or null if the tool should be filtered out (e.g. write_stdin).
      */
     public static String convertToolName(String toolName, JsonElement toolInput) {
         if ("shell_command".equals(toolName) && toolInput != null && toolInput.isJsonObject()) {
             JsonObject inputObj = toolInput.getAsJsonObject();
             if (inputObj.has("command")) {
                 String command = inputObj.get("command").getAsString().trim();
-                if (command.matches("^(ls|pwd|find|cat|head|tail|file|stat|tree)\\b.*")) {
+                // List/find commands -> glob (consistent with ai-bridge smartToolName)
+                if (command.matches("^(ls|find|tree)\\b.*")) {
+                    return "glob";
+                }
+                // File viewing commands -> read
+                if (command.matches("^(pwd|cat|head|tail|file|stat)\\b.*")) {
                     return "read";
-                } else if (command.matches("^(grep|rg|ack|ag)\\b.*")) {
+                }
+                // Search commands -> glob
+                if (command.matches("^(grep|rg|ack|ag)\\b.*")) {
                     return "glob";
                 }
             }
@@ -322,13 +350,55 @@ public class CodexMessageConverter {
                 return "todowrite";
             }
         }
+        // Ignore write_stdin - it's waiting for previous command result
+        if ("write_stdin".equals(toolName)) {
+            return null;
+        }
         return toolName;
     }
 
     /**
      * Convert tool input (update_plan -> todowrite format conversion).
+     * Also tracks exec_command sessions and enriches write_stdin with file paths.
      */
     public static JsonElement convertToolInput(String toolName, JsonElement toolInput) {
+        // Capture the write target when a terminal session starts writing to a file.
+        if ("exec_command".equals(toolName) && toolInput != null && toolInput.isJsonObject()) {
+            JsonObject inputObj = toolInput.getAsJsonObject();
+            if (inputObj.has("cmd") && inputObj.has("session_id")) {
+                String cmd = inputObj.get("cmd").getAsString();
+                int sessionId = inputObj.get("session_id").getAsInt();
+
+                // The regex covers redirection and tee-based writes used by the coding agents.
+                Matcher matcher = WRITE_CMD_PATTERN.matcher(cmd);
+                if (matcher.find()) {
+                    String filePath = matcher.group(1) != null ? matcher.group(1) :
+                                    (matcher.group(2) != null ? matcher.group(2) : matcher.group(3));
+                    if (filePath != null) {
+                        SESSION_FILE_MAP.put(sessionId, filePath.trim());
+                    }
+                }
+            }
+        }
+
+        // Enrich incremental writes with the previously discovered destination path.
+        if ("write".equals(toolName) && toolInput != null && toolInput.isJsonObject()) {
+            JsonObject inputObj = toolInput.getAsJsonObject();
+            if (inputObj.has("session_id")) {
+                int sessionId = inputObj.get("session_id").getAsInt();
+                String filePath = SESSION_FILE_MAP.get(sessionId);
+                if (filePath != null) {
+                    JsonObject enriched = new JsonObject();
+                    for (String key : inputObj.keySet()) {
+                        enriched.add(key, inputObj.get(key));
+                    }
+                    enriched.addProperty("file_path", filePath);
+                    return enriched;
+                }
+            }
+        }
+
+        // Translate plan updates into the todo structure expected by the Claude-style frontend.
         if (!"todowrite".equals(toolName) || toolInput == null || !toolInput.isJsonObject()) {
             return toolInput;
         }
@@ -384,6 +454,66 @@ public class CodexMessageConverter {
         JsonObject rawObj = new JsonObject();
         rawObj.add("content", content);
         rawObj.addProperty("role", "user");
+        frontendMsg.add("raw", rawObj);
+
+        if (timestamp != null) {
+            frontendMsg.addProperty("timestamp", timestamp);
+        }
+
+        return frontendMsg;
+    }
+
+    /**
+     * Convert Codex custom_tool_call to Claude tool_use format.
+     * Handles apply_patch and other custom tools.
+     */
+    public static JsonObject convertCustomToolCallToToolUse(JsonObject payload, String timestamp) {
+        JsonObject frontendMsg = new JsonObject();
+        frontendMsg.addProperty("type", "assistant");
+
+        String toolName = payload.has("name") ? payload.get("name").getAsString() : "unknown";
+
+        // Safely extract tool input as string, handling non-primitive types
+        String toolInput;
+        if (payload.has("input") && payload.get("input").isJsonPrimitive()) {
+            toolInput = payload.get("input").getAsString();
+        } else if (payload.has("input")) {
+            toolInput = payload.get("input").toString();
+        } else {
+            toolInput = "";
+        }
+
+        JsonObject toolUse = new JsonObject();
+        toolUse.addProperty("type", "tool_use");
+        toolUse.addProperty("id", payload.has("call_id") ? payload.get("call_id").getAsString() : "unknown");
+        toolUse.addProperty("name", toolName);
+
+        JsonObject input = new JsonObject();
+        input.addProperty("patch", toolInput);
+
+        // Surface the first touched file so the frontend can show a concrete target for patch-based edits.
+        if ("apply_patch".equals(toolName)
+                && (toolInput.contains("*** Add File:") || toolInput.contains("*** Update File:"))) {
+            String[] lines = toolInput.split("\n");
+            for (String line : lines) {
+                if (line.startsWith("*** Add File:") || line.startsWith("*** Update File:")) {
+                    String filePath = line.substring(line.indexOf(":") + 1).trim();
+                    input.addProperty("file_path", filePath);
+                    break;
+                }
+            }
+        }
+
+        toolUse.add("input", input);
+
+        JsonArray content = new JsonArray();
+        content.add(toolUse);
+
+        frontendMsg.addProperty("content", "Tool: " + toolName);
+
+        JsonObject rawObj = new JsonObject();
+        rawObj.add("content", content);
+        rawObj.addProperty("role", "assistant");
         frontendMsg.add("raw", rawObj);
 
         if (timestamp != null) {

--- a/src/main/java/com/github/claudecodegui/handler/FileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/FileHandler.java
@@ -5,6 +5,7 @@ import com.github.claudecodegui.service.RunConfigMonitorService;
 import com.github.claudecodegui.terminal.TerminalMonitorService;
 import com.github.claudecodegui.util.EditorFileUtils;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
+import com.github.claudecodegui.util.PathUtils;
 import com.github.claudecodegui.util.PlatformUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -12,7 +13,10 @@ import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.fileEditor.impl.EditorHistoryManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -441,7 +445,7 @@ public class FileHandler extends BaseMessageHandler {
      * Supports file paths with line numbers: file.txt:100 or file.txt:100-200.
      */
     private void handleOpenFile(String filePath) {
-        LOG.info("请求打开文件: " + filePath);
+        LOG.info("Open file request: " + filePath);
 
         // First process file path parsing on a regular thread (no VFS operations involved)
         CompletableFuture.runAsync(() -> {
@@ -449,6 +453,7 @@ public class FileHandler extends BaseMessageHandler {
                 // Parse file path and line number
                 final String[] parsedPath = {filePath};
                 final int[] parsedLineNumber = {-1};
+                final int[] parsedEndLineNumber = {-1};
 
                 // Detect and extract line number (format: file.txt:100 or file.txt:100-200)
                 int colonIndex = filePath.lastIndexOf(':');
@@ -457,36 +462,49 @@ public class FileHandler extends BaseMessageHandler {
                     // Check if after the colon is a line number (may include a range, e.g. 100-200)
                     if (afterColon.matches("\\d+(-\\d+)?")) {
                         parsedPath[0] = filePath.substring(0, colonIndex);
-                        // Extract start line number
                         int dashIndex = afterColon.indexOf('-');
-                        String lineStr = dashIndex > 0 ? afterColon.substring(0, dashIndex) : afterColon;
+                        String startLineStr = dashIndex > 0 ? afterColon.substring(0, dashIndex) : afterColon;
+                        String endLineStr = dashIndex > 0 ? afterColon.substring(dashIndex + 1) : null;
                         try {
-                            parsedLineNumber[0] = Integer.parseInt(lineStr);
-                            LOG.info("检测到行号: " + parsedLineNumber[0]);
+                            parsedLineNumber[0] = Integer.parseInt(startLineStr);
+                            if (endLineStr != null && !endLineStr.isBlank()) {
+                                parsedEndLineNumber[0] = Integer.parseInt(endLineStr);
+                                LOG.info("Detected line range: " + parsedLineNumber[0] + "-" + parsedEndLineNumber[0]);
+                            } else {
+                                LOG.info("Detected line number: " + parsedLineNumber[0]);
+                            }
                         } catch (NumberFormatException e) {
-                            LOG.warn("解析行号失败: " + lineStr);
+                            LOG.warn("Failed to parse line number: " + afterColon);
                         }
                     }
                 }
 
                 final String actualPath = parsedPath[0];
                 final int lineNumber = parsedLineNumber[0];
+                final int endLineNumber = parsedEndLineNumber[0];
 
                 File file = new File(actualPath);
+                if (!file.exists() && PlatformUtils.isWindows()) {
+                    String convertedPath = PathUtils.convertMsysToWindowsPath(actualPath);
+                    if (!convertedPath.equals(actualPath)) {
+                        LOG.info("Detected MSYS2 path, converted to Windows path: " + convertedPath);
+                        file = new File(convertedPath);
+                    }
+                }
 
                 // If file does not exist and is a relative path, try resolving relative to the project root
                 if (!file.exists() && !file.isAbsolute() && context.getProject().getBasePath() != null) {
                     File projectFile = new File(context.getProject().getBasePath(), actualPath);
-                    LOG.info("尝试相对于项目根目录解析: " + projectFile.getAbsolutePath());
+                    LOG.info("Trying to resolve relative to project root: " + projectFile.getAbsolutePath());
                     if (projectFile.exists()) {
                         file = projectFile;
                     }
                 }
 
                 if (!file.exists()) {
-                    LOG.warn("文件不存在: " + actualPath);
+                    LOG.warn("File not found: " + actualPath);
                     ApplicationManager.getApplication().invokeLater(() -> {
-                        callJavaScript("addErrorMessage", escapeJs("无法打开文件: 当前文件不存在 (" + actualPath + ")"));
+                        callJavaScript("addErrorMessage", escapeJs("Cannot open file: file does not exist (" + actualPath + ")"));
                     }, ModalityState.nonModal());
                     return;
                 }
@@ -495,37 +513,57 @@ public class FileHandler extends BaseMessageHandler {
 
                 // Use utility method to asynchronously refresh and find the file
                 EditorFileUtils.refreshAndFindFileAsync(finalFile, virtualFile -> {
-                    // File found successfully, open in editor
-                    FileEditorManager.getInstance(context.getProject()).openFile(virtualFile, true);
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (context.getProject().isDisposed() || !virtualFile.isValid()) {
+                            return;
+                        }
 
-                    // If a line number is present, navigate to the specified line
-                    if (lineNumber > 0) {
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            com.intellij.openapi.editor.Editor editor = com.intellij.openapi.fileEditor.FileEditorManager.getInstance(context.getProject()).getSelectedTextEditor();
-                            if (editor != null && editor.getDocument().getTextLength() > 0) {
-                                // Line numbers are 0-based internally, user input is 1-based
-                                int zeroBasedLine = Math.max(0, lineNumber - 1);
+                        Editor editor;
+                        if (lineNumber > 0) {
+                            OpenFileDescriptor descriptor = new OpenFileDescriptor(context.getProject(), virtualFile);
+                            editor = FileEditorManager.getInstance(context.getProject()).openTextEditor(descriptor, true);
+
+                            if (editor != null) {
                                 int lineCount = editor.getDocument().getLineCount();
-                                if (zeroBasedLine < lineCount) {
-                                    int offset = editor.getDocument().getLineStartOffset(zeroBasedLine);
-                                    editor.getCaretModel().moveToOffset(offset);
-                                    editor.getScrollingModel().scrollToCaret(com.intellij.openapi.editor.ScrollType.CENTER);
-                                    LOG.info("跳转到第 " + lineNumber + " 行");
-                                } else {
-                                    LOG.warn("行号 " + lineNumber + " 超出范围（文件共 " + lineCount + " 行）");
-                                }
-                            }
-                        }, ModalityState.nonModal());
-                    }
+                                if (lineCount > 0) {
+                                    int zeroBasedLine = Math.min(Math.max(0, lineNumber - 1), lineCount - 1);
+                                    int startOffset = editor.getDocument().getLineStartOffset(zeroBasedLine);
+                                    editor.getCaretModel().moveToOffset(startOffset);
 
-                    LOG.info("成功打开文件: " + filePath);
+                                    if (endLineNumber >= lineNumber) {
+                                        int zeroBasedEndLine = Math.min(endLineNumber - 1, lineCount - 1);
+                                        int endOffset = editor.getDocument().getLineEndOffset(zeroBasedEndLine);
+                                        editor.getSelectionModel().setSelection(startOffset, endOffset);
+                                        LOG.info("Navigated and selected line range: " + lineNumber + "-" + endLineNumber);
+                                    } else {
+                                        if (endLineNumber > 0) {
+                                            LOG.warn("Invalid line range: " + lineNumber + "-" + endLineNumber);
+                                        }
+                                        editor.getSelectionModel().removeSelection();
+                                        LOG.info("Navigated to line " + lineNumber);
+                                    }
+
+                                    editor.getScrollingModel().scrollToCaret(ScrollType.CENTER);
+                                } else {
+                                    LOG.warn("File is empty, cannot navigate to line " + lineNumber);
+                                }
+                            } else {
+                                LOG.warn("Cannot open text editor: " + virtualFile.getPath());
+                                FileEditorManager.getInstance(context.getProject()).openFile(virtualFile, true);
+                            }
+                        } else {
+                            FileEditorManager.getInstance(context.getProject()).openFile(virtualFile, true);
+                        }
+
+                        LOG.info("Successfully opened file: " + filePath);
+                    }, ModalityState.nonModal());
                 }, () -> {
                     // Failure callback
-                    LOG.error("最终无法获取 VirtualFile: " + filePath);
-                    callJavaScript("addErrorMessage", escapeJs("无法打开文件: " + filePath));
+                    LOG.error("Failed to get VirtualFile: " + filePath);
+                    callJavaScript("addErrorMessage", escapeJs("Cannot open file: " + filePath));
                 });
             } catch (Exception e) {
-                LOG.error("打开文件失败: " + e.getMessage(), e);
+                LOG.error("Failed to open file: " + e.getMessage(), e);
             }
         });
     }
@@ -538,7 +576,7 @@ public class FileHandler extends BaseMessageHandler {
             try {
                 BrowserUtil.browse(url);
             } catch (Exception e) {
-                LOG.error("无法打开浏览器: " + e.getMessage(), e);
+                LOG.error("Cannot open browser: " + e.getMessage(), e);
             }
         });
     }

--- a/src/main/java/com/github/claudecodegui/handler/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/HistoryHandler.java
@@ -351,6 +351,8 @@ public class HistoryHandler extends BaseMessageHandler {
             frontendMsg = CodexMessageConverter.convertFunctionCallToToolUse(payload, timestamp);
         } else if ("function_call_output".equals(payloadType)) {
             frontendMsg = CodexMessageConverter.convertFunctionCallOutputToToolResult(payload, timestamp);
+        } else if ("custom_tool_call".equals(payloadType)) {
+            frontendMsg = CodexMessageConverter.convertCustomToolCallToToolUse(payload, timestamp);
         }
 
         if (frontendMsg != null) {

--- a/src/main/java/com/github/claudecodegui/util/PathUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/PathUtils.java
@@ -96,6 +96,33 @@ public class PathUtils {
         return path.startsWith("\\\\") || path.startsWith("//");
     }
 
+    /**
+     * Convert an MSYS2-style path to a Windows path.
+     * Examples: /c/Users/test -> C:\Users\test, /d/work -> D:\work
+     * Returns the original path if conversion is not needed.
+     *
+     * @param path the original path
+     * @return the converted Windows path, or the original path
+     */
+    public static String convertMsysToWindowsPath(String path) {
+        if (path == null || path.isEmpty() || !PlatformUtils.isWindows()) {
+            return path;
+        }
+
+        if (isWindowsPath(path) || isUncPath(path)) {
+            return path;
+        }
+
+        if (!path.matches("^/[a-zA-Z](/.*)?$")) {
+            return path;
+        }
+
+        char driveLetter = Character.toUpperCase(path.charAt(1));
+        String remainder = path.length() > 2 ? path.substring(2) : "";
+        String windowsPath = driveLetter + ":" + (remainder.isEmpty() ? "/" : remainder);
+        return normalizeToPlatform(windowsPath);
+    }
+
     // ==================== Path Length Checks ====================
 
     /**

--- a/webview/src/components/toolBlocks/EditToolBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolBlock.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
 import { openFile, showDiff, refreshFile } from '../../utils/bridge';
-import { getFileName } from '../../utils/helpers';
 import { getFileIcon } from '../../utils/fileIcons';
+import { getToolLineInfo, resolveToolTarget } from '../../utils/toolPresentation';
 import GenericToolBlock from './GenericToolBlock';
 
 interface EditToolBlockProps {
@@ -106,12 +106,14 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
   // If denied, show as error state
   const isError = isDenied || (isCompleted && result?.is_error === true);
 
-  const filePath =
-    (typeof input?.file_path === 'string' ? input.file_path : undefined) ??
-    (typeof input?.filePath === 'string' ? input.filePath : undefined) ??
-    (typeof input?.path === 'string' ? input.path : undefined) ??
-    (typeof input?.target_file === 'string' ? input.target_file : undefined) ??
-    (typeof input?.targetFile === 'string' ? input.targetFile : undefined);
+  const target = input ? resolveToolTarget({
+    ...input,
+    file_path: (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+      (typeof input.filePath === 'string' ? input.filePath : undefined),
+    target_file: (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+      (typeof input.targetFile === 'string' ? input.targetFile : undefined),
+  }, name) : undefined;
+  const filePath = target?.openPath;
 
   const oldString =
     (typeof input?.old_string === 'string' ? input.old_string : undefined) ??
@@ -145,17 +147,19 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
     return <GenericToolBlock name={name} input={input} result={result} toolId={toolId} />;
   }
 
+  const lineInfo = input && target ? getToolLineInfo(input, target) : {};
+
   const handleFileClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (filePath) {
-      openFile(filePath);
+      openFile(filePath, lineInfo.start, lineInfo.end);
     }
   };
 
   const handleShowDiff = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (filePath) {
-      showDiff(filePath, oldString, newString, t('tools.editPrefix', { fileName: getFileName(filePath) }));
+      showDiff(filePath, oldString, newString, t('tools.editPrefix', { fileName: target?.cleanFileName ?? filePath }));
     }
   };
 
@@ -167,11 +171,10 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
     }
   };
 
-  const getFileIconSvg = (path?: string) => {
-    if (!path) return '';
-    const name = getFileName(path);
-    const extension = name.indexOf('.') !== -1 ? name.split('.').pop() : '';
-    return getFileIcon(extension, name);
+  const getFileIconSvg = () => {
+    if (!target) return '';
+    const extension = target.cleanFileName.includes('.') ? target.cleanFileName.split('.').pop() : '';
+    return getFileIcon(extension ?? '', target.cleanFileName);
   };
 
   return (
@@ -257,15 +260,22 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
             <span
               className="tool-title-summary clickable-file"
               onClick={handleFileClick}
-              title={t('tools.clickToOpen', { filePath })}
+              title={t('tools.clickToOpen', { filePath: target?.displayPath ?? filePath })}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <span 
-                style={{ marginRight: '4px', display: 'flex', alignItems: 'center', width: '16px', height: '16px' }} 
-                dangerouslySetInnerHTML={{ __html: getFileIconSvg(filePath) }} 
+              <span
+                style={{ marginRight: '4px', display: 'flex', alignItems: 'center', width: '16px', height: '16px' }}
+                dangerouslySetInnerHTML={{ __html: getFileIconSvg() }}
               />
-              {getFileName(filePath) || filePath}
+              {target?.displayPath || filePath}
             </span>
+            {lineInfo.start && (
+              <span className="tool-title-summary" style={{ marginLeft: '8px', fontSize: '12px' }}>
+                {lineInfo.end && lineInfo.end !== lineInfo.start
+                  ? t('tools.lineRange', { start: lineInfo.start, end: lineInfo.end })
+                  : t('tools.lineSingle', { line: lineInfo.start })}
+              </span>
+            )}
             
             {(diff.additions > 0 || diff.deletions > 0) && (
               <span

--- a/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
@@ -2,11 +2,13 @@ import { useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { openFile, showDiff, refreshFile } from '../../utils/bridge';
-import { getFileName } from '../../utils/helpers';
 import { getFileIcon } from '../../utils/fileIcons';
+import { resolveToolTarget } from '../../utils/toolPresentation';
 
 interface EditItem {
   filePath: string;
+  openPath: string;
+  displayPath: string;
   fileName: string;
   oldString: string;
   newString: string;
@@ -87,15 +89,15 @@ function parseEditItem(item: { name?: string; input?: ToolInput; result?: ToolRe
   const { input, result } = item;
   if (!input) return null;
 
-  // Extract file path (ensure it is a string, not an object)
-  const filePath =
-    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
-    (typeof input.filePath === 'string' ? input.filePath : undefined) ??
-    (typeof input.path === 'string' ? input.path : undefined) ??
-    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
-    (typeof input.targetFile === 'string' ? input.targetFile : undefined);
+  const target = resolveToolTarget({
+    ...input,
+    file_path: (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+      (typeof input.filePath === 'string' ? input.filePath : undefined),
+    target_file: (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+      (typeof input.targetFile === 'string' ? input.targetFile : undefined),
+  }, item.name);
 
-  if (!filePath) return null;
+  if (!target) return null;
 
   const oldString =
     (typeof input.old_string === 'string' ? input.old_string : undefined) ??
@@ -111,8 +113,10 @@ function parseEditItem(item: { name?: string; input?: ToolInput; result?: ToolRe
   const isError = isCompleted && result?.is_error === true;
 
   return {
-    filePath,
-    fileName: getFileName(filePath) || filePath,
+    filePath: target.rawPath,
+    openPath: target.openPath,
+    displayPath: target.displayPath,
+    fileName: target.cleanFileName,
     oldString,
     newString,
     additions,
@@ -123,12 +127,11 @@ function parseEditItem(item: { name?: string; input?: ToolInput; result?: ToolRe
 }
 
 /**
- * Get file icon SVG
+ * Get file icon SVG by file name (with extension).
  */
-function getFileIconSvg(filePath: string): string {
-  const name = getFileName(filePath);
-  const extension = name.indexOf('.') !== -1 ? name.split('.').pop() : '';
-  return getFileIcon(extension, name);
+function getFileIconSvg(fileName: string): string {
+  const extension = fileName.includes('.') ? fileName.split('.').pop() : '';
+  return getFileIcon(extension ?? '', fileName);
 }
 
 const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
@@ -150,7 +153,7 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
     editItems.forEach(item => {
       if (item.isCompleted && !item.isError && !refreshedFilesRef.current.has(item.filePath)) {
         refreshedFilesRef.current.add(item.filePath);
-        refreshFile(item.filePath);
+        refreshFile(item.openPath);
       }
     });
   }, [editItems]);
@@ -184,7 +187,7 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
 
   const handleShowDiff = (item: EditItem, e: React.MouseEvent) => {
     e.stopPropagation();
-    showDiff(item.filePath, item.oldString, item.newString, t('tools.editPrefix', { fileName: item.fileName }));
+    showDiff(item.openPath, item.oldString, item.newString, t('tools.editPrefix', { fileName: item.fileName }));
   };
 
   const handleRefresh = (filePath: string, e: React.MouseEvent) => {
@@ -272,11 +275,11 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
                   height: '16px',
                   flexShrink: 0,
                 }}
-                dangerouslySetInnerHTML={{ __html: getFileIconSvg(item.filePath) }}
+                dangerouslySetInnerHTML={{ __html: getFileIconSvg(item.fileName) }}
               />
               <span
                 className="clickable-file"
-                onClick={(e) => handleFileClick(item.filePath, e)}
+                onClick={(e) => handleFileClick(item.openPath, e)}
                 style={{
                   fontSize: '12px',
                   color: 'var(--text-primary)',
@@ -287,9 +290,9 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
                   minWidth: 0,
                   cursor: 'pointer',
                 }}
-                title={item.filePath}
+                title={item.displayPath}
               >
-                {item.fileName}
+                {item.displayPath}
               </span>
 
               {/* Diff stats */}
@@ -319,7 +322,7 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
                   <span className="codicon codicon-diff" style={{ fontSize: '12px' }} />
                 </button>
                 <button
-                  onClick={(e) => handleRefresh(item.filePath, e)}
+                  onClick={(e) => handleRefresh(item.openPath, e)}
                   title={t('tools.refreshFileInIdea')}
                   className="edit-group-action-btn"
                 >

--- a/webview/src/components/toolBlocks/GenericToolBlock.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.tsx
@@ -3,8 +3,10 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
 import { openFile } from '../../utils/bridge';
-import { formatParamValue, getFileName, truncate } from '../../utils/helpers';
+import { formatParamValue, truncate } from '../../utils/helpers';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
+import { parseCommandType } from '../../utils/toolCommandPath';
+import { getToolLineInfo, resolveToolTarget, summarizeToolCommand, extractPathsFromPatch } from '../../utils/toolPresentation';
 
 const CODICON_MAP: Record<string, string> = {
   read: 'codicon-eye',
@@ -20,17 +22,9 @@ const CODICON_MAP: Record<string, string> = {
   augmentcontextengine: 'codicon-symbol-class', // Added based on Picture 2
   update_plan: 'codicon-checklist', // Update plan tool
   shell_command: 'codicon-terminal', // Shell command tool
-};
-
-/**
- * Check if a shell command is a file/directory viewing operation
- */
-const isFileViewingCommand = (command?: string): boolean => {
-  if (!command || typeof command !== 'string') return false;
-  const trimmed = command.trim();
-  // File viewing: pwd, ls, cat, head, tail, sed -n, tree
-  return /^(pwd|ls|cat|head|tail|tree|file|stat)\b/.test(trimmed) ||
-         /^sed\s+-n\s+/.test(trimmed);
+  shell_command_read: 'codicon-eye',
+  shell_command_list: 'codicon-folder',
+  shell_command_search: 'codicon-search',
 };
 
 const getToolDisplayName = (t: any, name?: string, input?: ToolInput) => {
@@ -40,10 +34,29 @@ const getToolDisplayName = (t: any, name?: string, input?: ToolInput) => {
 
   const lowerName = name.toLowerCase();
 
-  // For shell_command, check the actual command to determine display name
-  if (lowerName === 'shell_command' && input?.command) {
-    if (isFileViewingCommand(input.command as string)) {
-      return t('tools.readFile');
+  // Command-executing tools that may contain file-reading commands
+  const isCommandTool = lowerName === 'shell_command' ||
+    lowerName === 'exec_command' ||
+    lowerName === 'execute_command' ||
+    lowerName === 'executecommand' ||
+    lowerName === 'bash' ||
+    lowerName === 'run_terminal_cmd';
+
+  // Codex uses 'cmd', others use 'command'
+  const commandStr = (input?.command as string | undefined) ?? (input?.cmd as string | undefined);
+
+  // For command-executing tools, check the actual command to determine display name
+  if (isCommandTool && commandStr) {
+    const parsed = parseCommandType(commandStr);
+    switch (parsed.type) {
+      case 'read':
+        return t('tools.readFile');
+      case 'list':
+        return t('tools.listFiles');
+      case 'search':
+        return t('tools.search');
+      default:
+        return t('tools.runCommand');
     }
   }
 
@@ -77,6 +90,7 @@ const getToolDisplayName = (t: any, name?: string, input?: ToolInput) => {
     'find': 'tools.findFile',
     'todowrite': 'tools.todoList',
     'update_plan': 'tools.updatePlan',
+    'apply_patch': 'tools.applyPatch',
   };
 
   if (toolKeyMap[lowerName]) {
@@ -100,112 +114,33 @@ const getToolDisplayName = (t: any, name?: string, input?: ToolInput) => {
   return name;
 };
 
-/**
- * Extract file/directory path from command string (for Codex commands)
- * Returns the path with optional metadata suffix (e.g., ":700-780" for line ranges, "/" for directories)
- */
-const extractFilePathFromCommand = (command: string | undefined, workdir?: string): string | undefined => {
-  if (!command || typeof command !== 'string') return undefined;
-
-  let trimmed = command.trim();
-
-  // Extract actual command from shell wrapper (/bin/zsh -lc '...' or /bin/bash -c '...')
-  const shellWrapperMatch = trimmed.match(/^\/bin\/(zsh|bash)\s+(?:-lc|-c)\s+['"](.+)['"]$/);
-  if (shellWrapperMatch) {
-    trimmed = shellWrapperMatch[2];
-  }
-
-  // Remove 'cd dir &&' prefix if present
-  const cdPrefixMatch = trimmed.match(/^cd\s+\S+\s+&&\s+(.+)$/);
-  if (cdPrefixMatch) {
-    trimmed = cdPrefixMatch[1].trim();
-  }
-
-  // Match pwd command - returns current directory from workdir
-  if (/^pwd\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match ls command (with or without flags)
-  // Examples: ls, ls -a, ls -la, ls /path, ls -a /path
-  const lsMatch = trimmed.match(/^ls\s+(?:-[a-zA-Z]+\s+)?(.+)$/);
-  if (lsMatch) {
-    const path = lsMatch[1].trim().replace(/^["']|["']$/g, '');
-    // Add trailing slash to indicate directory
-    return path.endsWith('/') ? path : path + '/';
-  }
-
-  // Match ls without path (current directory)
-  if (/^ls(?:\s+-[a-zA-Z]+)*\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match tree command (directory listing)
-  if (/^tree\b/.test(trimmed)) {
-    const treeMatch = trimmed.match(/^tree\s+(.+)$/);
-    if (treeMatch) {
-      const path = treeMatch[1].trim().replace(/^["']|["']$/g, '');
-      return path.endsWith('/') ? path : path + '/';
-    }
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match sed -n command (e.g., sed -n '700,780p' file.txt)
-  const sedMatch = trimmed.match(/^sed\s+-n\s+['"]?(\d+)(?:,(\d+))?p['"]?\s+(.+)$/);
-  if (sedMatch) {
-    const startLine = sedMatch[1];
-    const endLine = sedMatch[2];
-    const path = sedMatch[3].trim().replace(/^["']|["']$/g, '');
-
-    // Return file path with line range info
-    if (endLine) {
-      return `${path}:${startLine}-${endLine}`;
-    } else {
-      return `${path}:${startLine}`;
-    }
-  }
-
-  // Match cat command (simple case without flags)
-  const catMatch = trimmed.match(/^cat\s+(.+)$/);
-  if (catMatch) {
-    const path = catMatch[1].trim();
-    // Remove quotes if present
-    return path.replace(/^["']|["']$/g, '');
-  }
-
-  // Match head/tail commands (may have flags like -n 10)
-  const headTailMatch = trimmed.match(/^(head|tail)\s+(?:.*\s)?([^\s-][^\s]*)$/);
-  if (headTailMatch) {
-    const path = headTailMatch[2].trim();
-    // Remove quotes if present
-    return path.replace(/^["']|["']$/g, '');
-  }
-
-  return undefined;
-};
-
-const pickFilePath = (input: ToolInput, name?: string) => {
-  // First try standard file path fields (ensure they are strings, not objects)
-  const pathValue = input.path;
-  const filePathValue = input.file_path;
-  const targetFileValue = input.target_file;
-  const notebookPathValue = input.notebook_path;
-
-  const standardPath = (typeof filePathValue === 'string' ? filePathValue : undefined) ??
-    (typeof pathValue === 'string' ? pathValue : undefined) ??
-    (typeof targetFileValue === 'string' ? targetFileValue : undefined) ??
-    (typeof notebookPathValue === 'string' ? notebookPathValue : undefined);
-
-  if (standardPath) return standardPath;
-
-  // For Codex read or shell_command commands, extract from command string
+const getToolCodicon = (name?: string, input?: ToolInput): string => {
   const lowerName = (name ?? '').toLowerCase();
-  if ((lowerName === 'read' || lowerName === 'shell_command') && typeof input.command === 'string') {
-    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
-    return extractFilePathFromCommand(input.command, workdir);
+
+  const isCommandTool = lowerName === 'shell_command' ||
+    lowerName === 'exec_command' ||
+    lowerName === 'execute_command' ||
+    lowerName === 'executecommand' ||
+    lowerName === 'bash' ||
+    lowerName === 'run_terminal_cmd';
+
+  const commandStr = (input?.command as string | undefined) ?? (input?.cmd as string | undefined);
+
+  if (isCommandTool && commandStr) {
+    const parsed = parseCommandType(commandStr);
+    switch (parsed.type) {
+      case 'read':
+        return CODICON_MAP.shell_command_read ?? CODICON_MAP.shell_command;
+      case 'list':
+        return CODICON_MAP.shell_command_list ?? CODICON_MAP.shell_command;
+      case 'search':
+        return CODICON_MAP.shell_command_search ?? CODICON_MAP.shell_command;
+      default:
+        return CODICON_MAP.shell_command;
+    }
   }
 
-  return undefined;
+  return CODICON_MAP[lowerName] ?? 'codicon-tools';
 };
 
 const omitFields = new Set([
@@ -214,9 +149,12 @@ const omitFields = new Set([
   'target_file',
   'notebook_path',
   'command',
+  'cmd',          // Codex uses 'cmd' instead of 'command'
   'search_term',
-  'description',  // Omit Codex description field
-  'workdir',      // Omit Codex workdir field
+  'description',  // Codex description field
+  'workdir',      // Codex workdir field
+  'yield_time_ms',
+  'max_output_tokens',
 ]);
 
 interface GenericToolBlockProps {
@@ -231,10 +169,15 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
   const { t } = useTranslation();
   const lowerName = (name ?? '').toLowerCase();
   const [expanded, setExpanded] = useState(false);
-
-  const filePath = input ? pickFilePath(input, name) : undefined;
-
   const isDenied = useIsToolDenied(toolId);
+
+  // Ignore write_stdin tool - it's waiting for previous command result
+  if (lowerName === 'write_stdin') {
+    return null;
+  }
+
+  const target = input ? resolveToolTarget(input, name) : undefined;
+  const filePath = target?.rawPath;
 
   // Determine tool call status based on result
   // If denied, treat as completed (show error state)
@@ -250,13 +193,23 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
   }
 
   const displayName = getToolDisplayName(t, name, input);
-  const codicon = CODICON_MAP[(name ?? '').toLowerCase()] ?? 'codicon-tools';
+  const codicon = getToolCodicon(name, input);
+
+  // Codex uses 'cmd', others use 'command'
+  const commandStr = (typeof input.command === 'string' ? input.command : undefined) ??
+    (typeof input.cmd === 'string' ? input.cmd : undefined);
 
   let summary: string | null = null;
-  if (filePath) {
-    summary = getFileName(filePath);
-  } else if (typeof input.command === 'string') {
-    summary = truncate(input.command);
+  if (target) {
+    summary = target.cleanFileName || target.displayPath;
+  } else if (commandStr) {
+    const parsed = parseCommandType(commandStr);
+    if (parsed.type === 'read' && parsed.path) {
+      const pathParts = parsed.path.split('/');
+      summary = pathParts[pathParts.length - 1] || parsed.path;
+    } else {
+      summary = summarizeToolCommand(commandStr) ?? truncate(commandStr);
+    }
   } else if (typeof input.search_term === 'string') {
     summary = truncate(input.search_term);
   } else if (typeof input.pattern === 'string') {
@@ -269,51 +222,45 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
 
   const hasExpandableContent = otherParams.length > 0;
 
-  // Check if it's a special file (no extension but still a file)
-  const isSpecialFile = (fileName: string): boolean => {
-    const specialFiles = [
-      'makefile', 'dockerfile', 'jenkinsfile', 'vagrantfile',
-      'gemfile', 'rakefile', 'procfile', 'guardfile',
-      'license', 'licence', 'readme', 'changelog',
-      'gradlew', 'cname', 'authors', 'contributors'
-    ];
-    return specialFiles.includes(fileName.toLowerCase());
-  };
+  const isDirectoryPath = target?.isDirectory ?? false;
+  const isFilePath = target?.isFile ?? false;
+  const lineInfo = input && target ? getToolLineInfo(input, target) : {};
 
-  // Determine if it's a directory: ends with /, is . or .., or filename has no extension (and is not a special file)
-  const fileName = filePath ? getFileName(filePath) : '';
-  // Remove line number suffix when checking if it's a directory
-  const cleanFileName = fileName.replace(/:\d+(-\d+)?$/, '');
-  const isDirectoryPath = filePath && (
-    filePath.endsWith('/') ||
-    filePath === '.' ||
-    filePath === '..' ||
-    (!cleanFileName.includes('.') && !isSpecialFile(cleanFileName))
-  );
-  // Determine if it's a file path (not a directory)
-  const isFilePath = filePath && !isDirectoryPath;
+  // For command-executing tools with read type, treat as file if we have a path
+  const isCommandTool = lowerName === 'shell_command' ||
+    lowerName === 'exec_command' ||
+    lowerName === 'execute_command' ||
+    lowerName === 'executecommand' ||
+    lowerName === 'bash' ||
+    lowerName === 'run_terminal_cmd';
+  const isCommandRead = isCommandTool && commandStr && parseCommandType(commandStr).type === 'read';
+  const effectiveIsFile = isFilePath || isCommandRead;
 
   const handleFileClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (isFilePath) {
-      openFile(filePath);
+    if (target) {
+      openFile(target.openPath, lineInfo.start, lineInfo.end);
     }
   };
 
-  const getFileIconSvg = (path?: string) => {
-    if (!path) return '';
-    const name = getFileName(path);
-
+  const getFileIconSvg = () => {
+    if (!target) return '';
     if (isDirectoryPath) {
-      // For directories, use getFolderIcon to get a colored folder icon
-      return getFolderIcon(name);
-    } else {
-      // Remove line number suffix if present (e.g., "App.tsx:700-780" -> "App.tsx")
-      const cleanName = name.replace(/:\d+(-\d+)?$/, '');
-      const extension = cleanName.indexOf('.') !== -1 ? cleanName.split('.').pop() : '';
-      return getFileIcon(extension, cleanName);
+      return getFolderIcon(target.cleanFileName);
     }
+    const extension = target.cleanFileName.includes('.') ? target.cleanFileName.split('.').pop() : '';
+    return getFileIcon(extension ?? '', target.cleanFileName);
   };
+
+  const tooltipPath = target?.displayPath ?? filePath ?? summary ?? '';
+
+  // Extract all file paths for apply_patch tool
+  const patchContent = lowerName === 'apply_patch'
+    ? ((typeof input.input === 'string' ? input.input : undefined) ??
+       (typeof input.patch === 'string' ? input.patch : undefined) ??
+       (typeof input.content === 'string' ? input.content : undefined))
+    : undefined;
+  const patchFiles = patchContent ? extractPathsFromPatch(patchContent) : [];
 
   return (
     <div className="task-container">
@@ -333,26 +280,59 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
           <span className="tool-title-text">
             {displayName}
           </span>
-          {summary && (
+          {summary && patchFiles.length === 0 && (
               <span
-                className={`task-summary-text tool-title-summary ${isFilePath ? 'clickable-file' : ''}`}
-                title={isFilePath ? t('tools.clickToOpen', { filePath }) : summary}
-                onClick={isFilePath ? handleFileClick : undefined}
-                style={(isFilePath || isDirectoryPath) ? {
+                className={`task-summary-text tool-title-summary ${effectiveIsFile ? 'clickable-file' : ''}`}
+                title={effectiveIsFile ? t('tools.clickToOpen', { filePath: tooltipPath }) : tooltipPath}
+                onClick={effectiveIsFile ? handleFileClick : undefined}
+                style={(effectiveIsFile || isDirectoryPath) ? {
                   display: 'inline-flex',
                   alignItems: 'center',
                   maxWidth: 'fit-content'
                 } : undefined}
               >
-                {(isFilePath || isDirectoryPath) && (
+                {(effectiveIsFile || isDirectoryPath) && (
                    <span
                       style={{ marginRight: '4px', display: 'flex', alignItems: 'center', width: '16px', height: '16px' }}
-                      dangerouslySetInnerHTML={{ __html: getFileIconSvg(filePath) }}
+                      dangerouslySetInnerHTML={{ __html: getFileIconSvg() }}
                    />
                 )}
                 {summary}
               </span>
             )}
+          {patchFiles.length > 0 && (
+            <span className="tool-title-summary" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              {patchFiles.map((path, idx) => {
+                const fileName = path.split('/').pop() || path;
+                const ext = fileName.includes('.') ? fileName.split('.').pop() : '';
+                return (
+                  <span
+                    key={idx}
+                    className="clickable-file"
+                    title={t('tools.clickToOpen', { filePath: path })}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openFile(path);
+                    }}
+                    style={{ display: 'inline-flex', alignItems: 'center' }}
+                  >
+                    <span
+                      style={{ marginRight: '4px', display: 'flex', alignItems: 'center', width: '16px', height: '16px' }}
+                      dangerouslySetInnerHTML={{ __html: getFileIcon(ext ?? '', fileName) }}
+                    />
+                    {fileName}
+                  </span>
+                );
+              })}
+            </span>
+          )}
+          {lineInfo.start && (
+            <span className="tool-title-summary" style={{ marginLeft: '8px', fontSize: '12px' }}>
+              {lineInfo.end && lineInfo.end !== lineInfo.start
+                ? t('tools.lineRange', { start: lineInfo.start, end: lineInfo.end })
+                : t('tools.lineSingle', { line: lineInfo.start })}
+            </span>
+          )}
         </div>
 
         <div className={`tool-status-indicator ${isError ? 'error' : isCompleted ? 'completed' : 'pending'}`} />
@@ -376,4 +356,3 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
 };
 
 export default GenericToolBlock;
-

--- a/webview/src/components/toolBlocks/ReadToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolBlock.tsx
@@ -2,89 +2,12 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput } from '../../types';
 import { openFile } from '../../utils/bridge';
-import { getFileName } from '../../utils/helpers';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
+import { getToolLineInfo, resolveToolTarget } from '../../utils/toolPresentation';
 
 interface ReadToolBlockProps {
   input?: ToolInput;
 }
-
-/**
- * Extract file/directory path from command string (for Codex commands)
- */
-const extractFilePathFromCommand = (command: string | undefined, workdir?: string): string | undefined => {
-  if (!command || typeof command !== 'string') return undefined;
-
-  let trimmed = command.trim();
-
-  // Extract actual command from shell wrapper (/bin/zsh -lc '...' or /bin/bash -c '...')
-  const shellWrapperMatch = trimmed.match(/^\/bin\/(zsh|bash)\s+(?:-lc|-c)\s+['"](.+)['"]$/);
-  if (shellWrapperMatch) {
-    trimmed = shellWrapperMatch[2];
-  }
-
-  // Remove 'cd dir &&' prefix if present
-  const cdPrefixMatch = trimmed.match(/^cd\s+\S+\s+&&\s+(.+)$/);
-  if (cdPrefixMatch) {
-    trimmed = cdPrefixMatch[1].trim();
-  }
-
-  // Match pwd command - returns current directory from workdir
-  if (/^pwd\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match ls command (with or without flags)
-  const lsMatch = trimmed.match(/^ls\s+(?:-[a-zA-Z]+\s+)?(.+)$/);
-  if (lsMatch) {
-    const path = lsMatch[1].trim().replace(/^["']|["']$/g, '');
-    return path.endsWith('/') ? path : path + '/';
-  }
-
-  // Match ls without path (current directory)
-  if (/^ls(?:\s+-[a-zA-Z]+)*\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match tree command
-  if (/^tree\b/.test(trimmed)) {
-    const treeMatch = trimmed.match(/^tree\s+(.+)$/);
-    if (treeMatch) {
-      const path = treeMatch[1].trim().replace(/^["']|["']$/g, '');
-      return path.endsWith('/') ? path : path + '/';
-    }
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match sed -n command (e.g., sed -n '700,780p' file.txt)
-  const sedMatch = trimmed.match(/^sed\s+-n\s+['"]?(\d+)(?:,(\d+))?p['"]?\s+(.+)$/);
-  if (sedMatch) {
-    const startLine = sedMatch[1];
-    const endLine = sedMatch[2];
-    const path = sedMatch[3].trim().replace(/^["']|["']$/g, '');
-    if (endLine) {
-      return `${path}:${startLine}-${endLine}`;
-    } else {
-      return `${path}:${startLine}`;
-    }
-  }
-
-  // Match cat command
-  const catMatch = trimmed.match(/^cat\s+(.+)$/);
-  if (catMatch) {
-    const path = catMatch[1].trim();
-    return path.replace(/^["']|["']$/g, '');
-  }
-
-  // Match head/tail commands
-  const headTailMatch = trimmed.match(/^(head|tail)\s+(?:.*\s)?([^\s-][^\s]*)$/);
-  if (headTailMatch) {
-    const path = headTailMatch[2].trim();
-    return path.replace(/^["']|["']$/g, '');
-  }
-
-  return undefined;
-};
 
 const ReadToolBlock = ({ input }: ReadToolBlockProps) => {
   const [expanded, setExpanded] = useState(false);
@@ -94,70 +17,27 @@ const ReadToolBlock = ({ input }: ReadToolBlockProps) => {
     return null;
   }
 
-  // Try standard file path fields first (ensure they are strings, not objects)
-  let filePath =
-    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
-    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
-    (typeof input.path === 'string' ? input.path : undefined);
-
-  // If not found, try extracting from Codex command
-  if (!filePath && typeof input.command === 'string') {
-    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
-    filePath = extractFilePathFromCommand(input.command, workdir);
-  }
-
-  // Remove line number suffix for display
-  const cleanFileName = getFileName(filePath)?.replace(/:\d+(-\d+)?$/, '') || '';
-  const fileName = getFileName(filePath);
-
-  // Extract line info from either standard fields or from file path suffix
-  let lineInfo = '';
-
-  // First try standard offset/limit fields
-  if (typeof input.offset === 'number' && typeof input.limit === 'number') {
-    const startLine = Number(input.offset) + 1;
-    const endLine = Number(input.offset) + Number(input.limit);
-    lineInfo = t('tools.lineRange', { start: startLine, end: endLine });
-  }
-  // If not found, try extracting from file path suffix (e.g., "file.txt:300-370")
-  else if (filePath && /:\d+(-\d+)?$/.test(filePath)) {
-    const match = filePath.match(/:(\d+)(?:-(\d+))?$/);
-    if (match) {
-      const startLine = match[1];
-      const endLine = match[2];
-      if (endLine) {
-        lineInfo = t('tools.lineRange', { start: startLine, end: endLine });
-      } else {
-        lineInfo = t('tools.lineSingle', { line: startLine });
-      }
-    }
-  }
-
-  // Check if it's a directory (ends with / or is . or ..)
-  const isDirectory = filePath === '.' || filePath === '..' || filePath?.endsWith('/');
+  const target = resolveToolTarget(input, 'read');
+  const filePath = target?.rawPath;
+  const lineInfo = getToolLineInfo(input, target);
+  const isDirectory = target?.isDirectory ?? false;
   const iconClass = isDirectory ? 'codicon-folder' : 'codicon-file-code';
   const actionText = isDirectory ? t('permission.tools.readDirectory') : t('permission.tools.Read');
 
   const handleFileClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent bubbling to avoid triggering expand/collapse
-    if (filePath && !isDirectory) {
-      openFile(filePath);
+    if (target?.isFile) {
+      openFile(target.openPath, lineInfo.start, lineInfo.end);
     }
   };
 
-  const getFileIconSvg = (path?: string) => {
-    if (!path) return '';
-    const name = getFileName(path);
-
+  const getFileIconSvg = () => {
+    if (!target) return '';
     if (isDirectory) {
-      // Use folder icon for directories
-      return getFolderIcon(cleanFileName);
-    } else {
-      // Remove line number suffix if present
-      const cleanName = name.replace(/:\d+(-\d+)?$/, '');
-      const extension = cleanName.indexOf('.') !== -1 ? cleanName.split('.').pop() : '';
-      return getFileIcon(extension, cleanName);
+      return getFolderIcon(target.cleanFileName);
     }
+    const extension = target.cleanFileName.includes('.') ? target.cleanFileName.split('.').pop() : '';
+    return getFileIcon(extension ?? '', target.cleanFileName);
   };
 
   // Get all input parameters for the expanded view, excluding Codex-specific fields
@@ -193,14 +73,16 @@ const ReadToolBlock = ({ input }: ReadToolBlockProps) => {
           >
             <span
               style={{ marginRight: '4px', display: 'flex', alignItems: 'center', width: '16px', height: '16px' }}
-              dangerouslySetInnerHTML={{ __html: getFileIconSvg(filePath) }}
+              dangerouslySetInnerHTML={{ __html: getFileIconSvg() }}
             />
-            {cleanFileName || fileName || filePath}
+            {target?.displayPath || filePath}
           </span>
 
-          {lineInfo && (
+          {lineInfo.start && (
             <span className="tool-title-summary" style={{ marginLeft: '8px', fontSize: '12px' }}>
-              {lineInfo}
+              {lineInfo.end && lineInfo.end !== lineInfo.start
+                ? t('tools.lineRange', { start: lineInfo.start, end: lineInfo.end })
+                : t('tools.lineSingle', { line: lineInfo.start })}
             </span>
           )}
         </div>
@@ -249,4 +131,3 @@ const ReadToolBlock = ({ input }: ReadToolBlockProps) => {
 };
 
 export default ReadToolBlock;
-

--- a/webview/src/components/toolBlocks/ReadToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolGroupBlock.tsx
@@ -2,14 +2,18 @@ import { useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { openFile } from '../../utils/bridge';
-import { getFileName } from '../../utils/helpers';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
+import { getToolLineInfo, resolveToolTarget } from '../../utils/toolPresentation';
 
 interface FileItem {
   filePath: string;
+  displayPath: string;
   cleanFileName: string;
+  openPath: string;
   isDirectory: boolean;
   lineInfo?: string;
+  lineStart?: number;
+  lineEnd?: number;
   isCompleted: boolean;
   isError: boolean;
 }
@@ -28,178 +32,50 @@ const MAX_VISIBLE_ITEMS = 3;
 const ITEM_HEIGHT = 28;
 
 /**
- * Extract file path from tool input
- */
-const extractFilePath = (input: ToolInput): string | undefined => {
-  // Try standard file path fields first (ensure they are strings, not objects)
-  let filePath =
-    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
-    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
-    (typeof input.path === 'string' ? input.path : undefined);
-
-  // If not found, try extracting from Codex command
-  if (!filePath && typeof input.command === 'string') {
-    const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
-    filePath = extractFilePathFromCommand(input.command, workdir);
-  }
-
-  return filePath;
-};
-
-/**
- * Extract file/directory path from command string (for Codex commands)
- */
-const extractFilePathFromCommand = (command: string | undefined, workdir?: string): string | undefined => {
-  if (!command || typeof command !== 'string') return undefined;
-
-  let trimmed = command.trim();
-
-  // Extract actual command from shell wrapper
-  const shellWrapperMatch = trimmed.match(/^\/bin\/(zsh|bash)\s+(?:-lc|-c)\s+['"](.+)['"]$/);
-  if (shellWrapperMatch) {
-    trimmed = shellWrapperMatch[2];
-  }
-
-  // Remove 'cd dir &&' prefix if present
-  const cdPrefixMatch = trimmed.match(/^cd\s+\S+\s+&&\s+(.+)$/);
-  if (cdPrefixMatch) {
-    trimmed = cdPrefixMatch[1].trim();
-  }
-
-  // Match pwd command
-  if (/^pwd\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match ls command
-  const lsMatch = trimmed.match(/^ls\s+(?:-[a-zA-Z]+\s+)?(.+)$/);
-  if (lsMatch) {
-    const path = lsMatch[1].trim().replace(/^["']|["']$/g, '');
-    return path.endsWith('/') ? path : path + '/';
-  }
-
-  // Match ls without path
-  if (/^ls(?:\s+-[a-zA-Z]+)*\s*$/.test(trimmed)) {
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match tree command
-  if (/^tree\b/.test(trimmed)) {
-    const treeMatch = trimmed.match(/^tree\s+(.+)$/);
-    if (treeMatch) {
-      const path = treeMatch[1].trim().replace(/^["']|["']$/g, '');
-      return path.endsWith('/') ? path : path + '/';
-    }
-    return workdir ? workdir + '/' : undefined;
-  }
-
-  // Match sed -n command
-  const sedMatch = trimmed.match(/^sed\s+-n\s+['"]?(\d+)(?:,(\d+))?p['"]?\s+(.+)$/);
-  if (sedMatch) {
-    const startLine = sedMatch[1];
-    const endLine = sedMatch[2];
-    const path = sedMatch[3].trim().replace(/^["']|["']$/g, '');
-    return endLine ? `${path}:${startLine}-${endLine}` : `${path}:${startLine}`;
-  }
-
-  // Match cat command
-  const catMatch = trimmed.match(/^cat\s+(.+)$/);
-  if (catMatch) {
-    return catMatch[1].trim().replace(/^["']|["']$/g, '');
-  }
-
-  // Match head/tail commands
-  const headTailMatch = trimmed.match(/^(head|tail)\s+(?:.*\s)?([^\s-][^\s]*)$/);
-  if (headTailMatch) {
-    return headTailMatch[2].trim().replace(/^["']|["']$/g, '');
-  }
-
-  return undefined;
-};
-
-/**
  * Parse item to FileItem
  */
 const parseFileItem = (item: { input?: ToolInput; result?: ToolResultBlock | null }): FileItem | null => {
   const input = item.input;
   if (!input) return null;
 
-  const filePath = extractFilePath(input);
-  if (!filePath) return null;
+  const target = resolveToolTarget(input, 'read');
+  if (!target) return null;
 
-  const cleanFileName = getFileName(filePath)?.replace(/:\d+(-\d+)?$/, '') || filePath;
-  const isDirectory = filePath === '.' || filePath === '..' || filePath.endsWith('/');
-
-  // Extract line info from multiple sources
-  let lineInfo = '';
-
-  // Helper to parse number from string or number
-  const parseNum = (val: unknown): number | undefined => {
-    if (typeof val === 'number') return val;
-    if (typeof val === 'string' && /^\d+$/.test(val)) return parseInt(val, 10);
-    return undefined;
-  };
-
-  const offset = parseNum(input.offset);
-  const limit = parseNum(input.limit);
-
-  // 1. Check offset/limit fields (Claude Code standard)
-  if (offset !== undefined && limit !== undefined) {
-    const startLine = offset + 1;
-    const endLine = offset + limit;
-    lineInfo = `L${startLine}-${endLine}`;
-  }
-  // 2. Check line/lines field
-  else if (input.line !== undefined || input.lines !== undefined) {
-    const line = input.line ?? input.lines;
-    const lineNum = parseNum(line);
-    if (lineNum !== undefined) {
-      lineInfo = `L${lineNum}`;
-    } else if (typeof line === 'string') {
-      lineInfo = line.startsWith('L') ? line : `L${line}`;
-    }
-  }
-  // 3. Check start_line/end_line fields
-  else if (input.start_line !== undefined) {
-    const start = parseNum(input.start_line);
-    const end = parseNum(input.end_line);
-    if (start !== undefined) {
-      if (end !== undefined && end !== start) {
-        lineInfo = `L${start}-${end}`;
-      } else {
-        lineInfo = `L${start}`;
-      }
-    }
-  }
-  // 4. Extract from file path suffix (e.g., "file.txt:300-370")
-  else if (/:\d+(-\d+)?$/.test(filePath)) {
-    const match = filePath.match(/:(\d+)(?:-(\d+))?$/);
-    if (match) {
-      const startLine = match[1];
-      const endLine = match[2];
-      lineInfo = endLine ? `L${startLine}-${endLine}` : `L${startLine}`;
-    }
-  }
+  const lineInfoValue = getToolLineInfo(input, target);
+  const lineInfo = lineInfoValue.start
+    ? (lineInfoValue.end && lineInfoValue.end !== lineInfoValue.start
+      ? `L${lineInfoValue.start}-${lineInfoValue.end}`
+      : `L${lineInfoValue.start}`)
+    : '';
 
   // Determine completion status
   const isCompleted = item.result !== undefined && item.result !== null;
   const isError = isCompleted && item.result?.is_error === true;
 
-  return { filePath, cleanFileName, isDirectory, lineInfo, isCompleted, isError };
+  return {
+    filePath: target.rawPath,
+    displayPath: target.displayPath,
+    cleanFileName: target.cleanFileName,
+    openPath: target.openPath,
+    isDirectory: target.isDirectory,
+    lineInfo,
+    lineStart: lineInfoValue.start,
+    lineEnd: lineInfoValue.end,
+    isCompleted,
+    isError,
+  };
 };
 
 /**
- * Get file icon SVG
+ * Get file icon SVG by file name (with extension).
  */
-const getFileIconSvg = (filePath: string, isDirectory: boolean) => {
-  const name = getFileName(filePath);
+const getFileIconSvg = (fileName: string, isDirectory: boolean) => {
   if (isDirectory) {
-    const cleanName = name.replace(/\/$/, '');
-    return getFolderIcon(cleanName);
+    return getFolderIcon(fileName.replace(/\/$/, ''));
   }
-  const cleanName = name.replace(/:\d+(-\d+)?$/, '');
-  const extension = cleanName.indexOf('.') !== -1 ? cleanName.split('.').pop() : '';
-  return getFileIcon(extension, cleanName);
+  const cleanName = fileName.replace(/:\d+(-\d+)?$/, '');
+  const extension = cleanName.includes('.') ? cleanName.split('.').pop() : '';
+  return getFileIcon(extension ?? '', cleanName);
 };
 
 const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
@@ -235,12 +111,10 @@ const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
     ? MAX_VISIBLE_ITEMS * ITEM_HEIGHT
     : fileItems.length * ITEM_HEIGHT;
 
-  const handleFileClick = (filePath: string, isDirectory: boolean, e: React.MouseEvent) => {
+  const handleFileClick = (openPath: string, isDirectory: boolean, e: React.MouseEvent, lineStart?: number, lineEnd?: number) => {
     e.stopPropagation();
     if (!isDirectory) {
-      // Remove line number suffix for opening
-      const cleanPath = filePath.replace(/:\d+(-\d+)?$/, '');
-      openFile(cleanPath);
+      openFile(openPath, lineStart, lineEnd);
     }
   };
 
@@ -287,7 +161,7 @@ const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
             <div
               key={index}
               className={`file-list-item ${!item.isDirectory ? 'clickable-file' : ''}`}
-              onClick={(e) => handleFileClick(item.filePath, item.isDirectory, e)}
+              onClick={(e) => handleFileClick(item.openPath, item.isDirectory, e, item.lineStart, item.lineEnd)}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -298,7 +172,7 @@ const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
                 minHeight: `${ITEM_HEIGHT}px`,
                 flexShrink: 0,
               }}
-              title={item.filePath}
+              title={item.displayPath}
             >
               <span
                 style={{
@@ -309,7 +183,7 @@ const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
                   height: '16px',
                   flexShrink: 0,
                 }}
-                dangerouslySetInnerHTML={{ __html: getFileIconSvg(item.filePath, item.isDirectory) }}
+                dangerouslySetInnerHTML={{ __html: getFileIconSvg(item.cleanFileName, item.isDirectory) }}
               />
               <span
                 style={{
@@ -322,7 +196,7 @@ const ReadToolGroupBlock = ({ items }: ReadToolGroupBlockProps) => {
                   minWidth: 0,
                 }}
               >
-                {item.cleanFileName}
+                {item.displayPath}
               </span>
               {item.lineInfo && (
                 <span

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1016,7 +1016,9 @@
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
     "bashGroupFailed": "failed",
-    "promptLabel": "Prompt"
+    "promptLabel": "Prompt",
+    "updatePlan": "Update Plan",
+    "applyPatch": "Apply Patch"
   },
   "todo": {
     "inProgress": "In Progress {{completed}}/{{total}} tasks",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1022,7 +1022,8 @@
     "bashGroupAllCompleted": "全部完成",
     "bashGroupFailed": "失败",
     "promptLabel": "提示词",
-    "updatePlan": "更新计划"
+    "updatePlan": "更新计划",
+    "applyPatch": "应用补丁"
   },
   "todo": {
     "inProgress": "进行中 {{completed}}/{{total}} 个任务",

--- a/webview/src/utils/bridge.ts
+++ b/webview/src/utils/bridge.ts
@@ -32,7 +32,7 @@ export const sendBridgeEvent = (event: string, content = '') => {
   return callBridge(`${event}:${content}`);
 };
 
-export const openFile = (filePath?: string) => {
+export const openFile = (filePath?: string, lineStart?: number, lineEnd?: number) => {
   if (!filePath) {
     return;
   }
@@ -40,7 +40,11 @@ export const openFile = (filePath?: string) => {
   if (!isValidPath(filePath)) {
     return;
   }
-  sendBridgeEvent('open_file', filePath);
+  let path = filePath;
+  if (lineStart !== undefined) {
+    path = lineEnd !== undefined ? `${filePath}:${lineStart}-${lineEnd}` : `${filePath}:${lineStart}`;
+  }
+  sendBridgeEvent('open_file', path);
 };
 
 export const openBrowser = (url?: string) => {

--- a/webview/src/utils/toolCommandPath.test.ts
+++ b/webview/src/utils/toolCommandPath.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { extractFilePathFromCommand, isFileViewingCommand, parseCommandType } from './toolCommandPath';
+
+describe('toolCommandPath', () => {
+  it('extracts a sed target from grouped commands', () => {
+    const command = "sed -n '1,220p' src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java && printf '\\n---\\n' && sed -n '1,220p' src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java";
+
+    expect(extractFilePathFromCommand(command)).toBe(
+      'src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java:1-220',
+    );
+  });
+
+  it('extracts a path from shell-wrapped grouped commands', () => {
+    const command = "/bin/bash -lc '(sed -n '\\''230,430p'\\'' src/main/java/com/github/claudecodegui/dependency/DependencyManager.java && printf '\\''\\n---\\n'\\'' && sed -n '\\''260,340p'\\'' src/main/java/com/github/claudecodegui/handler/DependencyHandler.java)'";
+
+    expect(extractFilePathFromCommand(command)).toBe(
+      'src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:230-430',
+    );
+  });
+
+  it('extracts the first readable file from a pipeline', () => {
+    expect(extractFilePathFromCommand('cat README.md | head -n 20')).toBe('README.md');
+  });
+
+  it('detects file viewing commands through wrappers', () => {
+    const command = "/bin/zsh -lc 'cd /tmp && sed -n \"10,20p\" src/App.tsx && printf \"done\"'";
+
+    expect(isFileViewingCommand(command)).toBe(true);
+    expect(extractFilePathFromCommand(command, '/tmp')).toBe('src/App.tsx:10-20');
+  });
+
+  describe('parseCommandType', () => {
+    it('identifies read commands (cat, head, tail, nl)', () => {
+      expect(parseCommandType('cat file.txt').type).toBe('read');
+      expect(parseCommandType('head -n 20 file.txt').type).toBe('read');
+      expect(parseCommandType('tail -n 50 file.txt').type).toBe('read');
+      expect(parseCommandType('nl -ba file.txt').type).toBe('read');
+      expect(parseCommandType('sed -n "1,100p" file.txt').type).toBe('read');
+    });
+
+    it('identifies list commands (ls, tree)', () => {
+      expect(parseCommandType('ls -la').type).toBe('list');
+      expect(parseCommandType('ls src/').type).toBe('list');
+      expect(parseCommandType('tree -L 2').type).toBe('list');
+    });
+
+    it('identifies search commands (grep, rg)', () => {
+      expect(parseCommandType('grep -r "pattern" src/').type).toBe('search');
+      expect(parseCommandType('rg "TODO" .').type).toBe('search');
+    });
+
+    it('returns unknown for other commands', () => {
+      expect(parseCommandType('git status').type).toBe('unknown');
+      expect(parseCommandType('npm run build').type).toBe('unknown');
+      expect(parseCommandType('echo hello').type).toBe('unknown');
+    });
+
+    it('extracts path for read commands', () => {
+      const result = parseCommandType('cat src/main.ts');
+      expect(result.type).toBe('read');
+      expect(result.path).toBe('src/main.ts');
+    });
+
+    it('identifies multi-file sed commands as read', () => {
+      const command = "sed -n '240,420p' src/main/java/com/github/claudecodegui/handler/DependencyHandler.java && sed -n '420,760p' src/main/java/com/github/claudecodegui/bridge/NodeDetector.java";
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+      expect(result.path).toBe('src/main/java/com/github/claudecodegui/handler/DependencyHandler.java:240-420');
+    });
+
+    it('extracts clean file name from path with line numbers', () => {
+      const command = "sed -n '240,420p' src/main/java/com/example/File.java";
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+      // Should extract file name: File.java
+      const path = result.path;
+      const fileName = path?.split('/').pop()?.split(':')[0];
+      expect(fileName).toBe('File.java');
+    });
+
+    it('handles user-provided multi-sed command', () => {
+      const command = "sed -n '240,420p' src/main/java/com/github/claudecodegui/handler/DependencyHandler.java && sed -n '420,760p' src/main/java/com/github/claudecodegui/bridge/NodeDetector.java && sed -n '460,620p' src/main/java/com/github/claudecodegui/dependency/DependencyManager.java && sed -n '130,260p' webview/src/components/settings/DependencySection/index.tsx && sed -n '1,260p' webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts";
+
+      // Should identify as read type
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+
+      // Should extract first file path
+      expect(result.path).toBe('src/main/java/com/github/claudecodegui/handler/DependencyHandler.java:240-420');
+
+      // Extract clean file name for display
+      const fileName = result.path?.split('/').pop()?.split(':')[0];
+      expect(fileName).toBe('DependencyHandler.java');
+    });
+
+    it('handles nl piped to sed commands', () => {
+      const command = "nl -ba src/main/java/com/example/File.java | sed -n '1,100p'";
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+      expect(result.path).toBe('src/main/java/com/example/File.java');
+
+      // Extract clean file name
+      const fileName = result.path?.split('/').pop();
+      expect(fileName).toBe('File.java');
+    });
+
+    it('handles nl with line numbers piped to sed', () => {
+      const command = "nl -ba webview/src/components/toolBlocks/EditToolBlock.tsx | sed -n '1,260p'";
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+      expect(result.path).toBe('webview/src/components/toolBlocks/EditToolBlock.tsx');
+
+      const fileName = result.path?.split('/').pop();
+      expect(fileName).toBe('EditToolBlock.tsx');
+    });
+
+    it('extracts clean file name without line numbers', () => {
+      const command = "sed -n '240,420p' src/main/java/com/example/MyFile.java";
+      const result = parseCommandType(command);
+      expect(result.type).toBe('read');
+      expect(result.path).toBe('src/main/java/com/example/MyFile.java:240-420');
+
+      // Clean file name should not contain line numbers
+      const fileName = result.path?.split('/').pop()?.split(':')[0];
+      expect(fileName).toBe('MyFile.java');
+    });
+  });
+});

--- a/webview/src/utils/toolCommandPath.ts
+++ b/webview/src/utils/toolCommandPath.ts
@@ -1,0 +1,328 @@
+const stripWrappingQuotes = (value: string): string => {
+  if (value.length < 2) {
+    return value;
+  }
+
+  const firstChar = value[0];
+  const lastChar = value[value.length - 1];
+  if ((firstChar === '"' && lastChar === '"') || (firstChar === '\'' && lastChar === '\'')) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+};
+
+const stripOuterGrouping = (value: string): string => {
+  let current = value.trim();
+
+  while (current.startsWith('(') && current.endsWith(')')) {
+    let depth = 0;
+    let isBalanced = true;
+
+    for (let index = 0; index < current.length; index += 1) {
+      const char = current[index];
+      if (char === '(') {
+        depth += 1;
+      } else if (char === ')') {
+        depth -= 1;
+        if (depth === 0 && index < current.length - 1) {
+          isBalanced = false;
+          break;
+        }
+      }
+
+      if (depth < 0) {
+        isBalanced = false;
+        break;
+      }
+    }
+
+    if (!isBalanced || depth !== 0) {
+      break;
+    }
+
+    current = current.slice(1, -1).trim();
+  }
+
+  return current;
+};
+
+const splitTopLevelSegments = (command: string): string[] => {
+  const segments: string[] = [];
+  let current = '';
+  let quoteChar: '"' | '\'' | null = null;
+  let escapeNext = false;
+  let parenthesesDepth = 0;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    const nextChar = command[index + 1];
+
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      current += char;
+      escapeNext = true;
+      continue;
+    }
+
+    if (quoteChar) {
+      current += char;
+      if (char === quoteChar) {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === '\'') {
+      current += char;
+      quoteChar = char;
+      continue;
+    }
+
+    if (char === '(') {
+      parenthesesDepth += 1;
+      current += char;
+      continue;
+    }
+
+    if (char === ')' && parenthesesDepth > 0) {
+      parenthesesDepth -= 1;
+      current += char;
+      continue;
+    }
+
+    const hasTwoCharSeparator = (char === '&' && nextChar === '&') ||
+      (char === '|' && nextChar === '|');
+    const hasOneCharSeparator = char === ';' || (char === '|' && nextChar !== '|');
+
+    if (parenthesesDepth === 0 && (hasTwoCharSeparator || hasOneCharSeparator)) {
+      const trimmedSegment = current.trim();
+      if (trimmedSegment) {
+        segments.push(stripOuterGrouping(trimmedSegment));
+      }
+      current = '';
+      if (hasTwoCharSeparator) {
+        index += 1;
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  const trimmedSegment = current.trim();
+  if (trimmedSegment) {
+    segments.push(stripOuterGrouping(trimmedSegment));
+  }
+
+  return segments;
+};
+
+export const unwrapShellCommand = (command: string): string => {
+  let current = command.trim();
+  const shellWrapperMatch = current.match(/^\/bin\/(?:zsh|bash|sh)\s+(?:-lc|-c)\s+([\s\S]+)$/);
+  if (shellWrapperMatch) {
+    current = stripWrappingQuotes(shellWrapperMatch[1].trim());
+    current = current.replace(/'\\''/g, '\'');
+    current = current.replace(/'"'"'/g, '\'');
+  }
+
+  return stripOuterGrouping(current);
+};
+
+const normalizePathToken = (pathToken: string): string => stripWrappingQuotes(pathToken.trim());
+
+const parseSegmentPath = (segment: string, workdir?: string): string | undefined => {
+  if (/^pwd\s*$/.test(segment)) {
+    return workdir ? `${workdir}/` : undefined;
+  }
+
+  if (/^ls(?:\s+-[a-zA-Z]+)*\s*$/.test(segment)) {
+    return workdir ? `${workdir}/` : undefined;
+  }
+
+  const lsMatch = segment.match(/^ls\s+(?:-[a-zA-Z]+\s+)*(.+)$/);
+  if (lsMatch) {
+    const path = normalizePathToken(lsMatch[1]);
+    return path.endsWith('/') ? path : `${path}/`;
+  }
+
+  if (/^tree(?:\s+-[a-zA-Z]+)*\s*$/.test(segment)) {
+    return workdir ? `${workdir}/` : undefined;
+  }
+
+  const treeMatch = segment.match(/^tree\s+(?:-[a-zA-Z]+\s+)*(.+)$/);
+  if (treeMatch) {
+    const path = normalizePathToken(treeMatch[1]);
+    return path.endsWith('/') ? path : `${path}/`;
+  }
+
+  const sedMatch = segment.match(/^sed\s+-n\s+['"]?(\d+)(?:,(\d+))?p['"]?\s+(.+)$/);
+  if (sedMatch) {
+    const startLine = sedMatch[1];
+    const endLine = sedMatch[2];
+    const path = normalizePathToken(sedMatch[3]);
+    return endLine ? `${path}:${startLine}-${endLine}` : `${path}:${startLine}`;
+  }
+
+  const catMatch = segment.match(/^cat\s+(.+)$/);
+  if (catMatch) {
+    return normalizePathToken(catMatch[1]);
+  }
+
+  const headTailMatch = segment.match(/^(head|tail)\s+(?:-[a-zA-Z]+\s+\S+\s+)*(.+)$/);
+  if (headTailMatch) {
+    return normalizePathToken(headTailMatch[2]);
+  }
+
+  // nl -ba file | sed -n '1,100p' - extract file from nl command
+  const nlMatch = segment.match(/^nl\s+(?:-[a-zA-Z]+\s+)*(\S+)$/);
+  if (nlMatch) {
+    return normalizePathToken(nlMatch[1]);
+  }
+
+  // Write commands: cat > file, tee file, echo/printf > file
+  const catRedirectMatch = segment.match(/^cat\s*>\s*(.+)$/);
+  if (catRedirectMatch) {
+    return normalizePathToken(catRedirectMatch[1]);
+  }
+
+  const teeMatch = segment.match(/^tee\s+(?:-[a-zA-Z]+\s+)*(.+)$/);
+  if (teeMatch) {
+    return normalizePathToken(teeMatch[1]);
+  }
+
+  const redirectMatch = segment.match(/^(?:echo|printf)\s+.+\s*>\s*(.+)$/);
+  if (redirectMatch) {
+    return normalizePathToken(redirectMatch[1]);
+  }
+
+  return undefined;
+};
+
+/**
+ * Extract file path from a pipeline command like "nl -ba file | sed -n '1,100p'"
+ */
+const extractPathFromPipeline = (pipeline: string): string | undefined => {
+  // Split by pipe, but be careful about nested commands
+  const pipeParts = pipeline.split('|').map(p => p.trim());
+
+  for (const part of pipeParts) {
+    // Try to extract path from each part
+    const path = parseSegmentPath(part);
+    if (path) {
+      return path;
+    }
+  }
+
+  return undefined;
+};
+
+export const extractFilePathFromCommand = (command: string | undefined, workdir?: string): string | undefined => {
+  if (!command || typeof command !== 'string') {
+    return undefined;
+  }
+
+  const normalizedCommand = unwrapShellCommand(command);
+
+  // First, try to handle pipeline commands (nl -ba file | sed -n ...)
+  // Split by && and ; first, then check for pipes in each segment
+  const segments = splitTopLevelSegments(normalizedCommand);
+  const executableSegments = segments.filter((segment, index) => !(index === 0 && /^cd\s+.+$/.test(segment)));
+
+  for (const segment of executableSegments) {
+    // Check if this segment contains a pipe
+    if (segment.includes('|')) {
+      const path = extractPathFromPipeline(segment);
+      if (path) {
+        return path;
+      }
+    } else {
+      const path = parseSegmentPath(segment, workdir);
+      if (path) {
+        return path;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+export const isFileViewingCommand = (command?: string): boolean => {
+  if (!command || typeof command !== 'string') {
+    return false;
+  }
+
+  return extractFilePathFromCommand(command) !== undefined;
+};
+
+export type ParsedCommandType = 'read' | 'list' | 'search' | 'unknown';
+
+export interface ParsedCommandInfo {
+  type: ParsedCommandType;
+  displayText: string;
+  path?: string;
+}
+
+const READ_COMMANDS = ['cat', 'head', 'tail', 'less', 'more', 'nl', 'bat', 'sed'];
+const LIST_COMMANDS = ['ls', 'tree', 'find', 'git ls-files', 'git ls-tree'];
+const SEARCH_COMMANDS = ['grep', 'rg', 'git grep', 'ag', 'ack'];
+
+export const parseCommandType = (command: string | undefined): ParsedCommandInfo => {
+  if (!command || typeof command !== 'string') {
+    return { type: 'unknown', displayText: '' };
+  }
+
+  const normalizedCommand = unwrapShellCommand(command);
+  const firstSegment = normalizedCommand.split('\n')[0]?.trim() ?? '';
+
+  const lowerCommand = firstSegment.toLowerCase();
+
+  for (const cmd of READ_COMMANDS) {
+    if (lowerCommand.startsWith(cmd + ' ') || lowerCommand === cmd) {
+      const path = extractFilePathFromCommand(command);
+      return {
+        type: 'read',
+        displayText: path ?? firstSegment,
+        path,
+      };
+    }
+  }
+
+  for (const cmd of LIST_COMMANDS) {
+    if (lowerCommand.startsWith(cmd + ' ') || lowerCommand === cmd) {
+      const path = extractFilePathFromCommand(command);
+      return {
+        type: 'list',
+        displayText: path ?? firstSegment,
+        path,
+      };
+    }
+  }
+
+  for (const cmd of SEARCH_COMMANDS) {
+    if (lowerCommand.startsWith(cmd + ' ') || lowerCommand === cmd) {
+      return {
+        type: 'search',
+        displayText: firstSegment,
+      };
+    }
+  }
+
+  if (/^git\s+(status|diff|log|branch)/.test(lowerCommand)) {
+    return {
+      type: 'unknown',
+      displayText: firstSegment,
+    };
+  }
+
+  return {
+    type: 'unknown',
+    displayText: firstSegment,
+  };
+};

--- a/webview/src/utils/toolPresentation.test.ts
+++ b/webview/src/utils/toolPresentation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getToolLineInfo, resolveToolTarget, summarizeToolCommand } from './toolPresentation';
+
+describe('toolPresentation', () => {
+  it('relativizes display path to workdir and strips line suffix for open path', () => {
+    const target = resolveToolTarget({
+      command: "sed -n '10,20p' /repo/src/App.tsx",
+      workdir: '/repo',
+    }, 'shell_command');
+
+    expect(target).toMatchObject({
+      rawPath: '/repo/src/App.tsx:10-20',
+      openPath: '/repo/src/App.tsx',
+      displayPath: 'src/App.tsx:10-20',
+      cleanFileName: 'App.tsx',
+      isFile: true,
+      isDirectory: false,
+      lineStart: 10,
+      lineEnd: 20,
+    });
+  });
+
+  it('prefers structured line metadata over path suffix', () => {
+    const target = resolveToolTarget({
+      file_path: 'src/main.ts:1-10',
+      offset: 19,
+      limit: 5,
+    }, 'read');
+
+    expect(getToolLineInfo({
+      file_path: 'src/main.ts:1-10',
+      offset: 19,
+      limit: 5,
+    }, target)).toEqual({ start: 20, end: 24 });
+  });
+
+  it('summarizes shell-wrapped multiline commands like the TUI', () => {
+    const summary = summarizeToolCommand("/bin/bash -lc 'set -o pipefail\ncargo test\n--all-features --quiet'");
+
+    expect(summary).toBe('set -o pipefail ...');
+  });
+
+  it('keeps standard edit-file paths clickable without line suffixes', () => {
+    const target = resolveToolTarget({
+      file_path: '/repo/src/main.ts:3-8',
+    }, 'edit');
+
+    expect(target).toMatchObject({
+      rawPath: '/repo/src/main.ts:3-8',
+      openPath: '/repo/src/main.ts',
+      displayPath: 'main.ts:3-8',
+      cleanFileName: 'main.ts',
+    });
+  });
+
+  it('relativizes display path when workdir is provided', () => {
+    const target = resolveToolTarget({
+      file_path: '/repo/src/main.ts:3-8',
+      workdir: '/repo',
+    }, 'edit');
+
+    expect(target).toMatchObject({
+      rawPath: '/repo/src/main.ts:3-8',
+      openPath: '/repo/src/main.ts',
+      displayPath: 'src/main.ts:3-8',
+      cleanFileName: 'main.ts',
+    });
+  });
+});

--- a/webview/src/utils/toolPresentation.ts
+++ b/webview/src/utils/toolPresentation.ts
@@ -1,0 +1,226 @@
+import type { ToolInput } from '../types';
+import { getFileName, truncate } from './helpers';
+import { extractFilePathFromCommand, unwrapShellCommand } from './toolCommandPath';
+
+const SPECIAL_FILES = new Set([
+  'makefile', 'dockerfile', 'jenkinsfile', 'vagrantfile',
+  'gemfile', 'rakefile', 'procfile', 'guardfile',
+  'license', 'licence', 'readme', 'changelog',
+  'gradlew', 'cname', 'authors', 'contributors',
+]);
+
+const stripLineSuffix = (filePath: string): string => filePath.replace(/:\d+(-\d+)?$/, '');
+
+const parseLineSuffix = (filePath?: string): { start?: number; end?: number } => {
+  if (!filePath) {
+    return {};
+  }
+
+  const match = filePath.match(/:(\d+)(?:-(\d+))?$/);
+  if (!match) {
+    return {};
+  }
+
+  return {
+    start: Number(match[1]),
+    end: match[2] ? Number(match[2]) : undefined,
+  };
+};
+
+const parseNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    return Number(value);
+  }
+  return undefined;
+};
+
+const relativizeDisplayPath = (filePath: string, workdir?: string): string => {
+  const cleanPath = stripLineSuffix(filePath);
+
+  // 如果是绝对路径且有 workdir，尝试相对化
+  if (workdir && cleanPath.startsWith('/') && workdir.startsWith('/')) {
+    if (cleanPath === workdir) {
+      return filePath.startsWith(cleanPath) ? './' : '.';
+    }
+
+    const normalizedWorkdir = workdir.endsWith('/') ? workdir : `${workdir}/`;
+    if (cleanPath.startsWith(normalizedWorkdir)) {
+      const relativePath = cleanPath.slice(normalizedWorkdir.length);
+      const lineSuffix = filePath.slice(cleanPath.length);
+      return `${relativePath}${lineSuffix}`;
+    }
+  }
+
+  // 对于相对路径或无法相对化的路径，只返回文件名
+  return getFileName(filePath);
+};
+
+const detectDirectory = (filePath: string): boolean => {
+  if (filePath === '.' || filePath === '..' || filePath.endsWith('/')) {
+    return true;
+  }
+
+  const cleanFileName = getFileName(stripLineSuffix(filePath));
+  return !cleanFileName.includes('.') && !SPECIAL_FILES.has(cleanFileName.toLowerCase());
+};
+
+/**
+ * Extract file paths from apply_patch input
+ */
+export const extractPathsFromPatch = (patchContent: string): string[] => {
+  const paths: string[] = [];
+  const lines = patchContent.split('\n');
+
+  for (const line of lines) {
+    // Match "*** Add File: /path/to/file" or "*** Update File: /path/to/file"
+    const match = line.match(/^\*\*\* (?:Add|Update) File:\s*(.+)$/);
+    if (match) {
+      paths.push(match[1].trim());
+    }
+  }
+
+  return paths;
+};
+
+export interface ToolTargetInfo {
+  rawPath: string;
+  openPath: string;
+  displayPath: string;
+  fileName: string;
+  cleanFileName: string;
+  isDirectory: boolean;
+  isFile: boolean;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+export const resolveToolTarget = (input: ToolInput, name?: string): ToolTargetInfo | undefined => {
+  const workdir = typeof input.workdir === 'string' ? input.workdir : undefined;
+  const standardPath =
+    (typeof input.file_path === 'string' ? input.file_path : undefined) ??
+    (typeof input.path === 'string' ? input.path : undefined) ??
+    (typeof input.target_file === 'string' ? input.target_file : undefined) ??
+    (typeof input.notebook_path === 'string' ? input.notebook_path : undefined);
+
+  const lowerName = (name ?? '').toLowerCase();
+
+  // Handle apply_patch tool - extract file path from patch content
+  if (lowerName === 'apply_patch') {
+    const patchContent = (typeof input.input === 'string' ? input.input : undefined) ??
+      (typeof input.patch === 'string' ? input.patch : undefined) ??
+      (typeof input.content === 'string' ? input.content : undefined);
+
+    if (patchContent) {
+      const paths = extractPathsFromPatch(patchContent);
+      if (paths.length > 0) {
+        const rawPath = paths[0];
+        const { start, end } = parseLineSuffix(rawPath);
+        const openPath = stripLineSuffix(rawPath);
+        const displayPath = relativizeDisplayPath(rawPath, workdir);
+        const fileName = getFileName(displayPath);
+        const cleanFileName = getFileName(stripLineSuffix(displayPath));
+        const isDirectory = detectDirectory(rawPath);
+
+        return {
+          rawPath,
+          openPath,
+          displayPath: paths.length > 1 ? `${cleanFileName} (+${paths.length - 1} more)` : displayPath,
+          fileName,
+          cleanFileName,
+          isDirectory,
+          isFile: !isDirectory,
+          lineStart: start,
+          lineEnd: end,
+        };
+      }
+    }
+  }
+
+  // Command-executing tools that may contain file paths
+  const isCommandTool = lowerName === 'read' ||
+    lowerName === 'write' ||
+    lowerName === 'shell_command' ||
+    lowerName === 'exec_command' ||
+    lowerName === 'execute_command' ||
+    lowerName === 'executecommand' ||
+    lowerName === 'bash' ||
+    lowerName === 'run_terminal_cmd';
+
+  // Codex uses 'cmd', others use 'command'
+  const commandStr = (typeof input.command === 'string' ? input.command : undefined) ??
+    (typeof input.cmd === 'string' ? input.cmd : undefined);
+
+  const rawPath = standardPath ??
+    ((isCommandTool && commandStr)
+      ? extractFilePathFromCommand(commandStr, workdir)
+      : undefined);
+
+  if (!rawPath) {
+    return undefined;
+  }
+
+  const { start, end } = parseLineSuffix(rawPath);
+  const openPath = stripLineSuffix(rawPath);
+  const displayPath = relativizeDisplayPath(rawPath, workdir);
+  const fileName = getFileName(displayPath);
+  const cleanFileName = getFileName(stripLineSuffix(displayPath));
+  const isDirectory = detectDirectory(rawPath);
+
+  return {
+    rawPath,
+    openPath,
+    displayPath,
+    fileName,
+    cleanFileName,
+    isDirectory,
+    isFile: !isDirectory,
+    lineStart: start,
+    lineEnd: end,
+  };
+};
+
+export const getToolLineInfo = (input: ToolInput, target?: ToolTargetInfo): { start?: number; end?: number } => {
+  const offset = parseNumber(input.offset);
+  const limit = parseNumber(input.limit);
+  if (offset !== undefined && limit !== undefined) {
+    return {
+      start: offset + 1,
+      end: offset + limit,
+    };
+  }
+
+  const line = input.line ?? input.lines;
+  const lineNum = parseNumber(line);
+  if (lineNum !== undefined) {
+    return { start: lineNum };
+  }
+
+  const startLine = parseNumber(input.start_line);
+  const endLine = parseNumber(input.end_line);
+  if (startLine !== undefined) {
+    return { start: startLine, end: endLine };
+  }
+
+  return {
+    start: target?.lineStart,
+    end: target?.lineEnd,
+  };
+};
+
+export const summarizeToolCommand = (command?: string): string | undefined => {
+  if (!command || typeof command !== 'string') {
+    return undefined;
+  }
+
+  const strippedCommand = unwrapShellCommand(command);
+  const firstLine = strippedCommand.split('\n')[0]?.trim() ?? '';
+  if (!firstLine) {
+    return undefined;
+  }
+
+  const summary = strippedCommand.includes('\n') ? `${firstLine} ...` : firstLine;
+  return truncate(summary, 80);
+};


### PR DESCRIPTION
Refactor tool block components to properly handle Codex-specific tools:

- Filter out write_stdin tool rendering across all layers (JS, Java, React)
- Display apply_patch with clickable file names extracted from patch content
- Fix file navigation to support line number ranges (openFile with lineStart/lineEnd)
- Classify shell commands consistently between Java backend and JS frontend: ls/find/tree -> glob, cat/head/tail -> read, grep/rg -> glob
- Extract shared path resolution logic into toolPresentation.ts and toolCommandPath.ts utilities with comprehensive test coverage
- Add missing i18n keys for plan-related UI elements