### PR TITLE
fix: use projectPath as cwd when active file is outside project root

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -410,16 +410,14 @@ public class SessionHandler extends BaseMessageHandler {
             }
         }
 
-        // When the active file is outside projectPath, prefer its parent directory.
-        // Typical case: single-file temporary project (projectPath in /tmp)
-        // while the actual file is under the user's home path.
-        String activeFileDir = resolveWorkingDirectoryFromActiveFile(projectPath);
-        if (activeFileDir != null && !activeFileDir.isEmpty()) {
-            return activeFileDir;
-        }
-
-        // Fall back to the user's home directory when projectPath is invalid.
+        // When projectPath is invalid (null or missing), try the active file's
+        // parent directory first — typical case: single-file temporary project
+        // (projectPath in /tmp) while the actual file is under the user's home.
         if (projectPath == null || !new File(projectPath).exists()) {
+            String activeFileDir = resolveWorkingDirectoryFromActiveFile(projectPath);
+            if (activeFileDir != null && !activeFileDir.isEmpty()) {
+                return activeFileDir;
+            }
             String userHome = PlatformUtils.getHomeDirectory();
             LOG.warn("[SessionHandler] Using user home directory as fallback: " + userHome);
             return userHome;


### PR DESCRIPTION
## Summary
- Fix `SessionHandler.determineWorkingDirectory()` using active editor file's parent as cwd even when `projectPath` is valid
- Moves active-file fallback inside the `projectPath == null` block so it only applies to temp projects
- Prevents "API request failed" crash when a non-project file (e.g. `~/.claude/plans/*.md`) is open in the editor

## Reproduction
1. Open a file outside the project root in the editor (e.g. a Claude plan file under `~/.claude/plans/`)
2. Send a message in an existing or new session
3. Second message fails with "API request failed" / "Claude Code process exited with code 1"

## Root cause
`resolveWorkingDirectoryFromActiveFile()` was called unconditionally and returned the external file's parent directory as `cwd`. This caused `getSessionMessages()` to look for JSONL files in the wrong directory (sanitized path of the external directory instead of the project root).

## Fix
Move the active-file resolution inside the `projectPath == null || !exists()` guard so it only applies when the project path is genuinely invalid (e.g. single-file temporary projects with `/tmp` paths).

## Test plan
- [x] Open a file outside the project root in the editor
- [x] Start a session and send two messages
- [x] Verify no "API request failed" error occurs
- [x] Verify session appears in history with correct project cwd
- [ ] Verify single-file temp projects still resolve to active file's parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)