### PR TITLE
fix(node-path): reject invalid saved node paths

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/NodePathHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/NodePathHandler.java
@@ -42,10 +42,27 @@ public class NodePathHandler {
                 String versionToSend = null;
 
                 if (saved != null && !saved.trim().isEmpty()) {
-                    pathToSend = saved.trim();
-                    NodeDetectionResult result = context.getClaudeSDKBridge().verifyAndCacheNodePath(pathToSend);
+                    String trimmedPath = saved.trim();
+                    NodeDetectionResult result = this.context.getClaudeSDKBridge().verifyAndCacheNodePath(trimmedPath);
                     if (result != null && result.isFound()) {
+                        pathToSend = trimmedPath;
                         versionToSend = result.getNodeVersion();
+                    } else {
+                        // Saved path is invalid, clear it and trigger re-detection
+                        LOG.warn("[NodePathHandler] Saved Node.js path is invalid: " + trimmedPath
+                            + ", clearing and triggering re-detection");
+                        props.unsetValue(NODE_PATH_PROPERTY_KEY);
+                        this.context.getClaudeSDKBridge().setNodeExecutable(null);
+                        this.context.getCodexSDKBridge().setNodeExecutable(null);
+
+                        NodeDetectionResult detected = this.context.getClaudeSDKBridge().detectNodeWithDetails();
+                        if (detected != null && detected.isFound() && detected.getNodePath() != null) {
+                            pathToSend = detected.getNodePath();
+                            versionToSend = detected.getNodeVersion();
+                            props.setValue(NODE_PATH_PROPERTY_KEY, pathToSend);
+                            this.context.getClaudeSDKBridge().verifyAndCacheNodePath(pathToSend);
+                            this.context.getCodexSDKBridge().setNodeExecutable(pathToSend);
+                        }
                     }
                 } else {
                     NodeDetectionResult detected = context.getClaudeSDKBridge().detectNodeWithDetails();
@@ -134,16 +151,21 @@ public class NodePathHandler {
                         failureMsg = "已清空自定义路径，但无法自动检测到 Node.js，请手动配置路径";
                     }
                 } else {
-                    props.setValue(NODE_PATH_PROPERTY_KEY, pathArg);
+                    // Verify before saving to avoid caching invalid path
                     NodeDetectionResult result = context.getClaudeSDKBridge().verifyAndCacheNodePath(pathArg);
-                    LOG.info("[NodePathHandler] Updated manual Node.js path from settings: " + pathArg);
-                    finalPath = pathArg;
                     if (result != null && result.isFound()) {
+                        // Only save if verification succeeds
+                        props.setValue(NODE_PATH_PROPERTY_KEY, pathArg);
                         context.getCodexSDKBridge().setNodeExecutable(pathArg);
+                        finalPath = pathArg;
                         versionToSend = result.getNodeVersion();
                         verifySuccess = true;
+                        LOG.info("[NodePathHandler] Saved manual Node.js path: " + pathArg);
                     } else {
+                        // Verification failed, don't save invalid path
+                        finalPath = "";
                         failureMsg = result != null ? result.getErrorMessage() : "无法验证指定的 Node.js 路径";
+                        LOG.warn("[NodePathHandler] Node.js path verification failed: " + pathArg + " - " + failureMsg);
                     }
                 }
 

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -1,8 +1,9 @@
 package com.github.claudecodegui.ui;
 
-import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
+import com.github.claudecodegui.model.NodeDetectionResult;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.startup.BridgePreloader;
@@ -529,24 +530,46 @@ public class WebviewInitializer {
      * Handle Node.js path save from the error panel input.
      */
     public void handleNodePathSave(String manualPath) {
-        ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
-        CodexSDKBridge codexSDKBridge = host.getCodexSDKBridge();
-        JPanel mainPanel = host.getMainPanel();
+        ClaudeSDKBridge claudeSDKBridge = this.host.getClaudeSDKBridge();
+        CodexSDKBridge codexSDKBridge = this.host.getCodexSDKBridge();
+        JPanel mainPanel = this.host.getMainPanel();
 
         try {
             PropertiesComponent props = PropertiesComponent.getInstance();
 
             if (manualPath == null || manualPath.isEmpty()) {
+                // Clear saved path and trigger auto-detection
                 props.unsetValue(NODE_PATH_PROPERTY_KEY);
                 claudeSDKBridge.setNodeExecutable(null);
                 codexSDKBridge.setNodeExecutable(null);
-                LOG.info("Cleared manual Node.js path");
+                LOG.info("Cleared manual Node.js path, triggering auto-detection");
+
+                NodeDetectionResult detected = claudeSDKBridge.detectNodeWithDetails();
+                if (detected != null && detected.isFound() && detected.getNodePath() != null) {
+                    String detectedPath = detected.getNodePath();
+                    props.setValue(NODE_PATH_PROPERTY_KEY, detectedPath);
+                    claudeSDKBridge.verifyAndCacheNodePath(detectedPath);
+                    codexSDKBridge.setNodeExecutable(detectedPath);
+                    LOG.info("Auto-detected and saved Node.js path: " + detectedPath);
+                }
             } else {
-                props.setValue(NODE_PATH_PROPERTY_KEY, manualPath);
-                claudeSDKBridge.setNodeExecutable(manualPath);
-                codexSDKBridge.setNodeExecutable(manualPath);
-                claudeSDKBridge.verifyAndCacheNodePath(manualPath);
-                LOG.info("Saved manual Node.js path: " + manualPath);
+                // Verify before saving to avoid caching invalid path
+                NodeDetectionResult result = claudeSDKBridge.verifyAndCacheNodePath(manualPath);
+                if (result != null && result.isFound()) {
+                    // Only save if verification succeeds
+                    props.setValue(NODE_PATH_PROPERTY_KEY, manualPath);
+                    claudeSDKBridge.setNodeExecutable(manualPath);
+                    codexSDKBridge.setNodeExecutable(manualPath);
+                    LOG.info("Saved manual Node.js path: " + manualPath);
+                } else {
+                    // Verification failed, show error and don't save invalid path
+                    String errorMsg = result != null ? result.getErrorMessage() : "Unknown error";
+                    LOG.warn("Node.js path verification failed: " + manualPath + " - " + errorMsg);
+                    JOptionPane.showMessageDialog(mainPanel,
+                        "Node.js path verification failed: " + errorMsg + "\n\nPath not saved.",
+                        "Invalid Node.js Path", JOptionPane.WARNING_MESSAGE);
+                    return; // Don't reinitialize UI, let user try again
+                }
             }
 
             ApplicationManager.getApplication().invokeLater(() -> {


### PR DESCRIPTION
Prevent invalid Node.js paths from being persisted and keep bridge state in sync when users save a verified manual path.