### PR TITLE
fix: resolve race condition where last streaming assistant message is lost

### DIFF
--- a/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { MutableRefObject } from 'react';
 import type { ClaudeMessage } from '../../../types';
 import {
   OPTIMISTIC_MESSAGE_TIME_WINDOW,
   appendOptimisticMessageIfMissing,
+  ensureStreamingAssistantInList,
   getRawUuid,
   preserveLastAssistantIdentity,
   preserveMessageIdentity,
@@ -463,5 +464,86 @@ describe('preserveLastAssistantIdentity — turn ID guards', () => {
 
     const result = preserveLastAssistantIdentity(prev, next, findLastAssistantIndex);
     expect(result[0].timestamp).toBe(prevTs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureStreamingAssistantInList — race condition & fallback
+// ---------------------------------------------------------------------------
+
+describe('ensureStreamingAssistantInList', () => {
+  // ---- Primary path (refs valid) ----
+
+  it('returns resultList unchanged when streaming assistant already in resultList', () => {
+    const prev = [makeAssistantMsg('streaming', { __turnId: 1, isStreaming: true })];
+    const result = [makeAssistantMsg('streaming', { __turnId: 1, isStreaming: true })];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, true, 1);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(0);
+  });
+
+  it('appends streaming assistant from prev when missing from result (primary path)', () => {
+    const streamingMsg = makeAssistantMsg('streaming content', { __turnId: 1, isStreaming: true });
+    const prev = [makeUserMsg('q'), streamingMsg];
+    const result = [makeUserMsg('q')];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, true, 1);
+    expect(list).toHaveLength(2);
+    expect(list[1]).toBe(streamingMsg);
+    expect(streamingIndex).toBe(1);
+  });
+
+  // ---- Fallback path (refs cleared — race condition) ----
+
+  it('recovers streaming assistant from prevList when refs are already cleared', () => {
+    const streamingMsg = makeAssistantMsg('last streamed', { __turnId: 5, isStreaming: true });
+    const prev = [makeUserMsg('q'), streamingMsg];
+    const result = [makeUserMsg('q')];
+
+    // Simulate race: isStreaming=false, turnId=0 (cleared by onStreamEnd)
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toHaveLength(2);
+    expect(list[1]).toBe(streamingMsg);
+    expect(streamingIndex).toBe(1);
+  });
+
+  it('does NOT recover non-streaming assistant from prevList when refs are cleared', () => {
+    const finishedMsg = makeAssistantMsg('done', { __turnId: 5, isStreaming: false });
+    const prev = [makeUserMsg('q'), finishedMsg];
+    const result = [makeUserMsg('q')];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(-1);
+  });
+
+  it('does NOT recover assistant without __turnId from prevList when refs are cleared', () => {
+    const noTurnMsg = makeAssistantMsg('old msg', { isStreaming: true });
+    const prev = [makeUserMsg('q'), noTurnMsg];
+    const result = [makeUserMsg('q')];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(-1);
+  });
+
+  it('does not duplicate when resultList already contains the streaming assistant (fallback)', () => {
+    const streamingMsg = makeAssistantMsg('streaming', { __turnId: 3, isStreaming: true });
+    const prev = [streamingMsg];
+    const result = [makeAssistantMsg('streaming', { __turnId: 3 })];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(-1);
+  });
+
+  it('returns resultList unchanged when prevList has no streaming assistant and refs cleared', () => {
+    const prev = [makeUserMsg('q'), makeAssistantMsg('done', { isStreaming: false })];
+    const result = [makeUserMsg('q')];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(-1);
   });
 });

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -205,6 +205,71 @@ export const preserveStreamingAssistantContent = (
 };
 
 // ---------------------------------------------------------------------------
+// Streaming assistant preservation
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a streaming assistant message is not lost when updateMessages replaces
+ * the entire message list.  Returns the (possibly amended) result list and the
+ * index of the streaming assistant inside it.
+ *
+ * The function has two paths:
+ * 1. Primary — refs are valid (normal streaming).
+ * 2. Fallback — refs already cleared (race condition). Uses message-level
+ *    `isStreaming` + `__turnId` markers to recover.
+ */
+export const ensureStreamingAssistantInList = (
+  prevList: ClaudeMessage[],
+  resultList: ClaudeMessage[],
+  isStreaming: boolean,
+  streamingTurnId: number,
+): { list: ClaudeMessage[]; streamingIndex: number } => {
+  // Primary path: refs are still valid
+  if (isStreaming && streamingTurnId > 0) {
+    const existingIdx = resultList.findIndex(
+      (m) => m.__turnId === streamingTurnId && m.type === 'assistant',
+    );
+    if (existingIdx >= 0) {
+      return { list: resultList, streamingIndex: existingIdx };
+    }
+
+    let streamingAssistant: ClaudeMessage | undefined;
+    for (let i = prevList.length - 1; i >= 0; i--) {
+      if (prevList[i].__turnId === streamingTurnId && prevList[i].type === 'assistant') {
+        streamingAssistant = prevList[i];
+        break;
+      }
+    }
+
+    if (streamingAssistant) {
+      const result = [...resultList, streamingAssistant];
+      return { list: result, streamingIndex: result.length - 1 };
+    }
+
+    return { list: resultList, streamingIndex: -1 };
+  }
+
+  // Fallback path: refs already cleared (race condition).
+  // Only consider the most recent streaming assistant in prevList.
+  for (let i = prevList.length - 1; i >= 0; i--) {
+    const msg = prevList[i];
+    if (msg.type === 'assistant' && msg.isStreaming && msg.__turnId && msg.__turnId > 0) {
+      const alreadyPresent = resultList.some(
+        (m) => m.type === 'assistant' && m.__turnId === msg.__turnId,
+      );
+      if (!alreadyPresent) {
+        const result = [...resultList, msg];
+        return { list: result, streamingIndex: result.length - 1 };
+      }
+      // Already in resultList — no recovery needed
+      break;
+    }
+  }
+
+  return { list: resultList, streamingIndex: -1 };
+};
+
+// ---------------------------------------------------------------------------
 // Re-export ClaudeRawMessage so callers can use it without an extra import
 // ---------------------------------------------------------------------------
 export type { ClaudeRawMessage };

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -12,6 +12,7 @@ import type { ClaudeMessage } from '../../../types';
 import { sendBridgeEvent } from '../../../utils/bridge';
 import {
   appendOptimisticMessageIfMissing,
+  ensureStreamingAssistantInList,
   preserveLastAssistantIdentity,
   preserveStreamingAssistantContent,
 } from '../messageSync';
@@ -49,31 +50,16 @@ export function registerMessageCallbacks(
   } = options;
 
   const ensureStreamingAssistantPreserved = (prevList: ClaudeMessage[], resultList: ClaudeMessage[]): ClaudeMessage[] => {
-    if (!isStreamingRef.current || streamingTurnIdRef.current <= 0) return resultList;
-
-    // Check if result already contains the current streaming assistant
-    const turnId = streamingTurnIdRef.current;
-    const existingIdx = resultList.findIndex((m) => m.__turnId === turnId && m.type === 'assistant');
-    if (existingIdx >= 0) {
-      streamingMessageIndexRef.current = existingIdx;
-      return resultList;
+    const { list, streamingIndex } = ensureStreamingAssistantInList(
+      prevList,
+      resultList,
+      isStreamingRef.current,
+      streamingTurnIdRef.current,
+    );
+    if (streamingIndex >= 0) {
+      streamingMessageIndexRef.current = streamingIndex;
     }
-
-    // Find the streaming assistant in prev (reverse search for efficiency)
-    let streamingAssistant: ClaudeMessage | undefined;
-    for (let i = prevList.length - 1; i >= 0; i--) {
-      if (prevList[i].__turnId === turnId && prevList[i].type === 'assistant') {
-        streamingAssistant = prevList[i];
-        break;
-      }
-    }
-
-    if (!streamingAssistant) return resultList;
-
-    // Append the streaming assistant to result
-    const result = [...resultList, streamingAssistant];
-    streamingMessageIndexRef.current = result.length - 1;
-    return result;
+    return list;
   };
 
   window.updateMessages = (json) => {

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -194,48 +194,54 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
       thinkingUpdateTimeoutRef.current = null;
     }
 
-    // Flush final content BEFORE marking stream as ended
+    // Snapshot keys that need collapsing BEFORE they are cleared inside the updater.
+    const keysToCollapse = new Set(autoExpandedThinkingKeysRef.current);
+
+    // Flush final content AND clear streaming refs inside the same updater.
+    // This ensures any previously queued setMessages updater (e.g. from
+    // updateMessages) still reads valid refs when it executes, because React
+    // processes updaters in enqueue order.
     setMessages((prev) => {
-      if (prev.length === 0) return prev;
+      let newMessages = prev;
       const idx = streamingMessageIndexRef.current;
-      if (idx < 0 || idx >= prev.length || prev[idx]?.type !== 'assistant') {
-        return prev;
+      if (prev.length > 0 && idx >= 0 && idx < prev.length && prev[idx]?.type === 'assistant') {
+        const finalContent = streamingContentRef.current;
+        newMessages = [...prev];
+        newMessages[idx] = {
+          ...newMessages[idx],
+          content: finalContent || newMessages[idx].content,
+          isStreaming: false,
+        };
       }
-      const finalContent = streamingContentRef.current;
-      const newMessages = [...prev];
-      newMessages[idx] = {
-        ...newMessages[idx],
-        content: finalContent || newMessages[idx].content,
-        isStreaming: false,
-      };
+
+      // Clear all streaming refs AFTER flushing content, inside the updater
+      isStreamingRef.current = false;
+      useBackendStreamingRenderRef.current = false;
+      streamingMessageIndexRef.current = -1;
+      streamingTurnIdRef.current = -1;
+      streamingContentRef.current = '';
+      streamingTextSegmentsRef.current = [];
+      activeTextSegmentIndexRef.current = -1;
+      streamingThinkingSegmentsRef.current = [];
+      activeThinkingSegmentIndexRef.current = -1;
+      seenToolUseCountRef.current = 0;
+      autoExpandedThinkingKeysRef.current.clear();
+
       return newMessages;
     });
 
-    // Mark streaming as ended AFTER flushing content
-    isStreamingRef.current = false;
-    useBackendStreamingRenderRef.current = false;
-
-    if (setExpandedThinking) {
+    // Collapse auto-expanded thinking blocks using the pre-clear snapshot
+    if (setExpandedThinking && keysToCollapse.size > 0) {
       setExpandedThinking((prev) => {
-        const keys = autoExpandedThinkingKeysRef.current;
-        if (keys.size === 0) return prev;
         const next = { ...prev };
-        keys.forEach((key) => {
+        keysToCollapse.forEach((key) => {
           next[key] = false;
         });
         return next;
       });
     }
 
-    streamingMessageIndexRef.current = -1;
-    streamingTurnIdRef.current = -1;
-    streamingContentRef.current = '';
-    streamingTextSegmentsRef.current = [];
-    activeTextSegmentIndexRef.current = -1;
-    streamingThinkingSegmentsRef.current = [];
-    activeThinkingSegmentIndexRef.current = -1;
-    seenToolUseCountRef.current = 0;
-    autoExpandedThinkingKeysRef.current.clear();
+    // React state (not ref) — React batches this with setMessages automatically
     setStreamingActive(false);
   };
 


### PR DESCRIPTION
Move streaming ref cleanup (isStreamingRef, streamingTurnIdRef, etc.) from synchronous code into the setMessages updater body in onStreamEnd. This ensures previously queued setMessages updaters (e.g. from updateMessages) still read valid refs when React executes them in batch.

Also add a fallback path in ensureStreamingAssistantPreserved that recovers a streaming assistant via message-level __turnId + isStreaming markers when refs are already cleared due to the race window.

Snapshot autoExpandedThinkingKeysRef before the updater to prevent the collapsed-thinking logic from reading an already-cleared Set.