### PR TITLE
fix: handle CRLF/LF line ending mismatch in diff review

### DIFF
--- a/src/main/java/com/github/claudecodegui/permission/DiffReviewService.java
+++ b/src/main/java/com/github/claudecodegui/permission/DiffReviewService.java
@@ -218,19 +218,82 @@ public class DiffReviewService {
 
         boolean replaceAll = inputs.has("replace_all") && inputs.get("replace_all").getAsBoolean();
 
-        if (replaceAll) {
-            return originalContent.replace(oldString, newString);
-        } else {
+        String effectiveOldString = oldString;
+        String effectiveNewString = newString;
+
+        if (!replaceAll) {
+            // Try exact match first
             int index = originalContent.indexOf(oldString);
+
+            // Common mismatch on Windows: tool input uses LF but file content is CRLF
+            if (index < 0) {
+                String crlfOld = oldString.replace("\n", "\r\n");
+                if (!crlfOld.equals(oldString)) {
+                    int crlfIndex = originalContent.indexOf(crlfOld);
+                    if (crlfIndex >= 0) {
+                        index = crlfIndex;
+                        effectiveOldString = crlfOld;
+                        effectiveNewString = newString.replace("\n", "\r\n");
+                        LOG.info("DiffReview: Matched old_string after normalizing LF->CRLF");
+                    }
+                }
+            }
+
+            // Inverse mismatch: tool input CRLF, file content LF
+            if (index < 0) {
+                String lfOld = oldString.replace("\r\n", "\n");
+                if (!lfOld.equals(oldString)) {
+                    int lfIndex = originalContent.indexOf(lfOld);
+                    if (lfIndex >= 0) {
+                        index = lfIndex;
+                        effectiveOldString = lfOld;
+                        effectiveNewString = newString.replace("\r\n", "\n");
+                        LOG.info("DiffReview: Matched old_string after normalizing CRLF->LF");
+                    }
+                }
+            }
+
             if (index >= 0) {
                 return originalContent.substring(0, index)
-                        + newString
-                        + originalContent.substring(index + oldString.length());
-            } else {
-                LOG.warn("DiffReview: old_string not found in file content");
-                return null;
+                        + effectiveNewString
+                        + originalContent.substring(index + effectiveOldString.length());
+            }
+
+            LOG.warn("DiffReview: old_string not found in file content (fileLength=" + originalContent.length()
+                    + ", oldStringLength=" + oldString.length() + ")");
+            return null;
+        }
+
+        // For replace_all
+        String result = originalContent.replace(oldString, newString);
+        if (!result.equals(originalContent)) {
+            return result;
+        }
+
+        // For replace_all, also try line-ending variants to avoid silent no-ops
+        String crlfOld = oldString.replace("\n", "\r\n");
+        if (!crlfOld.equals(oldString)) {
+            String crlfNew = newString.replace("\n", "\r\n");
+            result = originalContent.replace(crlfOld, crlfNew);
+            if (!result.equals(originalContent)) {
+                LOG.info("DiffReview: Matched old_string after normalizing LF->CRLF (replace_all)");
+                return result;
             }
         }
+
+        String lfOld = oldString.replace("\r\n", "\n");
+        if (!lfOld.equals(oldString)) {
+            String lfNew = newString.replace("\r\n", "\n");
+            result = originalContent.replace(lfOld, lfNew);
+            if (!result.equals(originalContent)) {
+                LOG.info("DiffReview: Matched old_string after normalizing CRLF->LF (replace_all)");
+                return result;
+            }
+        }
+
+        LOG.warn("DiffReview: old_string not found in file content (replace_all, fileLength=" + originalContent.length()
+                + ", oldStringLength=" + oldString.length() + ")");
+        return null;
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/permission/PermissionService.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionService.java
@@ -1498,16 +1498,20 @@ public class PermissionService {
 
         Project matchedProject = findProjectByCwd(request);
 
-        // Retry once if dialogShowers is empty (timing issue: registration may not be complete yet)
+        // Retry if dialogShowers is empty (timing issue: webview registration may not be complete yet)
+        // Wait up to 2 seconds for dialog showers to register (handles open-tab scenario)
         if (matchedProject == null && this.dialogShowers.isEmpty()) {
-            LOG.info("[DIFF_REVIEW] dialogShowers empty, retrying after 100ms...");
+            LOG.info("[DIFF_REVIEW] dialogShowers empty, waiting for registration (max 2s)...");
             try {
-                Thread.sleep(100);
+                for (int i = 0; i < 20 && this.dialogShowers.isEmpty(); i++) {
+                    Thread.sleep(100);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
             matchedProject = findProjectByCwd(request);
-            LOG.info("[DIFF_REVIEW] Retry result: " + (matchedProject != null ? matchedProject.getName() : "null"));
+            LOG.info("[DIFF_REVIEW] Retry result after " + (!this.dialogShowers.isEmpty() ? "registration" : "timeout")
+                    + ": " + (matchedProject != null ? matchedProject.getName() : "null"));
         }
 
         if (matchedProject == null) {


### PR DESCRIPTION
- Add line ending normalization in DiffReviewService for Edit tool
- Try LF->CRLF and CRLF->LF conversion when exact match fails
- Extend dialogShower registration wait timeout from 100ms to 2s
- Improve logging for debugging purposes

This fixes diff review not opening on Windows where file content uses CRLF but tool input uses LF (or vice versa).