### PR TITLE
fix: add runtime session epoch isolation to prevent ghost messages

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -9,6 +9,9 @@ import {
   getMcpServerStatus as claudeGetMcpServerStatus,
   getMcpServerTools as claudeGetMcpServerTools
 } from '../services/claude/message-service.js';
+import {
+  resetRuntimePersistent as claudeResetRuntimePersistent
+} from '../services/claude/persistent-query-service.js';
 import { getSessionMessages as claudeGetSessionMessages } from '../services/claude/session-service.js';
 
 /**
@@ -89,11 +92,16 @@ export async function handleClaudeCommand(command, args, stdinData) {
       break;
     }
 
+    case 'resetRuntime': {
+      await claudeResetRuntimePersistent(stdinData || {});
+      break;
+    }
+
     default:
       throw new Error(`Unknown Claude command: ${command}`);
   }
 }
 
 export function getClaudeCommandList() {
-  return ['send', 'sendWithAttachments', 'getSession', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools'];
+  return ['send', 'sendWithAttachments', 'getSession', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools', 'resetRuntime'];
 }

--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -32,7 +32,8 @@ import {
   sendMessageWithAttachmentsPersistent,
   preconnectPersistent,
   shutdownPersistentRuntimes,
-  abortCurrentTurn
+  abortCurrentTurn,
+  resetRuntimePersistent
 } from './services/claude/persistent-query-service.js';
 
 // =============================================================================
@@ -314,6 +315,8 @@ async function processRequest(request) {
       await sendMessageWithAttachmentsPersistent(stdinData);
     } else if (provider === 'claude' && command === 'preconnect') {
       await preconnectPersistent(stdinData);
+    } else if (provider === 'claude' && command === 'resetRuntime') {
+      await resetRuntimePersistent(stdinData);
     } else {
       // Dispatch to the existing handlers for non-send commands.
       switch (provider) {

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -263,12 +263,13 @@ function normalizePermissionMode(permissionMode) {
   return 'default';
 }
 
-function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled) {
+function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch) {
   const material = {
     cwd: options.cwd || '',
     additionalDirectories: options.additionalDirectories || [],
     systemPromptAppend: systemPromptAppend || '',
-    streamingEnabled: !!streamingEnabled
+    streamingEnabled: !!streamingEnabled,
+    runtimeSessionEpoch: runtimeSessionEpoch || ''
   };
   return JSON.stringify(material);
 }
@@ -368,6 +369,9 @@ async function buildRequestContext(params, withAttachments) {
   const requestedSessionId = (typeof params.sessionId === 'string' && params.sessionId.trim() !== '')
     ? params.sessionId.trim()
     : null;
+  const runtimeSessionEpoch = (typeof params.runtimeSessionEpoch === 'string' && params.runtimeSessionEpoch.trim() !== '')
+    ? params.runtimeSessionEpoch.trim()
+    : null;
 
   const workingDirectory = selectWorkingDirectory(params.cwd || null);
   try {
@@ -394,20 +398,28 @@ async function buildRequestContext(params, withAttachments) {
 
   const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId);
 
+  const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch);
+  console.log('[LIFECYCLE] buildRequestContext sessionId=' + (requestedSessionId || '(new)')
+    + ' epoch=' + (runtimeSessionEpoch || '(none)')
+    + ' signature=' + runtimeSignature);
+
   return {
     requestedSessionId,
+    runtimeSessionEpoch,
     streamingEnabled,
     options,
     userMessage,
     sdkModelName,
     permissionMode,
     maxThinkingTokens,
-    runtimeSignature: buildRuntimeSignature(options, systemPromptAppend, streamingEnabled)
+    runtimeSignature
   };
 }
 
 function registerRuntimeSession(runtime, sessionId) {
   if (!sessionId) return;
+  console.log('[LIFECYCLE] registerRuntimeSession sessionId=' + sessionId
+    + ' epoch=' + (runtime?.runtimeSessionEpoch || '(none)'));
   for (const [signature, item] of anonymousRuntimesBySignature.entries()) {
     if (item === runtime) {
       anonymousRuntimesBySignature.delete(signature);
@@ -420,6 +432,7 @@ function registerRuntimeSession(runtime, sessionId) {
     }
   }
   runtime.sessionId = sessionId;
+  runtime.runtimeSessionEpoch = runtime.runtimeSessionEpoch || null;
   runtimesBySessionId.set(sessionId, runtime);
   anonymousRuntimes.delete(runtime);
   registerActiveQueryResult(sessionId, runtime.query);
@@ -427,6 +440,9 @@ function registerRuntimeSession(runtime, sessionId) {
 
 async function disposeRuntime(runtime) {
   if (!runtime || runtime.closed) return;
+  console.log('[LIFECYCLE] disposeRuntime sessionId=' + (runtime.sessionId || '(new)')
+    + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
+    + ' signature=' + (runtime.runtimeSignature || '(none)'));
   runtime.closed = true;
 
   try {
@@ -459,6 +475,7 @@ async function createRuntime(requestContext) {
   const runtime = {
     closed: false,
     sessionId: requestContext.requestedSessionId || null,
+    runtimeSessionEpoch: requestContext.runtimeSessionEpoch || null,
     runtimeSignature: requestContext.runtimeSignature,
     currentModel: requestContext.sdkModelName || null,
     currentPermissionMode: initialPermissionMode,
@@ -506,6 +523,10 @@ async function createRuntime(requestContext) {
     anonymousRuntimesBySignature.set(requestContext.runtimeSignature, runtime);
   }
 
+  console.log('[LIFECYCLE] createRuntime sessionId=' + (runtime.sessionId || '(new)')
+    + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
+    + ' signature=' + runtime.runtimeSignature);
+
   return runtime;
 }
 
@@ -548,11 +569,36 @@ async function applyDynamicControls(runtime, requestContext) {
   }
 }
 
+function assertRuntimeOwnership(runtime, requestContext) {
+  if (!runtime || runtime.closed) {
+    const err = new Error('Runtime is closed');
+    err.runtimeTerminated = true;
+    throw err;
+  }
+
+  if (requestContext.runtimeSessionEpoch && runtime.runtimeSessionEpoch !== requestContext.runtimeSessionEpoch) {
+    const err = new Error(
+      `Runtime ownership mismatch: expected epoch ${requestContext.runtimeSessionEpoch}, got ${runtime.runtimeSessionEpoch || '(none)'}`
+    );
+    err.runtimeTerminated = true;
+    throw err;
+  }
+
+  if (requestContext.requestedSessionId && runtime.sessionId && runtime.sessionId !== requestContext.requestedSessionId) {
+    const err = new Error(
+      `Runtime ownership mismatch: expected session ${requestContext.requestedSessionId}, got ${runtime.sessionId}`
+    );
+    err.runtimeTerminated = true;
+    throw err;
+  }
+}
+
 const ANONYMOUS_RUNTIME_MAX_IDLE_MS = 10 * 60 * 1000; // 10 minutes
 
 async function cleanupStaleAnonymousRuntimes() {
   const now = Date.now();
-  for (const runtime of anonymousRuntimes) {
+  const snapshot = [...anonymousRuntimes];
+  for (const runtime of snapshot) {
     if (runtime.closed) {
       anonymousRuntimes.delete(runtime);
       continue;
@@ -580,10 +626,22 @@ async function acquireRuntime(requestContext) {
     runtime = null;
   }
 
-  if (!runtime) {
-    runtime = await createRuntime(requestContext);
+  if (runtime && requestContext.runtimeSessionEpoch && runtime.runtimeSessionEpoch !== requestContext.runtimeSessionEpoch) {
+    console.log('[LIFECYCLE] disposeRuntimeForEpochMismatch existing=' + (runtime.runtimeSessionEpoch || '(none)')
+      + ' requested=' + requestContext.runtimeSessionEpoch);
+    await disposeRuntime(runtime);
+    runtime = null;
   }
 
+  if (!runtime) {
+    runtime = await createRuntime(requestContext);
+  } else {
+    console.log('[LIFECYCLE] reuseRuntime sessionId=' + (runtime.sessionId || '(new)')
+      + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
+      + ' signature=' + runtime.runtimeSignature);
+  }
+
+  assertRuntimeOwnership(runtime, requestContext);
   await applyDynamicControls(runtime, requestContext);
   runtime.lastUsedAt = Date.now();
   return runtime;
@@ -699,6 +757,8 @@ async function executeTurn(runtime, requestContext, turnMeta) {
   }
 
   activeTurnRuntime = runtime;
+  console.log('[LIFECYCLE] executeTurn sessionId=' + (requestContext.requestedSessionId || runtime.sessionId || '(new)')
+    + ' epoch=' + (requestContext.runtimeSessionEpoch || runtime.runtimeSessionEpoch || '(none)'));
 
   const turnState = {
     streamingEnabled: requestContext.streamingEnabled,
@@ -858,7 +918,32 @@ export async function sendMessageWithAttachmentsPersistent(params = {}) {
 export async function preconnectPersistent(params = {}) {
   const safeParams = params || {};
   const requestContext = await buildRequestContext(safeParams, false);
+  console.log('[LIFECYCLE] preconnectPersistent epoch=' + (requestContext.runtimeSessionEpoch || '(none)'));
   await acquireRuntime(requestContext);
+}
+
+export async function resetRuntimePersistent(params = {}) {
+  const runtimeSessionEpoch = typeof params === 'string'
+    ? params
+    : (params?.runtimeSessionEpoch || null);
+
+  console.log('[LIFECYCLE] resetRuntimePersistent targetEpoch=' + (runtimeSessionEpoch || '(all-runtimes)'));
+
+  const runtimes = new Set([
+    ...anonymousRuntimes,
+    ...anonymousRuntimesBySignature.values(),
+    ...runtimesBySessionId.values(),
+    activeTurnRuntime
+  ].filter(Boolean));
+
+  for (const runtime of runtimes) {
+    if (!runtimeSessionEpoch || runtime.runtimeSessionEpoch === runtimeSessionEpoch) {
+      await disposeRuntime(runtime);
+      if (activeTurnRuntime === runtime) {
+        activeTurnRuntime = null;
+      }
+    }
+  }
 }
 
 export async function abortCurrentTurn() {
@@ -867,6 +952,7 @@ export async function abortCurrentTurn() {
   // a non-null runtime, subsequent callers see null and exit early.
   const runtime = activeTurnRuntime;
   if (!runtime) return;
+  console.log('[LIFECYCLE] abortCurrentTurn epoch=' + (runtime.runtimeSessionEpoch || '(none)'));
   activeTurnRuntime = null;
 
   try {
@@ -892,3 +978,35 @@ export async function shutdownPersistentRuntimes() {
   runtimesBySessionId.clear();
   cachedQueryFn = null;
 }
+
+export const __testing = {
+  async resetState() {
+    await shutdownPersistentRuntimes();
+    activeTurnRuntime = null;
+  },
+  setQueryFn(queryFn) {
+    cachedQueryFn = queryFn;
+  },
+  async buildRequestContext(params = {}, withAttachments = false) {
+    return buildRequestContext(params, withAttachments);
+  },
+  async acquireRuntime(requestContext) {
+    return acquireRuntime(requestContext);
+  },
+  async resetRuntimePersistent(params = {}) {
+    return resetRuntimePersistent(params);
+  },
+  setActiveTurnRuntime(runtime) {
+    activeTurnRuntime = runtime;
+  },
+  getRuntimeForSession(sessionId) {
+    return runtimesBySessionId.get(sessionId) || null;
+  },
+  getSnapshot() {
+    return {
+      anonymousRuntimeCount: anonymousRuntimes.size,
+      sessionRuntimeCount: runtimesBySessionId.size,
+      activeTurnEpoch: activeTurnRuntime?.runtimeSessionEpoch || null
+    };
+  }
+};

--- a/ai-bridge/services/claude/persistent-query-service.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.test.mjs
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing } from './persistent-query-service.js';
+
+function createQueryFactory() {
+  const runtimes = [];
+  return {
+    runtimes,
+    queryFn({ prompt, options }) {
+      const runtime = {
+        prompt,
+        options,
+        closed: false,
+        setPermissionMode: async () => {},
+        setModel: async () => {},
+        setMaxThinkingTokens: async () => {},
+        close() {
+          this.closed = true;
+        },
+        async next() {
+          return { done: true, value: undefined };
+        }
+      };
+      runtimes.push(runtime);
+      return runtime;
+    }
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test.after(async () => {
+  await __testing.resetState();
+});
+
+test('anonymous runtime is isolated by runtimeSessionEpoch', async () => {
+  const factory = createQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const firstContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-1',
+    cwd: process.cwd(),
+    message: 'hello'
+  }, false);
+
+  const runtime1 = await __testing.acquireRuntime(firstContext);
+  const runtime1Again = await __testing.acquireRuntime(firstContext);
+  assert.equal(runtime1, runtime1Again);
+  assert.equal(factory.runtimes.length, 1);
+
+  const secondContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-2',
+    cwd: process.cwd(),
+    message: 'hello again'
+  }, false);
+
+  const runtime2 = await __testing.acquireRuntime(secondContext);
+  assert.notEqual(runtime1, runtime2);
+  assert.equal(factory.runtimes.length, 2);
+});
+
+test('same-tab new-session isolation matches fresh runtime isolation expectations', async () => {
+  const factory = createQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const firstContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-a',
+    cwd: process.cwd(),
+    message: 'first turn'
+  }, false);
+  const runtimeA = await __testing.acquireRuntime(firstContext);
+
+  await __testing.resetRuntimePersistent({ runtimeSessionEpoch: 'epoch-a' });
+
+  const secondContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-b',
+    cwd: process.cwd(),
+    message: 'new session turn'
+  }, false);
+  const runtimeB = await __testing.acquireRuntime(secondContext);
+
+  assert.notEqual(runtimeA, runtimeB);
+  assert.equal(factory.runtimes.length, 2);
+  assert.equal(__testing.getSnapshot().anonymousRuntimeCount, 1);
+});
+
+test('resetRuntimePersistent disposes active turn runtime for interrupted old epoch before next first send', async () => {
+  const factory = createQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const oldContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-old',
+    cwd: process.cwd(),
+    message: 'streaming turn'
+  }, false);
+  const oldRuntime = await __testing.acquireRuntime(oldContext);
+  __testing.setActiveTurnRuntime(oldRuntime);
+
+  await __testing.resetRuntimePersistent({ runtimeSessionEpoch: 'epoch-old' });
+
+  const nextContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-new',
+    cwd: process.cwd(),
+    message: 'first send after interrupt'
+  }, false);
+  const nextRuntime = await __testing.acquireRuntime(nextContext);
+
+  assert.equal(oldRuntime.closed, true);
+  assert.notEqual(oldRuntime, nextRuntime);
+  assert.equal(__testing.getSnapshot().activeTurnEpoch, null);
+});
+
+test('restore-history continuation keeps runtime bound to restored session after reset of prior epoch', async () => {
+  const factory = createQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const oldAnonymousContext = await __testing.buildRequestContext({
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-stale',
+    cwd: process.cwd(),
+    message: 'stale anonymous'
+  }, false);
+  await __testing.acquireRuntime(oldAnonymousContext);
+  await __testing.resetRuntimePersistent({ runtimeSessionEpoch: 'epoch-stale' });
+
+  const restoredContext = await __testing.buildRequestContext({
+    sessionId: 'hist-restore',
+    runtimeSessionEpoch: 'epoch-restore',
+    cwd: process.cwd(),
+    message: 'restored continuation'
+  }, false);
+  const restoredRuntime = await __testing.acquireRuntime(restoredContext);
+  const restoredRuntimeAgain = await __testing.acquireRuntime(restoredContext);
+
+  assert.equal(restoredRuntime, restoredRuntimeAgain);
+  assert.equal(__testing.getRuntimeForSession('hist-restore'), restoredRuntime);
+});

--- a/src/main/java/com/github/claudecodegui/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSession.java
@@ -966,12 +966,16 @@ public class ClaudeSession {
             LOG.warn("[Streaming] Failed to read streaming config: " + e.getMessage());
         }
 
-        final String previousSessionId = state.getSessionId();
+        final String runtimeSessionEpoch = state.getRuntimeSessionEpoch();
+        LOG.info("[Lifecycle] sendToClaude sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
+                + ", epoch=" + runtimeSessionEpoch
+                + ", cwd=" + state.getCwd());
 
         return claudeSDKBridge.sendMessage(
                         channelId,
                         input,
                         state.getSessionId(),
+                        runtimeSessionEpoch,
                         state.getCwd(),
                         attachments,
                         effectivePermissionMode,
@@ -979,6 +983,7 @@ public class ClaudeSession {
                         openedFilesJson,
                         agentPrompt,
                         streaming,
+                        false,
                         handler
                 ).thenApply(result -> null)
                 .thenCompose(v -> {
@@ -992,16 +997,6 @@ public class ClaudeSession {
                         }
                         updateUserMessageUuids();
                     });
-                }).whenComplete((unused, throwable) -> {
-                    if (throwable == null
-                            && (previousSessionId == null || previousSessionId.isEmpty())
-                            && state.getSessionId() != null && !state.getSessionId().isEmpty()) {
-                        // Refill anonymous warm runtime after first turn captures a session ID,
-                        // so the next new chat can also hit a pre-warmed path.
-                        // NOTE: Idle anonymous runtimes are cleaned up by persistent-query-service's
-                        // cleanupStaleAnonymousRuntimes() (ANONYMOUS_RUNTIME_MAX_IDLE_MS = 10min).
-                        claudeSDKBridge.prewarmDaemonAsync(state.getCwd());
-                    }
                 });
     }
 
@@ -1420,6 +1415,22 @@ public class ClaudeSession {
      */
     public String getProvider() {
         return state.getProvider();
+    }
+
+    /**
+     * Get the current runtime session epoch.
+     */
+    public String getRuntimeSessionEpoch() {
+        return state.getRuntimeSessionEpoch();
+    }
+
+    /**
+     * Rotate the runtime session epoch.
+     */
+    public String rotateRuntimeSessionEpoch() {
+        String epoch = state.rotateRuntimeSessionEpoch();
+        LOG.info("[Lifecycle] Rotated runtime session epoch to: " + epoch);
+        return epoch;
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -119,10 +119,14 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         }
     }
 
+    public void prewarmDaemonAsync(String cwd) {
+        prewarmDaemonAsync(cwd, null);
+    }
+
     /**
      * Prewarm daemon asynchronously to reduce first-message latency.
      */
-    public void prewarmDaemonAsync(String cwd) {
+    public void prewarmDaemonAsync(String cwd, String runtimeSessionEpoch) {
         // Cancel any previous prewarm in progress
         CompletableFuture<?> prev = prewarmFuture;
         if (prev != null && !prev.isDone()) {
@@ -135,6 +139,8 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                     JsonObject preconnectParams = new JsonObject();
                     preconnectParams.addProperty("cwd", cwd != null ? cwd : "");
                     preconnectParams.addProperty("sessionId", "");
+                    preconnectParams.addProperty("runtimeSessionEpoch",
+                            runtimeSessionEpoch != null ? runtimeSessionEpoch : "");
                     preconnectParams.addProperty("permissionMode", "");
                     preconnectParams.addProperty("model", "");
                     preconnectParams.addProperty("streaming", true);
@@ -177,7 +183,8 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                     );
 
                     preconnectFuture.get(45, TimeUnit.SECONDS);
-                    LOG.info("[ClaudeSDKBridge] Daemon prewarm completed");
+                    LOG.info("[ClaudeSDKBridge] Daemon prewarm completed for epoch="
+                            + (runtimeSessionEpoch != null ? runtimeSessionEpoch : "(none)"));
                 } else {
                     LOG.info("[ClaudeSDKBridge] Daemon prewarm skipped (daemon unavailable)");
                 }
@@ -185,6 +192,53 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                 LOG.debug("[ClaudeSDKBridge] Daemon prewarm failed: " + e.getMessage());
             }
         });
+    }
+
+    public void resetPersistentRuntime(String runtimeSessionEpoch) {
+        DaemonBridge db = daemonBridge;
+        if (db == null || !db.isAlive()) {
+            LOG.info("[ClaudeSDKBridge] Skip runtime reset; daemon unavailable for epoch="
+                    + (runtimeSessionEpoch != null ? runtimeSessionEpoch : "(none)"));
+            return;
+        }
+
+        try {
+            JsonObject params = new JsonObject();
+            params.addProperty("runtimeSessionEpoch", runtimeSessionEpoch != null ? runtimeSessionEpoch : "");
+            CompletableFuture<Boolean> resetFuture = db.sendCommand(
+                    "claude.resetRuntime",
+                    params,
+                    new DaemonBridge.DaemonOutputCallback() {
+                        @Override
+                        public void onLine(String line) {
+                            if (line != null && !line.isBlank()) {
+                                LOG.info("[ClaudeSDKBridge] Runtime reset line: " + line);
+                            }
+                        }
+
+                        @Override
+                        public void onStderr(String text) {
+                            if (text != null && !text.isBlank()) {
+                                LOG.debug("[ClaudeSDKBridge] Runtime reset stderr: " + text);
+                            }
+                        }
+
+                        @Override
+                        public void onError(String error) {
+                            LOG.warn("[ClaudeSDKBridge] Runtime reset error: " + error);
+                        }
+
+                        @Override
+                        public void onComplete(boolean success) {
+                            LOG.info("[ClaudeSDKBridge] Runtime reset completed: success=" + success
+                                    + ", epoch=" + (runtimeSessionEpoch != null ? runtimeSessionEpoch : "(none)"));
+                        }
+                    }
+            );
+            resetFuture.get(15, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.warn("[ClaudeSDKBridge] Runtime reset failed: " + e.getMessage());
+        }
     }
 
     @Override
@@ -666,7 +720,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             List<ClaudeSession.Attachment> attachments,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, null, null, null, null, null, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, null, null, null, null, null, false, callback);
     }
 
     /**
@@ -684,7 +738,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             String agentPrompt,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, callback);
     }
 
     /**
@@ -703,7 +757,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean streaming,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, callback);
     }
 
     /**
@@ -723,10 +777,32 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean disableThinking,
             MessageCallback callback
     ) {
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode,
+                model, openedFiles, agentPrompt, streaming, disableThinking, callback);
+    }
+
+    /**
+     * Send message in existing channel (streaming response, with all options including streaming flag and disableThinking).
+     */
+    public CompletableFuture<SDKResult> sendMessage(
+            String channelId,
+            String message,
+            String sessionId,
+            String runtimeSessionEpoch,
+            String cwd,
+            List<ClaudeSession.Attachment> attachments,
+            String permissionMode,
+            String model,
+            JsonObject openedFiles,
+            String agentPrompt,
+            Boolean streaming,
+            Boolean disableThinking,
+            MessageCallback callback
+    ) {
         // Try daemon mode first (avoids per-request Node.js process spawning)
         DaemonBridge db = getDaemonBridge();
         if (db != null) {
-            return sendMessageViaDaemon(db, channelId, message, sessionId, cwd,
+            return sendMessageViaDaemon(db, channelId, message, sessionId, runtimeSessionEpoch, cwd,
                     attachments, permissionMode, model, openedFiles, agentPrompt,
                     streaming, disableThinking, callback);
         }
@@ -783,6 +859,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                 JsonObject stdinInput = new JsonObject();
                 stdinInput.addProperty("message", message);
                 stdinInput.addProperty("sessionId", sessionId != null ? sessionId : "");
+                stdinInput.addProperty("runtimeSessionEpoch", runtimeSessionEpoch != null ? runtimeSessionEpoch : "");
                 stdinInput.addProperty("cwd", cwd != null ? cwd : "");
                 stdinInput.addProperty("permissionMode", permissionMode != null ? permissionMode : "");
                 stdinInput.addProperty("model", model != null ? model : "");
@@ -1577,6 +1654,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             String channelId,
             String message,
             String sessionId,
+            String runtimeSessionEpoch,
             String cwd,
             List<ClaudeSession.Attachment> attachments,
             String permissionMode,
@@ -1596,7 +1674,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             try {
                 // Build params (same fields as stdinInput in process mode)
                 JsonObject params = buildSendParams(
-                        message, sessionId, cwd, permissionMode, model,
+                        message, sessionId, runtimeSessionEpoch, cwd, permissionMode, model,
                         attachments, openedFiles, agentPrompt, streaming, disableThinking);
 
                 boolean hasAttachments = attachments != null && !attachments.isEmpty()
@@ -1739,7 +1817,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
      * Build the params JSON for a send command (shared between daemon and process modes).
      */
     private JsonObject buildSendParams(
-            String message, String sessionId, String cwd,
+            String message, String sessionId, String runtimeSessionEpoch, String cwd,
             String permissionMode, String model,
             List<ClaudeSession.Attachment> attachments,
             JsonObject openedFiles, String agentPrompt,
@@ -1748,6 +1826,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         JsonObject params = new JsonObject();
         params.addProperty("message", message);
         params.addProperty("sessionId", sessionId != null ? sessionId : "");
+        params.addProperty("runtimeSessionEpoch", runtimeSessionEpoch != null ? runtimeSessionEpoch : "");
         params.addProperty("cwd", cwd != null ? cwd : "");
         params.addProperty("permissionMode", permissionMode != null ? permissionMode : "");
         params.addProperty("model", model != null ? model : "");

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -94,6 +94,10 @@ public class SessionLifecycleManager {
                                                           : CompletableFuture.completedFuture(null);
 
         interruptFuture.thenRun(() -> {
+            if (oldSession != null) {
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
+                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldSession.getRuntimeSessionEpoch());
+            }
             LOG.info("Old session interrupted, creating new session");
 
             ApplicationManager.getApplication().invokeLater(() -> {
@@ -117,8 +121,9 @@ public class SessionLifecycleManager {
 
             String workingDirectory = determineWorkingDirectory();
             newSession.setSessionInfo(null, workingDirectory);
-            LOG.info("New session created successfully, working directory: " + workingDirectory);
-            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory);
+            LOG.info("New session created successfully, working directory: " + workingDirectory
+                    + ", epoch=" + newSession.getRuntimeSessionEpoch());
+            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
 
             // Push slash commands for the new session
             fetchSlashCommandsOnStartup();
@@ -169,27 +174,47 @@ public class SessionLifecycleManager {
         host.callJavaScript("clearMessages");
         host.clearPendingPermissionRequests();
 
-        ClaudeSession newSession = new ClaudeSession(
-                host.getProject(), host.getClaudeSDKBridge(), host.getCodexSDKBridge());
-        newSession.setPermissionMode(previousPermissionMode);
-        newSession.setProvider(previousProvider);
-        newSession.setModel(previousModel);
-        LOG.info("Restored session state to loaded session: mode=" + previousPermissionMode
-                         + ", provider=" + previousProvider + ", model=" + previousModel);
+        CompletableFuture<Void> interruptFuture = oldSession != null
+                ? oldSession.interrupt()
+                : CompletableFuture.completedFuture(null);
 
-        host.setSession(newSession);
-        host.getHandlerContext().setSession(newSession);
-        host.setupSessionCallbacks();
+        interruptFuture.thenRun(() -> {
+            if (oldSession != null) {
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
+                LOG.info("[Lifecycle] Requested daemon runtime reset before history load for old epoch="
+                        + oldSession.getRuntimeSessionEpoch());
+            }
 
-        String workingDir = (projectPath != null && new File(projectPath).exists())
+            ClaudeSession newSession = new ClaudeSession(
+                    host.getProject(), host.getClaudeSDKBridge(), host.getCodexSDKBridge());
+            newSession.setPermissionMode(previousPermissionMode);
+            newSession.setProvider(previousProvider);
+            newSession.setModel(previousModel);
+            LOG.info("Restored session state to loaded session: mode=" + previousPermissionMode
+                             + ", provider=" + previousProvider + ", model=" + previousModel);
+
+            host.setSession(newSession);
+            host.getHandlerContext().setSession(newSession);
+            host.setupSessionCallbacks();
+
+            String workingDir = (projectPath != null && new File(projectPath).exists())
                                     ? projectPath : determineWorkingDirectory();
-        newSession.setSessionInfo(sessionId, workingDir);
+            newSession.setSessionInfo(sessionId, workingDir);
 
-        newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
-            host.callJavaScript("historyLoadComplete");
-        })).exceptionally(ex -> {
+            newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
+                host.callJavaScript("historyLoadComplete");
+            })).exceptionally(ex -> {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    // Release transition guard so the frontend is not permanently stuck
+                    host.callJavaScript("historyLoadComplete");
+                    host.callJavaScript("addErrorMessage",
+                            JsUtils.escapeJs("Failed to load session: " + ex.getMessage()));
+                });
+                return null;
+            });
+        }).exceptionally(ex -> {
+            LOG.error("Failed to load history session: " + ex.getMessage(), ex);
             ApplicationManager.getApplication().invokeLater(() -> {
-                // Release transition guard so the frontend is not permanently stuck
                 host.callJavaScript("historyLoadComplete");
                 host.callJavaScript("addErrorMessage",
                         JsUtils.escapeJs("Failed to load session: " + ex.getMessage()));

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Session state management.
@@ -38,6 +39,7 @@ public class SessionState {
     // Session identifiers
     private String sessionId;
     private String channelId;
+    private volatile String runtimeSessionEpoch = UUID.randomUUID().toString();
 
     // Session state — accessed only on EDT / single handler thread, no volatile needed.
     private boolean busy = false;
@@ -125,6 +127,10 @@ public class SessionState {
         return reasoningEffort;
     }
 
+    public String getRuntimeSessionEpoch() {
+        return runtimeSessionEpoch;
+    }
+
     public List<String> getSlashCommands() {
         return new ArrayList<>(slashCommands);
     }
@@ -186,6 +192,20 @@ public class SessionState {
 
     public void setReasoningEffort(String reasoningEffort) {
         this.reasoningEffort = reasoningEffort;
+    }
+
+    public void setRuntimeSessionEpoch(String runtimeSessionEpoch) {
+        if (runtimeSessionEpoch == null || runtimeSessionEpoch.trim().isEmpty()) {
+            this.runtimeSessionEpoch = UUID.randomUUID().toString();
+            return;
+        }
+        this.runtimeSessionEpoch = runtimeSessionEpoch;
+    }
+
+    public String rotateRuntimeSessionEpoch() {
+        String newEpoch = UUID.randomUUID().toString();
+        this.runtimeSessionEpoch = newEpoch;
+        return newEpoch;
     }
 
     public void setSlashCommands(List<String> slashCommands) {

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -177,7 +177,11 @@ public class WebviewInitializer {
         }
 
         // Prewarm daemon in background so first user message starts faster.
-        claudeSDKBridge.prewarmDaemonAsync(host.getProject().getBasePath());
+        // Bind the warm runtime to the current logical session epoch so future new-session
+        // transitions cannot accidentally reuse stale anonymous runtime ownership.
+        claudeSDKBridge.prewarmDaemonAsync(host.getProject().getBasePath(), host.getHandlerContext().getSession() != null
+                ? host.getHandlerContext().getSession().getRuntimeSessionEpoch()
+                : null);
 
         // Check JCEF support before creating browser
         if (!JBCefBrowserFactory.isJcefSupported()) {

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -498,6 +498,14 @@ interface Window {
   __sessionTransitioning?: boolean;
 
   /**
+   * Session transition token (debug/logging only).
+   * Regenerated for each logical transition so callbacks can identify the active transition
+   * generation in logs. NOT used for guard logic — the boolean __sessionTransitioning flag
+   * is the actual guard.
+   */
+  __sessionTransitionToken?: string | null;
+
+  /**
    * Rewind result callback - returns the result of a rewind operation
    */
   onRewindResult?: (json: string) => void;

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -24,6 +24,7 @@ describe('useSessionManagement', () => {
 
   beforeEach(() => {
     (window as any).__sessionTransitioning = false;
+    (window as any).__sessionTransitionToken = null;
     window.sendToJava = vi.fn();
   });
 
@@ -46,6 +47,7 @@ describe('useSessionManagement', () => {
     });
 
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setStatus).toHaveBeenCalledWith('');
     expect(mocks.setLoading).toHaveBeenCalledWith(false);
@@ -95,6 +97,7 @@ describe('useSessionManagement', () => {
     expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'interrupt_session:');
     expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'load_session:history-1');
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith('history-1');
@@ -123,6 +126,7 @@ describe('useSessionManagement', () => {
     expect(window.sendToJava).toHaveBeenCalledWith('interrupt_session:');
     expect(window.sendToJava).toHaveBeenCalledWith('create_new_session:');
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith(null);
@@ -151,6 +155,7 @@ describe('useSessionManagement', () => {
     // Should show confirm dialog, NOT immediately transition
     expect(result.current.showNewSessionConfirm).toBe(true);
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
     expect(mocks.setMessages).not.toHaveBeenCalled();
   });
 
@@ -179,6 +184,7 @@ describe('useSessionManagement', () => {
     });
 
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith(null);
@@ -213,6 +219,7 @@ describe('useSessionManagement', () => {
     expect(window.sendToJava).toHaveBeenCalledWith('interrupt_session:');
     expect(window.sendToJava).toHaveBeenCalledWith('create_new_session:');
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith(null);
@@ -258,6 +265,7 @@ describe('useSessionManagement', () => {
 
     // But should still set transition guard
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith('hist-2');
@@ -319,14 +327,18 @@ describe('useSessionManagement', () => {
   it('historyLoadComplete releases transition guard', () => {
     // Simulate what happens when Java calls historyLoadComplete after successful load
     (window as any).__sessionTransitioning = true;
+    (window as any).__sessionTransitionToken = 'transition-test';
 
     // historyLoadComplete is defined in useWindowCallbacks, but we can test
     // that the guard release mechanism works by direct simulation
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBe('transition-test');
 
     // Simulate historyLoadComplete behavior
     (window as any).__sessionTransitioning = false;
+    (window as any).__sessionTransitionToken = null;
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
   });
 
   it('loadHistorySession sets transition guard that blocks updateMessages', () => {
@@ -364,21 +376,27 @@ describe('useSessionManagement', () => {
 
     // Guard is set, blocking stale updateMessages
     expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBeTruthy();
 
     // Simulate historyLoadComplete (success path releases guard)
     act(() => {
       (window as any).__sessionTransitioning = false;
+      (window as any).__sessionTransitionToken = null;
     });
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
 
     // Simulate failure path: guard must also be released
     act(() => {
       (window as any).__sessionTransitioning = true; // re-arm
+      (window as any).__sessionTransitionToken = 'transition-rearm';
     });
     // Java exceptionally block calls historyLoadComplete before addErrorMessage
     act(() => {
       (window as any).__sessionTransitioning = false;
+      (window as any).__sessionTransitionToken = null;
     });
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
   });
 });

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -7,6 +7,9 @@ type ViewMode = 'chat' | 'history' | 'settings';
 
 type ToastType = 'info' | 'success' | 'warning' | 'error';
 
+const createSessionTransitionToken = () =>
+  `transition-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
 interface UseSessionManagementOptions {
   messages: ClaudeMessage[];
   loading: boolean;
@@ -79,6 +82,7 @@ export function useSessionManagement({
 
   const beginSessionTransition = useCallback((nextSessionId: string | null, nextTitle: string | null) => {
     window.__sessionTransitioning = true;
+    window.__sessionTransitionToken = createSessionTransitionToken();
     // Use the single cleanup entry point exposed by useWindowCallbacks.
     // This clears both React state AND internal streaming refs in one shot.
     if (typeof (window as any).__resetTransientUiState === 'function') {

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -90,6 +90,7 @@ describe('useWindowCallbacks integration', () => {
 
   beforeEach(() => {
     (window as any).__sessionTransitioning = false;
+    (window as any).__sessionTransitionToken = null;
     (window as any).__deniedToolIds = new Set();
     window.sendToJava = vi.fn();
   });
@@ -102,6 +103,7 @@ describe('useWindowCallbacks integration', () => {
 
     // Simulate: beginSessionTransition sets guard
     (window as any).__sessionTransitioning = true;
+    (window as any).__sessionTransitionToken = 'transition-1';
 
     // Simulate: Java calls historyLoadComplete on success
     act(() => {
@@ -109,6 +111,7 @@ describe('useWindowCallbacks integration', () => {
     });
 
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
   });
 
   // ===== setSessionId releases transition guard =====
@@ -118,12 +121,14 @@ describe('useWindowCallbacks integration', () => {
     renderHook(() => useWindowCallbacks(opts));
 
     (window as any).__sessionTransitioning = true;
+    (window as any).__sessionTransitionToken = 'transition-2';
 
     act(() => {
       (window as any).setSessionId('new-session-123');
     });
 
     expect((window as any).__sessionTransitioning).toBe(false);
+    expect((window as any).__sessionTransitionToken).toBeNull();
     expect(opts.setCurrentSessionId).toHaveBeenCalledWith('new-session-123');
   });
 
@@ -164,6 +169,22 @@ describe('useWindowCallbacks integration', () => {
 
     // setMessages SHOULD be called
     expect(opts.setMessages).toHaveBeenCalled();
+  });
+
+  it('updateStatus does not release an active transition token', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    (window as any).__sessionTransitioning = true;
+    (window as any).__sessionTransitionToken = 'transition-status';
+
+    act(() => {
+      (window as any).updateStatus('warming runtime');
+    });
+
+    expect((window as any).__sessionTransitioning).toBe(true);
+    expect((window as any).__sessionTransitionToken).toBe('transition-status');
+    expect(opts.setStatus).toHaveBeenCalledWith('warming runtime');
   });
 
   // ===== addErrorMessage only shows toast (no status) =====

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -209,6 +209,13 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     }
   };
 
+  const releaseSessionTransition = () => {
+    if (window.__sessionTransitioning) {
+      window.__sessionTransitioning = false;
+    }
+    window.__sessionTransitionToken = null;
+  };
+
   // Expose as single entry point for session transition cleanup.
   // beginSessionTransition (useSessionManagement) calls this to synchronously
   // clear both React state AND internal refs in one shot.
@@ -476,10 +483,9 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     };
 
     window.updateStatus = (text) => {
-      // Backend sends updateStatus after creating a new session; clear the message update suppression flag
-      if (window.__sessionTransitioning) {
-        window.__sessionTransitioning = false;
-      }
+      // Do not release the transition guard from generic status updates.
+      // Only explicit session-bound callbacks such as historyLoadComplete/setSessionId
+      // are allowed to finish the active transition generation.
       setStatus(text);
       if (suppressNextStatusToastRef.current) {
         suppressNextStatusToastRef.current = false;
@@ -534,9 +540,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     // History load complete callback — triggers Markdown re-rendering
     // to fix the issue where Markdown doesn't render on first history load.
     window.historyLoadComplete = () => {
-      if (window.__sessionTransitioning) {
-        window.__sessionTransitioning = false;
-      }
+      releaseSessionTransition();
       // Trigger a component re-render by updating the last message reference (avoids O(n) shallow copy)
       setMessages((prev) => {
         if (prev.length === 0) return prev;
@@ -565,6 +569,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
 
     // ========== Streaming Callbacks ==========
     window.onStreamStart = () => {
+      if (window.__sessionTransitioning) return;
       streamingContentRef.current = '';
       isStreamingRef.current = true;
       useBackendStreamingRenderRef.current = false;
@@ -599,6 +604,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     };
 
     window.onContentDelta = (delta: string) => {
+      if (window.__sessionTransitioning) return;
       if (!isStreamingRef.current) return;
       streamingContentRef.current += delta;
       activeThinkingSegmentIndexRef.current = -1;
@@ -657,6 +663,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     };
 
     window.onThinkingDelta = (delta: string) => {
+      if (window.__sessionTransitioning) return;
       if (!isStreamingRef.current) return;
       activeTextSegmentIndexRef.current = -1;
 
@@ -714,6 +721,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     };
 
     window.onStreamEnd = () => {
+      if (window.__sessionTransitioning) return;
       // Notify backend about stream completion for tab status indicator
       sendBridgeEvent('tab_status_changed', JSON.stringify({ status: 'completed' }));
 
@@ -839,9 +847,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
     // ========== Session Callbacks ==========
     window.setSessionId = (sessionId: string) => {
       const oldId = currentSessionIdRef.current;
-      if (window.__sessionTransitioning) {
-        window.__sessionTransitioning = false;
-      }
+      releaseSessionTransition();
       setCurrentSessionId(sessionId);
 
       // B-011 + B-014: Persist custom title under the real SDK session ID.


### PR DESCRIPTION
Introduce runtimeSessionEpoch (a per-session UUID) across all three layers to ensure strict runtime ownership during session transitions:

- Java: SessionState generates epoch on construction; ClaudeSDKBridge threads it through sendMessage/prewarm/resetRuntime; SessionLifecycleManager resets old epoch runtimes before creating new sessions or loading history
- Node.js: persistent-query-service uses epoch in runtime signatures, adds assertRuntimeOwnership guard, resetRuntimePersistent for epoch-scoped disposal, and snapshot-based iteration to avoid concurrent modification
- Frontend: streaming callbacks (onStreamStart/onContentDelta/onThinkingDelta/ onStreamEnd) early-return during session transitions; updateStatus no longer releases the transition guard; only historyLoadComplete/setSessionId do

Also includes review-driven fixes: volatile read-then-write race in rotateRuntimeSessionEpoch, assertRuntimeOwnership ordering before applyDynamicControls, anonymousRuntimesBySignature included in reset snapshot, and cleanupStaleAnonymousRuntimes snapshot before iteration.