### PR TITLE
fix: restore correct token usage tracking in streaming multi-turn conversations

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -136,8 +136,14 @@ function processStreamMessage(msg, state, logPrefix) {
     state.hasStreamEvents = true;
     const event = msg.event;
     if (event) {
+      // Usage tracking during streaming (following CLI's accumulation logic):
+      // - message_start: ACCUMULATE usage across all turns (not reset!)
+      // - message_delta: incremental output_tokens updates
+      // - The accumulatedUsage represents the cumulative total across all turns in multi-turn tool use.
       if (event.type === 'message_start' && event.message?.usage) {
-        state.accumulatedUsage = mergeUsage(null, event.message.usage);
+        // IMPORTANT: Must use mergeUsage(state.accumulatedUsage, ...) to accumulate across turns.
+        // Using mergeUsage(null, ...) would reset and only show the last turn's usage.
+        state.accumulatedUsage = mergeUsage(state.accumulatedUsage, event.message.usage);
       }
       if (event.type === 'message_delta' && event.usage) {
         state.accumulatedUsage = mergeUsage(state.accumulatedUsage, event.usage);
@@ -185,6 +191,11 @@ function processStreamMessage(msg, state, logPrefix) {
     }
   }
 
+  // Emit usage tag for assistant messages.
+  // IMPORTANT: This is the authoritative source for token usage, NOT the accumulatedUsage.
+  // The assistant message's usage field contains the correct cumulative total.
+  // In streaming mode, this overwrites any intermediate [USAGE] values sent during streaming.
+  // The Java backend (ClaudeMessageHandler.handleAssistantMessage) relies on this for correct totals.
   emitUsageTag(msg);
 
   // Output tool_result blocks from user messages
@@ -290,7 +301,9 @@ async function executeWithRetry({ createQueryResult, streamingEnabled, resumeSes
       // Success
       if (retryAttempt > 0) console.log(`[RETRY]${lp} Success after ${retryAttempt} retry attempt(s)`);
       if (streamingEnabled && state.streamStarted) {
-        if (state.accumulatedUsage) emitAccumulatedUsage(state.accumulatedUsage);
+        // NOTE: Do NOT emit accumulatedUsage at stream end.
+        // The assistant message's usage (sent via emitUsageTag at line 200) is the authoritative final value.
+        // Emitting accumulatedUsage here would send a redundant or potentially stale value.
         process.stdout.write('[STREAM_END]\n');
         outerStreamState.streamEnded = true;
       }
@@ -346,7 +359,9 @@ function logLoopError(error, lp) {
  */
 function handleSendError(error, streamState, sdkStderrLines) {
   if (streamState.streamingEnabled && streamState.streamStarted && !streamState.streamEnded) {
-    emitAccumulatedUsage(streamState.accumulatedUsage);
+    // NOTE: Do NOT emit accumulatedUsage at stream end, even on error.
+    // If assistant messages were received, emitUsageTag already sent the correct usage.
+    // If no assistant message was received, the usage would be incomplete anyway.
     process.stdout.write('[STREAM_END]\n');
   }
   const payload = buildConfigErrorPayload(error);

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -676,12 +676,17 @@ function processStreamEvent(msg, turnState) {
   const event = msg.event;
   if (!event) return;
 
-  // Handle message_start: reset per-turn accumulator (matches CLI behavior)
+  // Usage tracking during streaming (following CLI's accumulation logic):
+  // - message_start: ACCUMULATE usage across all turns (not reset!)
+  // - message_delta: incremental output_tokens updates
+  // - The accumulatedUsage represents the cumulative total across all turns in multi-turn tool use.
   if (event.type === 'message_start' && event.message?.usage) {
-    turnState.accumulatedUsage = mergeUsage(null, event.message.usage);
+    // IMPORTANT: Must use mergeUsage(turnState.accumulatedUsage, ...) to accumulate across turns.
+    // Using mergeUsage(null, ...) would reset and only show the last turn's usage.
+    turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.message.usage);
   }
 
-  // Handle message_delta: accumulate output_tokens and emit [USAGE] tag
+  // Handle message_delta: accumulate output_tokens and emit [USAGE] tag for real-time feedback
   if (event.type === 'message_delta' && event.usage) {
     turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.usage);
     emitAccumulatedUsage(turnState.accumulatedUsage);
@@ -836,6 +841,11 @@ async function executeTurn(runtime, requestContext, turnMeta) {
     }
 
     processMessageContent(msg, turnState);
+    // Emit usage tag for assistant messages.
+    // IMPORTANT: This is the authoritative source for token usage, NOT the accumulatedUsage.
+    // The assistant message's usage field contains the correct cumulative total.
+    // In streaming mode, this overwrites any intermediate [USAGE] values sent during streaming.
+    // The Java backend (ClaudeMessageHandler.handleAssistantMessage) relies on this for correct totals.
     emitUsageTag(msg);
     processToolResultMessages(msg);
 
@@ -854,10 +864,9 @@ async function executeTurn(runtime, requestContext, turnMeta) {
   }
 
   if (turnState.streamingEnabled && turnState.streamStarted && !turnState.streamEnded) {
-    // Emit final accumulated usage before stream end
-    if (turnState.accumulatedUsage) {
-      emitAccumulatedUsage(turnState.accumulatedUsage);
-    }
+    // NOTE: Do NOT emit accumulatedUsage at stream end.
+    // The assistant message's usage (sent via emitUsageTag above) is the authoritative final value.
+    // Emitting accumulatedUsage here would send a redundant or potentially stale value.
     process.stdout.write('[STREAM_END]\n');
     turnState.streamEnded = true;
   }
@@ -917,10 +926,9 @@ async function sendInternal(params, withAttachments) {
       activeTurnRuntime = null;
     }
     if (turnMeta.state?.streamingEnabled && turnMeta.state?.streamStarted && !turnMeta.state?.streamEnded) {
-      // Emit final accumulated usage before stream end
-      if (turnMeta.state?.accumulatedUsage) {
-        emitAccumulatedUsage(turnMeta.state.accumulatedUsage);
-      }
+      // NOTE: Do NOT emit accumulatedUsage at stream end, even on error.
+      // If an assistant message was received, emitUsageTag already sent the correct usage.
+      // If no assistant message was received, the usage would be incomplete anyway.
       process.stdout.write('[STREAM_END]\n');
       turnMeta.state.streamEnded = true;
     }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -260,10 +260,19 @@ public class ClaudeMessageHandler implements MessageCallback {
                 LOG.debug("Streaming active, skipping full message update in handleAssistantMessage");
             }
 
-            // Update status bar with usage from the assistant message.
-            // In streaming mode, usage is primarily updated via handleUsage() from [USAGE] tags,
-            // so skip here to avoid duplicate updates. In non-streaming mode, this is the primary path.
-            if (!isStreaming && mergedRaw.has("message") && mergedRaw.get("message").isJsonObject()) {
+            // Update status bar with usage from the final assistant message (matches CLI's PP1 behavior).
+            // This ensures the displayed value matches what resume shows from JSONL history.
+            // The assistant message's usage field is the authoritative final value.
+            //
+            // IMPORTANT: This update MUST happen in BOTH streaming and non-streaming modes:
+            // - In streaming mode: [USAGE] tags provide intermediate updates for real-time feedback,
+            //   but the assistant message's usage is the authoritative final value that must overwrite
+            //   any intermediate values to ensure consistency with JSONL history and CLI behavior.
+            // - In non-streaming mode: This is the primary path to update token usage.
+            //
+            // DO NOT add !isStreaming check here - it was previously introduced in commit 03640408
+            // and caused incorrect token display in streaming mode (see commit history for details).
+            if (mergedRaw.has("message") && mergedRaw.get("message").isJsonObject()) {
                 JsonObject messageObj = mergedRaw.getAsJsonObject("message");
                 if (messageObj.has("usage") && messageObj.get("usage").isJsonObject()) {
                     JsonObject usage = messageObj.getAsJsonObject("usage");
@@ -271,7 +280,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                     int maxTokens = SettingsHandler.getModelContextLimit(state.getModel());
                     ClaudeNotifier.setTokenUsage(project, usedTokens, maxTokens);
                     callbackHandler.notifyUsageUpdate(usedTokens, maxTokens);
-                    LOG.debug("Updated token usage from assistant message (non-streaming): " + usedTokens);
+                    LOG.debug("Updated token usage from assistant message: " + usedTokens);
                 }
             }
         } catch (Exception e) {
@@ -697,8 +706,14 @@ public class ClaudeMessageHandler implements MessageCallback {
 
     /**
      * Backfill usage data into the current assistant message's raw JSON.
-     * Uses monotonic increase check to prevent overwriting a larger value with a smaller one
-     * (e.g., due to out-of-order message delivery).
+     * Always updates during streaming to capture accumulating usage data.
+     *
+     * IMPORTANT: This method does NOT perform monotonic increase checks.
+     * - The assistant message's final usage value (from handleAssistantMessage) is the authoritative
+     *   value that will overwrite any intermediate values from [USAGE] tags.
+     * - Monotonic checks were previously added in commit 03640408 but removed because they prevented
+     *   the authoritative final value from being applied when messages arrive out of order.
+     * - Allowing overwrites ensures consistency with JSONL history and CLI behavior.
      */
     private void backfillUsageToAssistantMessage(JsonObject usageJson) {
         if (currentAssistantMessage == null || currentAssistantMessage.raw == null) return;
@@ -706,17 +721,9 @@ public class ClaudeMessageHandler implements MessageCallback {
                 ? currentAssistantMessage.raw.getAsJsonObject("message") : null;
         if (message == null) return;
 
-        // Monotonic increase check: only update if new total >= existing total
-        int newTotal = TokenUsageUtils.extractUsedTokens(usageJson, state.getProvider());
-        if (message.has("usage") && message.get("usage").isJsonObject()) {
-            int existingTotal = TokenUsageUtils.extractUsedTokens(message.getAsJsonObject("usage"), state.getProvider());
-            if (newTotal < existingTotal) {
-                LOG.debug("Skipping usage backfill: new total " + newTotal + " < existing " + existingTotal);
-                return;
-            }
-        }
+        // Always update usage during streaming to capture accumulating values
         message.add("usage", usageJson);
-        LOG.debug("Updated assistant message usage from [USAGE] tag: " + newTotal);
+        LOG.debug("Updated assistant message usage from [USAGE] tag");
     }
 
     private void applyThinkingDeltaToRaw(String delta) {


### PR DESCRIPTION
Commit 0364040839686c11dbb99f42cb3e97807a911420 introduced two breaking changes to token usage handling in streaming mode:

1. Added a `!isStreaming` guard to `handleAssistantMessage` in Java, which prevented the authoritative assistant message usage from being applied in streaming mode. This caused the UI to display stale intermediate values instead of the correct final totals.

2. Added a monotonic increase check to `backfillUsageToAssistantMessage`, which blocked the authoritative final value from overwriting intermediate values when messages arrive out of order.

Additionally, the JavaScript layer had a pre-existing bug where `accumulatedUsage` was reset on each `message_start` event via `mergeUsage(null, ...)`, causing multi-turn tool use conversations to only show usage from the last turn instead of the cumulative total.

Fixes applied:

Java (ClaudeMessageHandler.java):
- Remove `!isStreaming` guard so assistant message usage is applied in both streaming and non-streaming modes
- Remove monotonic increase check so the authoritative final value can always overwrite intermediate values
- Add detailed comments warning against re-introducing these guards

JavaScript (message-sender.js, persistent-query-service.js):
- Change `mergeUsage(null, event.message.usage)` to `mergeUsage(state.accumulatedUsage, event.message.usage)` on `message_start` to accumulate usage across all turns, following CLI's accumulation logic
- Remove `emitAccumulatedUsage()` calls at stream end to avoid overwriting the authoritative value from `emitUsageTag()`
- Add comments documenting the authoritative usage data flow


DO NOT CHANGE this part anymore...... AI code review do not know how to handle the usage.