### PR TITLE
fix(chat): 修复上下文菜单剪切功能并增强文件标签处理

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -900,7 +900,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
               onClose={ctxMenu.close}
               items={[
                 { label: t('contextMenu.copy', 'Copy'), action: () => copySelection(ctxMenu.savedRange, ctxMenu.selectedText), disabled: !ctxMenu.hasSelection },
-                { label: t('contextMenu.cut', 'Cut'), action: () => { if (editableRef.current) { cutSelection(ctxMenu.savedRange, ctxMenu.selectedText, editableRef.current); handleInput(); } }, disabled: !ctxMenu.hasSelection },
+                { label: t('contextMenu.cut', 'Cut'), action: () => { if (editableRef.current) { cutSelection(ctxMenu.savedRange, ctxMenu.selectedText, editableRef.current, ctxMenu.targetFileTag); handleInput(); } }, disabled: !ctxMenu.hasSelection },
                 { label: t('contextMenu.paste', 'Paste'), action: () => { if (editableRef.current) { pasteAtCursor(ctxMenu.savedRange, editableRef.current, handleInput); } } },
                 { separator: true },
                 { label: t('contextMenu.newline', 'Insert Newline'), action: () => { if (editableRef.current) { insertNewline(ctxMenu.savedRange, editableRef.current); handleInput(); } } },

--- a/webview/src/hooks/useContextMenu.ts
+++ b/webview/src/hooks/useContextMenu.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { sendToJava } from '../utils/bridge.js';
 
 interface ContextMenuState {
@@ -6,8 +7,40 @@ interface ContextMenuState {
   x: number;
   y: number;
   hasSelection: boolean;
+  selectionSource: 'none' | 'text' | 'fileTag';
+  targetFileTag: HTMLElement | null;
   savedRange: Range | null;
   selectedText: string;
+}
+
+function placeCursorAfterRemoval(
+  editable: HTMLElement,
+  nextSibling: ChildNode | null,
+  previousSibling: ChildNode | null
+): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  const range = document.createRange();
+  if (nextSibling?.isConnected) {
+    if (nextSibling.nodeType === Node.TEXT_NODE) {
+      range.setStart(nextSibling, 0);
+    } else {
+      range.setStartBefore(nextSibling);
+    }
+  } else if (previousSibling?.isConnected) {
+    if (previousSibling.nodeType === Node.TEXT_NODE) {
+      const textLength = previousSibling.textContent?.length ?? 0;
+      range.setStart(previousSibling, textLength);
+    } else {
+      range.setStartAfter(previousSibling);
+    }
+  } else {
+    range.selectNodeContents(editable);
+  }
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
 }
 
 function restoreRange(range: Range | null): void {
@@ -23,16 +56,34 @@ function restoreRange(range: Range | null): void {
 
 export function useContextMenu() {
   const [state, setState] = useState<ContextMenuState>({
-    visible: false, x: 0, y: 0, hasSelection: false, savedRange: null, selectedText: '',
+    visible: false, x: 0, y: 0, hasSelection: false, selectionSource: 'none', targetFileTag: null, savedRange: null, selectedText: '',
   });
 
-  const open = useCallback((e: React.MouseEvent) => {
+  const open = useCallback((e: ReactMouseEvent) => {
     e.preventDefault();
     const sel = window.getSelection();
-    const selectedText = sel?.toString() ?? '';
+    const textSelection = sel?.toString() ?? '';
+    const fileTag = (e.target as HTMLElement | null)?.closest('.file-tag') as HTMLElement | null;
+    const fileTagPath = fileTag?.getAttribute('data-file-path')?.trim() ?? '';
+    // When right-clicking on a file tag, it is allowed to copy its full @ pathLx-Ly reference instead of misjudging as "no selection".
+    const selectedText = textSelection.trim().length > 0
+      ? textSelection
+      : (fileTagPath ? `@${fileTagPath}` : '');
+    const selectionSource: ContextMenuState['selectionSource'] = textSelection.trim().length > 0
+      ? 'text'
+      : (fileTagPath ? 'fileTag' : 'none');
     const hasSelection = selectedText.trim().length > 0;
     const savedRange = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
-    setState({ visible: true, x: e.clientX, y: e.clientY, hasSelection, savedRange, selectedText });
+    setState({
+      visible: true,
+      x: e.clientX,
+      y: e.clientY,
+      hasSelection,
+      selectionSource,
+      targetFileTag: fileTag,
+      savedRange,
+      selectedText,
+    });
   }, []);
 
   const close = useCallback(() => {
@@ -49,9 +100,22 @@ export function copySelection(_savedRange: Range | null, text: string): void {
 }
 
 /** Cut saved selection text via Java bridge (for contenteditable) */
-export function cutSelection(savedRange: Range | null, text: string, el?: HTMLElement): void {
+export function cutSelection(
+  savedRange: Range | null,
+  text: string,
+  el?: HTMLElement,
+  targetFileTag?: HTMLElement | null
+): void {
   if (!text) return;
   sendToJava('write_clipboard', text);
+  if (targetFileTag?.isConnected && el?.contains(targetFileTag)) {
+    const nextSibling = targetFileTag.nextSibling;
+    const previousSibling = targetFileTag.previousSibling;
+    targetFileTag.remove();
+    el.focus();
+    placeCursorAfterRemoval(el, nextSibling, previousSibling);
+    return;
+  }
   if (el) el.focus();
   restoreRange(savedRange);
   document.execCommand('delete');


### PR DESCRIPTION
- 在cutSelection函数中添加targetFileTag参数以支持文件标签剪切
- 添加placeCursorAfterRemoval函数来正确定位光标位置
- 扩展ContextMenuState接口以包含selectionSource和targetFileTag属性
- 改进右键菜单打开逻辑以区分文本选择和文件标签选择
- 实现文件标签的正确删除和光标定位功能
- 导入ReactMouseEvent类型定义以提高类型安全性