### PR TITLE
fix: preserve streaming assistant placeholder across messages_update

### DIFF
--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -318,6 +318,33 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
       return copy;
     };
 
+    // FIX B-034: When onStreamStart adds a streaming assistant placeholder, a subsequent
+    // messages_update from the backend may replace the message list without that placeholder
+    // (backend doesn't know about it yet). This causes streamingMessageIndex to regress to
+    // the previous turn's assistant, writing new streaming content into the wrong message
+    // and making the old assistant's text disappear temporarily.
+    const appendStreamingAssistantIfMissing = (prevList: ClaudeMessage[], nextList: ClaudeMessage[]): ClaudeMessage[] => {
+      if (!isStreamingRef.current) return nextList;
+
+      // Find the streaming assistant placeholder in prev (scan from end — it's always near the tail)
+      let streamingMsg: ClaudeMessage | undefined;
+      for (let i = prevList.length - 1; i >= 0; i--) {
+        if (prevList[i].type === 'assistant' && prevList[i].isStreaming) {
+          streamingMsg = prevList[i];
+          break;
+        }
+      }
+      if (!streamingMsg) return nextList;
+
+      // Check if nextList already includes a streaming assistant
+      for (let i = nextList.length - 1; i >= 0; i--) {
+        if (nextList[i].type === 'assistant' && nextList[i].isStreaming) return nextList;
+      }
+
+      // Re-append the streaming placeholder so streamingMessageIndex stays correct
+      return [...nextList, streamingMsg];
+    };
+
     const preserveStreamingAssistantContent = (prevList: ClaudeMessage[], nextList: ClaudeMessage[]): ClaudeMessage[] => {
       if (!isStreamingRef.current) return nextList;
 
@@ -378,6 +405,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
 
               smartMerged = preserveLastAssistantIdentity(prev, smartMerged);
               smartMerged = preserveStreamingAssistantContent(prev, smartMerged);
+              smartMerged = appendStreamingAssistantIfMissing(prev, smartMerged);
               const result = appendOptimisticMessageIfMissing(prev, smartMerged);
 
               // FIX: In Claude mode, update streamingMessageIndexRef so that
@@ -409,7 +437,9 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
 
             const lastAssistantIdx = findLastAssistantIndex(parsed);
             if (lastAssistantIdx < 0) {
-              return appendOptimisticMessageIfMissing(prev, parsed);
+              let earlyResult = appendOptimisticMessageIfMissing(prev, parsed);
+              earlyResult = appendStreamingAssistantIfMissing(prev, earlyResult);
+              return earlyResult;
             }
             // ... (rest of streaming logic)
             // Simplified handling due to code structure — reuse existing streaming logic.
@@ -470,6 +500,7 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
           patched = appendOptimisticMessageIfMissing(prev, patched);
           patched = preserveLastAssistantIdentity(prev, patched);
           patched = preserveStreamingAssistantContent(prev, patched);
+          patched = appendStreamingAssistantIfMissing(prev, patched);
 
           const patchedAssistantIdx = findLastAssistantIndex(patched);
           if (patchedAssistantIdx >= 0 && patched[patchedAssistantIdx]?.type === 'assistant') {


### PR DESCRIPTION
## Summary

- **Bug:** When sending a prompt in an existing session, previous assistant text messages temporarily disappear (tool blocks remain visible). They reappear once the new stream's `messages_update` includes the new assistant message (~3-13s later).
- **Root cause:** Race condition between `onStreamStart` and `messages_update` in `useWindowCallbacks.ts`. When `onStreamStart` creates a streaming assistant placeholder and `messages_update` arrives shortly after with the backend's message list (which doesn't include the placeholder yet), the placeholder is lost. `streamingMessageIndex` regresses to the previous turn's assistant, causing `onContentDelta` to overwrite the old message's content.
- **Fix:** Add `appendStreamingAssistantIfMissing()` — analogous to the existing `appendOptimisticMessageIfMissing()` for user messages — to re-append the streaming placeholder when it's missing from the backend's list. Applied in all three streaming paths of `updateMessages`.

## Diagnosis

Confirmed via diagnostic snapshots showing `streamingMessageIndex` pointing to a previous assistant message (e.g., index 1736 with messageCount 1748 = 12 message gap; worst case: index 179 with messageCount 245 = 66 message gap).

## Test plan

- [ ] Open an existing session with prior assistant messages containing both text and tool blocks
- [ ] Send a new prompt and observe that previous assistant text does NOT disappear
- [ ] Verify the new streaming response appears correctly below the user message
- [ ] Test with sessions that have many tool calls (larger gap between assistant and end of list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)