### PR TITLE
fix: Codex history initial load returns fewer sessions than refresh

### DIFF
--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexCache.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexCache.java
@@ -131,9 +131,10 @@ public class SessionIndexCache {
             return null;
         }
 
-        long currentDirModified = getDirModifiedTime(sessionsDir);
-        if (!entry.isValid(currentDirModified)) {
-            LOG.info("[SessionIndexCache] Codex cache invalid: expired or dir changed for " + projectPath);
+        // Codex sessions use nested year/month/day directories, so root directory
+        // timestamp is unreliable for detecting new files. Use TTL-only validation.
+        if (entry.isExpired()) {
+            LOG.info("[SessionIndexCache] Codex cache expired for " + projectPath);
             codexCache.remove(projectPath);
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
@@ -264,14 +264,7 @@ public class SessionIndexManager {
         }
 
         try {
-            // For Codex, check the root directory's modification time
-            long currentDirModified = Files.getLastModifiedTime(sessionsDir).toMillis();
-
-            if (currentDirModified <= projectIndex.lastDirScanTime) {
-                return UpdateType.NONE;
-            }
-
-            // Directory timestamp changed; count current files
+            // Count files first (recursive walk for nested year/month/day structure)
             long currentFileCount;
             try (Stream<Path> paths = Files.walk(sessionsDir)) {
                 currentFileCount = paths
@@ -280,14 +273,13 @@ public class SessionIndexManager {
                     .count();
             }
 
-            if (currentFileCount > projectIndex.fileCount) {
+            if (currentFileCount == projectIndex.fileCount) {
+                return UpdateType.NONE;
+            } else if (currentFileCount > projectIndex.fileCount) {
                 LOG.info("[SessionIndexManager] Codex file count increased: " + projectIndex.fileCount + " -> " + currentFileCount + ", incremental update");
                 return UpdateType.INCREMENTAL;
-            } else if (currentFileCount < projectIndex.fileCount) {
-                LOG.info("[SessionIndexManager] Codex file count decreased, full update");
-                return UpdateType.FULL;
             } else {
-                // File count is the same but directory timestamp changed; content may have been updated
+                LOG.info("[SessionIndexManager] Codex file count decreased: " + projectIndex.fileCount + " -> " + currentFileCount + ", full update");
                 return UpdateType.FULL;
             }
         } catch (IOException e) {


### PR DESCRIPTION
Codex sessions are stored in nested year/month/day directories (e.g. ~/.codex/sessions/2026/03/17/), unlike Claude's flat structure.

The root cause was that getUpdateTypeRecursive() checked only the root directory's modification timestamp to decide whether to use the cached index. Since adding files in subdirectories does not update the parent directory's mtime, the check returned NONE (use stale index) even when new session files existed in deeper directories.

Fix by replacing the unreliable root-dir timestamp check with a Files.walk file-count comparison, matching the strategy already used by Claude's getUpdateType(). Also switch SessionIndexCache.getCodexSessions to TTL-only validation for the same reason.