### PR TITLE
feat: add apiKeyHelper support for enterprise authentication

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -7,7 +7,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { platform } from 'os';
 import { execSync } from 'child_process';
-import { getClaudeDir } from '../utils/path-utils.js';
+import { getClaudeDir, getManagedSettingsPath } from '../utils/path-utils.js';
 
 // Conditional debug logging: set CLAUDE_DEBUG=1 to enable verbose diagnostics
 const DEBUG = process.env.CLAUDE_DEBUG === '1' || process.env.CLAUDE_DEBUG === 'true';
@@ -29,6 +29,26 @@ function injectProxyEnvVars(settings) {
       process.env[varName] = settings.env[varName];
       debugLog(`[DEBUG] Set ${varName} from settings.json`);
     }
+  }
+}
+
+/**
+ * Load managed settings from the platform-specific managed-settings.json.
+ * These are typically configured by enterprise IT administrators.
+ * @returns {Object|null} Parsed managed settings or null if not found/invalid
+ */
+export function loadManagedSettings() {
+  try {
+    const managedPath = getManagedSettingsPath();
+    if (!existsSync(managedPath)) {
+      return null;
+    }
+    const settings = JSON.parse(readFileSync(managedPath, 'utf8'));
+    debugLog('[DEBUG] Loaded managed settings from:', managedPath);
+    return settings;
+  } catch (error) {
+    debugLog('[DEBUG] Failed to load managed settings:', error.message);
+    return null;
   }
 }
 
@@ -219,11 +239,36 @@ export function setupApiKey() {
       debugLog('[DEBUG] Auth type:', authType);
       return { apiKey: null, baseUrl, authType, apiKeySource, baseUrlSource };
     } else {
-      // Neither API Key nor CLI session found
+      // Check for apiKeyHelper in managed settings or user settings before giving up.
+      // The SDK handles apiKeyHelper execution natively, so we just need to not throw.
+      const managedSettings = loadManagedSettings();
+      const hasApiKeyHelper = managedSettings?.apiKeyHelper || settings?.apiKeyHelper;
+
+      if (hasApiKeyHelper) {
+        debugLog('[INFO] Using apiKeyHelper authentication (SDK will handle execution)');
+        authType = 'api_key_helper';
+        apiKeySource = managedSettings?.apiKeyHelper
+          ? 'managed-settings.json (apiKeyHelper)'
+          : 'settings.json (apiKeyHelper)';
+
+        // Clear all API Key environment variables so the SDK uses apiKeyHelper
+        delete process.env.ANTHROPIC_API_KEY;
+        delete process.env.ANTHROPIC_AUTH_TOKEN;
+
+        if (baseUrl) {
+          process.env.ANTHROPIC_BASE_URL = baseUrl;
+        }
+
+        debugLog('[DEBUG] Auth type:', authType);
+        return { apiKey: null, baseUrl, authType, apiKeySource, baseUrlSource };
+      }
+
+      // Neither API Key, CLI session, nor apiKeyHelper found
       console.error('[ERROR] API Key not configured and no CLI session found.');
       console.error('[ERROR] Please either:');
       console.error('[ERROR]   1. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN in ~/.claude/settings.json');
       console.error('[ERROR]   2. Run "claude login" to authenticate via CLI');
+      console.error('[ERROR]   3. Configure apiKeyHelper in managed-settings.json or settings.json');
       throw new Error('API Key not configured and no CLI session found');
     }
   }

--- a/ai-bridge/utils/path-utils.js
+++ b/ai-bridge/utils/path-utils.js
@@ -5,7 +5,7 @@
 
 import fs from 'fs';
 import { resolve, join } from 'path';
-import { homedir, tmpdir } from 'os';
+import { homedir, tmpdir, platform } from 'os';
 
 // Cache the resolved home directory path to avoid redundant computation
 let cachedRealHomeDir = null;
@@ -50,6 +50,25 @@ export function getCodemossDir() {
  */
 export function getClaudeDir() {
   return join(getRealHomeDir(), '.claude');
+}
+
+/**
+ * Get the platform-specific path for Claude Code managed settings.
+ * Managed settings are typically configured by enterprise IT administrators.
+ * - macOS: /Library/Application Support/ClaudeCode/managed-settings.json
+ * - Linux: /etc/claude-code/managed-settings.json
+ * - Windows: C:\Program Files\ClaudeCode\managed-settings.json
+ * @returns {string} The managed-settings.json file path
+ */
+export function getManagedSettingsPath() {
+  const currentPlatform = platform();
+  if (currentPlatform === 'win32') {
+    return join('C:', 'Program Files', 'ClaudeCode', 'managed-settings.json');
+  } else if (currentPlatform === 'darwin') {
+    return join('/Library', 'Application Support', 'ClaudeCode', 'managed-settings.json');
+  } else {
+    return join('/etc', 'claude-code', 'managed-settings.json');
+  }
 }
 
 /**

--- a/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
@@ -89,6 +89,28 @@ public class ClaudeSettingsManager {
     }
 
     /**
+     * Read managed settings from the platform-specific managed-settings.json.
+     * Returns null if the file does not exist or cannot be parsed.
+     */
+    public JsonObject readManagedSettings() {
+        try {
+            Path managedPath = pathManager.getManagedSettingsPath();
+            File managedFile = managedPath.toFile();
+
+            if (!managedFile.exists()) {
+                return null;
+            }
+
+            try (FileReader reader = new FileReader(managedFile)) {
+                return JsonParser.parseReader(reader).getAsJsonObject();
+            }
+        } catch (Exception e) {
+            LOG.debug("[ClaudeSettingsManager] Failed to read managed-settings.json: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Write Claude Settings.
      */
     public void writeClaudeSettings(JsonObject settings) throws IOException {
@@ -197,12 +219,34 @@ public class ClaudeSettingsManager {
 
             String baseUrl = env.has("ANTHROPIC_BASE_URL") ? env.get("ANTHROPIC_BASE_URL").getAsString() : "";
 
+            // If no API key found, check for apiKeyHelper in user settings or managed settings
+            if (apiKey.isEmpty() && "none".equals(authType)) {
+                if (claudeSettings.has("apiKeyHelper") && !claudeSettings.get("apiKeyHelper").isJsonNull()) {
+                    authType = "api_key_helper";
+                } else {
+                    JsonObject managedSettings = readManagedSettings();
+                    if (managedSettings != null && managedSettings.has("apiKeyHelper") && !managedSettings.get("apiKeyHelper").isJsonNull()) {
+                        authType = "api_key_helper";
+                    }
+                }
+            }
+
             result.addProperty("apiKey", apiKey);
             result.addProperty("authType", authType);  // Add auth type identifier
             result.addProperty("baseUrl", baseUrl);
         } else {
+            // No env object — still check for apiKeyHelper
+            String authType = "none";
+            if (claudeSettings.has("apiKeyHelper") && !claudeSettings.get("apiKeyHelper").isJsonNull()) {
+                authType = "api_key_helper";
+            } else {
+                JsonObject managedSettings = readManagedSettings();
+                if (managedSettings != null && managedSettings.has("apiKeyHelper") && !managedSettings.get("apiKeyHelper").isJsonNull()) {
+                    authType = "api_key_helper";
+                }
+            }
             result.addProperty("apiKey", "");
-            result.addProperty("authType", "none");
+            result.addProperty("authType", authType);
             result.addProperty("baseUrl", "");
         }
 

--- a/src/main/java/com/github/claudecodegui/settings/ConfigPathManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ConfigPathManager.java
@@ -22,6 +22,7 @@ public class ConfigPathManager {
     private static final String PROMPT_FILE_NAME = "prompt.json";
     private static final String CLAUDE_DIR_NAME = ".claude";
     private static final String CLAUDE_SETTINGS_FILE_NAME = "settings.json";
+    private static final String MANAGED_SETTINGS_FILE_NAME = "managed-settings.json";
 
     /**
      * Get the configuration file path (~/.codemoss/config.json).
@@ -74,6 +75,23 @@ public class ConfigPathManager {
     public Path getClaudeSettingsPath() {
         String homeDir = PlatformUtils.getHomeDirectory();
         return Paths.get(homeDir, CLAUDE_DIR_NAME, CLAUDE_SETTINGS_FILE_NAME);
+    }
+
+    /**
+     * Get the platform-specific managed-settings.json path.
+     * Managed settings are typically configured by enterprise IT administrators.
+     * - macOS: /Library/Application Support/ClaudeCode/managed-settings.json
+     * - Linux: /etc/claude-code/managed-settings.json
+     * - Windows: C:\Program Files\ClaudeCode\managed-settings.json
+     */
+    public Path getManagedSettingsPath() {
+        if (PlatformUtils.isWindows()) {
+            return Paths.get("C:", "Program Files", "ClaudeCode", MANAGED_SETTINGS_FILE_NAME);
+        } else if (PlatformUtils.isMac()) {
+            return Paths.get("/Library", "Application Support", "ClaudeCode", MANAGED_SETTINGS_FILE_NAME);
+        } else {
+            return Paths.get("/etc", "claude-code", MANAGED_SETTINGS_FILE_NAME);
+        }
     }
 
     /**

--- a/webview/src/components/settings/ConfigInfoDisplay/index.tsx
+++ b/webview/src/components/settings/ConfigInfoDisplay/index.tsx
@@ -11,6 +11,7 @@ export interface ClaudeConfig {
   baseUrl: string;
   providerId?: string;
   providerName?: string;
+  authType?: string;
 }
 
 /**
@@ -336,7 +337,7 @@ const ConfigInfoDisplay = ({
     );
   }
 
-  if (!config || (!config.apiKey && !config.baseUrl)) {
+  if (!config || (!config.apiKey && !config.baseUrl && config.authType !== 'api_key_helper')) {
     return (
       <div className={styles.container}>
         <div className={styles.header}>
@@ -444,22 +445,30 @@ const ConfigInfoDisplay = ({
         {/* API Key preview */}
         <div className={styles.field}>
           <span className={`codicon codicon-key ${styles.icon}`} />
-          <code
-            className={`${styles.value} ${styles.clickable}`}
-            onClick={() => handleCopy(apiKey, t('settings.provider.apiKey'))}
-            title={t('config.clickToCopy')}
-          >
-            {getApiKeyPreview()}
-          </code>
-          {apiKey && (
-            <button
-              type="button"
-              className={styles.toggleBtn}
-              onClick={() => setShowApiKey(!showApiKey)}
-              title={showApiKey ? t('settings.provider.hide') : t('settings.provider.show')}
-            >
-              <span className={`codicon ${showApiKey ? 'codicon-eye-closed' : 'codicon-eye'}`} style={{ fontSize: '14px' }} />
-            </button>
+          {config.authType === 'api_key_helper' ? (
+            <code className={styles.value}>
+              {t('settings.provider.apiKeyHelper', 'API Key Helper')}
+            </code>
+          ) : (
+            <>
+              <code
+                className={`${styles.value} ${styles.clickable}`}
+                onClick={() => handleCopy(apiKey, t('settings.provider.apiKey'))}
+                title={t('config.clickToCopy')}
+              >
+                {getApiKeyPreview()}
+              </code>
+              {apiKey && (
+                <button
+                  type="button"
+                  className={styles.toggleBtn}
+                  onClick={() => setShowApiKey(!showApiKey)}
+                  title={showApiKey ? t('settings.provider.hide') : t('settings.provider.show')}
+                >
+                  <span className={`codicon ${showApiKey ? 'codicon-eye-closed' : 'codicon-eye'}`} style={{ fontSize: '14px' }} />
+                </button>
+              )}
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

- Adds support for `apiKeyHelper` — a shell script that generates temporary API keys, commonly used in enterprise environments via `managed-settings.json`
- The plugin previously threw an error when no API key or CLI session was found, blocking the SDK from handling `apiKeyHelper` natively
- Now detects `apiKeyHelper` in both user `settings.json` and platform-specific `managed-settings.json`, passes through to the SDK instead of throwing
- Settings UI displays "API Key Helper" label instead of showing a "no config" warning

## Changes

| File | Change |
|------|--------|
| `ai-bridge/utils/path-utils.js` | Add `getManagedSettingsPath()` with platform-specific paths |
| `ai-bridge/config/api-config.js` | Add `loadManagedSettings()`, modify `setupApiKey()` to detect `apiKeyHelper` |
| `src/.../ConfigPathManager.java` | Add `getManagedSettingsPath()` (macOS/Linux/Windows) |
| `src/.../ClaudeSettingsManager.java` | Add `readManagedSettings()`, detect `apiKeyHelper` in `getCurrentClaudeConfig()` |
| `webview/.../ConfigInfoDisplay/index.tsx` | Handle `api_key_helper` auth type in UI |

## Test plan

- [ ] Configure `apiKeyHelper` in `~/.claude/settings.json` pointing to a script that outputs a valid API key
- [ ] Remove `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` from settings.json env
- [ ] Open the plugin — settings page should show "API Key Helper" instead of "no config"
- [ ] Send a message — should work (SDK handles helper execution and TTL refresh)
- [ ] Verify normal API key and CLI session auth still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)