### PR TITLE
fix: 修复切换模型后请求仍使用旧模型的问题

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -269,7 +269,8 @@ function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, ru
     additionalDirectories: options.additionalDirectories || [],
     systemPromptAppend: systemPromptAppend || '',
     streamingEnabled: !!streamingEnabled,
-    runtimeSessionEpoch: runtimeSessionEpoch || ''
+    runtimeSessionEpoch: runtimeSessionEpoch || '',
+    model: options.model || ''  // Include model in signature to force runtime recreation on model change
   };
   return JSON.stringify(material);
 }

--- a/src/main/java/com/github/claudecodegui/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSession.java
@@ -967,9 +967,11 @@ public class ClaudeSession {
         }
 
         final String runtimeSessionEpoch = state.getRuntimeSessionEpoch();
+        final String currentModel = state.getModel();
         LOG.info("[Lifecycle] sendToClaude sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
                 + ", epoch=" + runtimeSessionEpoch
-                + ", cwd=" + state.getCwd());
+                + ", cwd=" + state.getCwd()
+                + ", model=" + currentModel);
 
         return claudeSDKBridge.sendMessage(
                         channelId,
@@ -979,7 +981,7 @@ public class ClaudeSession {
                         state.getCwd(),
                         attachments,
                         effectivePermissionMode,
-                        state.getModel(),
+                        currentModel,
                         openedFilesJson,
                         agentPrompt,
                         streaming,

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -363,7 +363,8 @@ public class SettingsHandler extends BaseMessageHandler {
             }
 
             if (context.getSession() != null) {
-                context.getSession().setModel(model);
+                context.getSession().setModel(finalModelName);
+                LOG.info("[SettingsHandler] Updated session model to: " + finalModelName);
             }
 
             // Update status bar with basic model name


### PR DESCRIPTION
## 概述

## 截图
<img width="1116" height="844" alt="image" src="https://github.com/user-attachments/assets/ae60aca9-b9a7-4aaf-95eb-c9d319013cf5" />


修复切换模型后不生效的问题：当用户切换模型（例如从 claude-sonnet-4-5 切换到 claude-opus-4-6）时，运行时复用了旧的缓存会话，导致请求仍然发送到旧模型。

Closes #619

## 根因分析

1. **运行时签名未包含 `model` 字段** — `persistent-query-service.js` 中的 `buildRuntimeSignature()` 使用 `cwd`、`systemPromptAppend`、`streamingEnabled` 等参数计算缓存 key，但**不包含**模型名称。切换模型后生成的签名相同，因此旧的运行时被直接复用。
2. **SettingsHandler 使用了错误的变量** — `setModel(model)` 使用的是原始输入值，而非解析后的 `finalModelName`，导致 UI 显示的模型与会话实际使用的模型不一致。

## 变更内容

### `ai-bridge/services/claude/persistent-query-service.js`
- 在 `buildRuntimeSignature()` 的签名材料中加入 `model` 字段，使模型切换时缓存失效，强制重新创建运行时。

### `src/main/java/com/github/claudecodegui/ClaudeSession.java`
- 将 `state.getModel()` 提取为局部变量 `currentModel`，提升可读性。
- 在生命周期日志中增加 `model=` 输出，便于调试排查。

### `src/main/java/com/github/claudecodegui/handler/SettingsHandler.java`
- 修复 `setModel(model)` 为 `setModel(finalModelName)`，使用解析后的模型名称。
- 新增模型更新日志输出。

## 测试计划

- [x] 在设置中添加自定义模型（如 `claude-sonnet-4-5`），切换后发送消息，验证请求发送到正确的模型
- [x] 切回默认模型，验证运行时重新创建，请求使用默认模型
- [x] 重启 IDE 并重新打开对话，验证之前选择的模型正确持久化
- [x] 检查 IDE 日志中是否包含 `model=` 生命周期日志和 `Updated session model to:` 设置日志
