### PR TITLE
feat: configurable tab status indicator

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/ProjectConfigHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/ProjectConfigHandler.java
@@ -344,6 +344,34 @@ public class ProjectConfigHandler {
         }
     }
 
+    private static final String TAB_STATUS_INDICATOR_KEY = "claude.code.tab.status.indicator";
+
+    public void handleGetTabStatusIndicator() {
+        boolean enabled = PropertiesComponent.getInstance().getBoolean(TAB_STATUS_INDICATOR_KEY, true);
+        ApplicationManager.getApplication().invokeLater(() -> {
+            JsonObject r = new JsonObject();
+            r.addProperty("tabStatusIndicatorEnabled", enabled);
+            context.callJavaScript("window.updateTabStatusIndicator", context.escapeJs(gson.toJson(r)));
+        });
+    }
+
+    public void handleSetTabStatusIndicator(String content) {
+        try {
+            JsonObject json = gson.fromJson(content, JsonObject.class);
+            boolean enabled = json == null || !json.has("tabStatusIndicatorEnabled")
+                || json.get("tabStatusIndicatorEnabled").getAsBoolean();
+            PropertiesComponent.getInstance().setValue(TAB_STATUS_INDICATOR_KEY, enabled, true);
+            LOG.info("[ProjectConfigHandler] Set tab status indicator: " + enabled);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                JsonObject r = new JsonObject();
+                r.addProperty("tabStatusIndicatorEnabled", enabled);
+                context.callJavaScript("window.updateTabStatusIndicator", context.escapeJs(gson.toJson(r)));
+            });
+        } catch (Exception e) {
+            LOG.error("[ProjectConfigHandler] Failed to set tab status indicator: " + e.getMessage(), e);
+        }
+    }
+
     /** Get usage statistics. Supports both Claude and Codex providers. */
     public void handleGetUsageStatistics(String content) {
         CompletableFuture.runAsync(() -> {

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -44,6 +44,8 @@ public class SettingsHandler extends BaseMessageHandler {
         "set_send_shortcut",
         "get_auto_open_file_enabled",
         "set_auto_open_file_enabled",
+        "get_tab_status_indicator",
+        "set_tab_status_indicator",
         "get_ide_theme",
         "get_commit_prompt",
         "set_commit_prompt",
@@ -153,6 +155,12 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "set_auto_open_file_enabled":
                 projectConfigHandler.handleSetAutoOpenFileEnabled(content);
+                return true;
+            case "get_tab_status_indicator":
+                projectConfigHandler.handleGetTabStatusIndicator();
+                return true;
+            case "set_tab_status_indicator":
+                projectConfigHandler.handleSetTabStatusIndicator(content);
                 return true;
             case "get_ide_theme":
                 projectConfigHandler.handleGetIdeTheme();

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -57,6 +57,7 @@ public class ChatWindowDelegate {
     private static final Logger LOG = Logger.getInstance(ChatWindowDelegate.class);
     private static final String NODE_PATH_PROPERTY_KEY = "claude.code.node.path";
     private static final String PERMISSION_MODE_PROPERTY_KEY = "claude.code.permission.mode";
+    private static final String TAB_STATUS_INDICATOR_KEY = "claude.code.tab.status.indicator";
     private static final int STATUS_RESET_DELAY_SECONDS = 5;
 
     /**
@@ -381,15 +382,21 @@ public class ChatWindowDelegate {
                 LOG.debug("[TabStatus] Detected external rename, updated originalTabName to: " + tabName);
             }
 
+            boolean indicatorEnabled = PropertiesComponent.getInstance().getBoolean(TAB_STATUS_INDICATOR_KEY, true);
+
             String displayName;
             switch (status) {
                 case ANSWERING:
-                    displayName = tabName + "...";
+                    displayName = indicatorEnabled ? tabName + "..." : tabName;
                     LOG.debug("[TabStatus] Set answering state for tab: " + displayName);
                     break;
                 case COMPLETED:
-                    String completedText = ClaudeCodeGuiBundle.message("tab.status.completed");
-                    displayName = tabName + " (" + completedText + ")";
+                    if (indicatorEnabled) {
+                        String completedText = ClaudeCodeGuiBundle.message("tab.status.completed");
+                        displayName = tabName + " (" + completedText + ")";
+                    } else {
+                        displayName = tabName;
+                    }
                     LOG.debug("[TabStatus] Set completed state for tab: " + displayName);
 
                     statusResetTask = AppExecutorUtil.getAppScheduledExecutorService().schedule(() -> {

--- a/webview/src/components/settings/BasicConfigSection/BehaviorTab.tsx
+++ b/webview/src/components/settings/BasicConfigSection/BehaviorTab.tsx
@@ -81,6 +81,8 @@ export interface BehaviorTabProps {
   onAutoOpenFileEnabledChange?: (enabled: boolean) => void;
   diffExpandedByDefault?: boolean;
   onDiffExpandedByDefaultChange?: (enabled: boolean) => void;
+  tabStatusIndicatorEnabled?: boolean;
+  onTabStatusIndicatorEnabledChange?: (enabled: boolean) => void;
   soundNotificationEnabled?: boolean;
   onSoundNotificationEnabledChange?: (enabled: boolean) => void;
   soundOnlyWhenUnfocused?: boolean;
@@ -103,6 +105,8 @@ const BehaviorTab = ({
   onAutoOpenFileEnabledChange = () => {},
   diffExpandedByDefault = false,
   onDiffExpandedByDefaultChange = () => {},
+  tabStatusIndicatorEnabled = true,
+  onTabStatusIndicatorEnabledChange = () => {},
   soundNotificationEnabled = false,
   onSoundNotificationEnabledChange = () => {},
   soundOnlyWhenUnfocused = false,
@@ -161,6 +165,30 @@ const BehaviorTab = ({
             <div className={styles.themeCardDesc}>{t('settings.basic.sendShortcut.cmdEnterDesc')}</div>
           </div>
         </div>
+      </div>
+
+      {/* Tab status indicator */}
+      <div className={styles.streamingSection}>
+        <div className={styles.fieldHeader}>
+          <span className="codicon codicon-browser" />
+          <span className={styles.fieldLabel}>Tab status indicator</span>
+        </div>
+        <label className={styles.toggleWrapper}>
+          <input
+            type="checkbox"
+            className={styles.toggleInput}
+            checked={tabStatusIndicatorEnabled}
+            onChange={(e) => onTabStatusIndicatorEnabledChange(e.target.checked)}
+          />
+          <span className={styles.toggleSlider} />
+          <span className={styles.toggleLabel}>
+            {tabStatusIndicatorEnabled ? 'Enabled' : 'Disabled'}
+          </span>
+        </label>
+        <small className={styles.formHint}>
+          <span className="codicon codicon-info" />
+          <span>Show "..." while streaming and "(Completed)" when done in the tab title</span>
+        </small>
       </div>
 
       {/* Streaming configuration */}

--- a/webview/src/components/settings/BasicConfigSection/index.tsx
+++ b/webview/src/components/settings/BasicConfigSection/index.tsx
@@ -51,6 +51,9 @@ interface BasicConfigSectionProps {
   // Diff expanded by default configuration
   diffExpandedByDefault?: boolean;
   onDiffExpandedByDefaultChange?: (enabled: boolean) => void;
+  // Tab status indicator configuration
+  tabStatusIndicatorEnabled?: boolean;
+  onTabStatusIndicatorEnabledChange?: (enabled: boolean) => void;
   // Sound notification configuration
   soundNotificationEnabled?: boolean;
   onSoundNotificationEnabledChange?: (enabled: boolean) => void;
@@ -113,6 +116,8 @@ const BasicConfigSection = (props: BasicConfigSectionProps) => {
           onAutoOpenFileEnabledChange={props.onAutoOpenFileEnabledChange}
           diffExpandedByDefault={props.diffExpandedByDefault}
           onDiffExpandedByDefaultChange={props.onDiffExpandedByDefaultChange}
+          tabStatusIndicatorEnabled={props.tabStatusIndicatorEnabled}
+          onTabStatusIndicatorEnabledChange={props.onTabStatusIndicatorEnabledChange}
           soundNotificationEnabled={props.soundNotificationEnabled}
           onSoundNotificationEnabledChange={props.onSoundNotificationEnabledChange}
           soundOnlyWhenUnfocused={props.soundOnlyWhenUnfocused}

--- a/webview/src/components/settings/hooks/useSettingsBasicActions.ts
+++ b/webview/src/components/settings/hooks/useSettingsBasicActions.ts
@@ -49,6 +49,7 @@ export interface UseSettingsBasicActionsReturn {
   soundOnlyWhenUnfocused: boolean;
   selectedSound: string;
   customSoundPath: string;
+  tabStatusIndicatorEnabled: boolean;
   diffExpandedByDefault: boolean;
   historyCompletionEnabled: boolean;
 
@@ -61,6 +62,7 @@ export interface UseSettingsBasicActionsReturn {
   handleCodexSandboxModeChange: (mode: 'workspace-write' | 'danger-full-access') => void;
   handleSendShortcutChange: (shortcut: 'enter' | 'cmdEnter') => void;
   handleAutoOpenFileEnabledChange: (enabled: boolean) => void;
+  handleTabStatusIndicatorEnabledChange: (enabled: boolean) => void;
   handleSoundNotificationEnabledChange: (enabled: boolean) => void;
   handleSoundOnlyWhenUnfocusedChange: (enabled: boolean) => void;
   handleSelectedSoundChange: (soundId: string) => void;
@@ -99,6 +101,7 @@ export interface UseSettingsBasicActionsReturn {
   /** @internal */ setSoundOnlyWhenUnfocused: (enabled: boolean) => void;
   /** @internal */ setSelectedSound: (soundId: string) => void;
   /** @internal */ setCustomSoundPath: (path: string) => void;
+  /** @internal */ setTabStatusIndicatorEnabled: (enabled: boolean) => void;
   /** @internal */ setDiffExpandedByDefault: (expanded: boolean) => void;
   /** @internal */ setHistoryCompletionEnabled: (enabled: boolean) => void;
 }
@@ -156,6 +159,9 @@ export function useSettingsBasicActions({
   const [soundOnlyWhenUnfocused, setSoundOnlyWhenUnfocused] = useState<boolean>(false);
   const [selectedSound, setSelectedSound] = useState<string>('default');
   const [customSoundPath, setCustomSoundPath] = useState<string>('');
+
+  // Tab status indicator configuration
+  const [tabStatusIndicatorEnabled, setTabStatusIndicatorEnabled] = useState<boolean>(true);
 
   // Diff expanded by default configuration (localStorage-only)
   const [diffExpandedByDefault, setDiffExpandedByDefault] = useState<boolean>(() => {
@@ -239,6 +245,12 @@ export function useSettingsBasicActions({
       sendToJava(`set_auto_open_file_enabled:${JSON.stringify(payload)}`);
     }
   }, [onAutoOpenFileEnabledChangeProp]);
+
+  // Tab status indicator toggle change handler
+  const handleTabStatusIndicatorEnabledChange = useCallback((enabled: boolean) => {
+    setTabStatusIndicatorEnabled(enabled);
+    sendToJava(`set_tab_status_indicator:${JSON.stringify({ tabStatusIndicatorEnabled: enabled })}`);
+  }, []);
 
   // Sound notification toggle change handler
   const handleSoundNotificationEnabledChange = useCallback((enabled: boolean) => {
@@ -328,6 +340,8 @@ export function useSettingsBasicActions({
     setSelectedSound,
     customSoundPath,
     setCustomSoundPath,
+    tabStatusIndicatorEnabled,
+    setTabStatusIndicatorEnabled,
     diffExpandedByDefault,
     setDiffExpandedByDefault,
     historyCompletionEnabled,
@@ -338,6 +352,7 @@ export function useSettingsBasicActions({
     handleCodexSandboxModeChange,
     handleSendShortcutChange,
     handleAutoOpenFileEnabledChange,
+    handleTabStatusIndicatorEnabledChange,
     handleSoundNotificationEnabledChange,
     handleSoundOnlyWhenUnfocusedChange,
     handleSelectedSoundChange,

--- a/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
+++ b/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
@@ -31,6 +31,8 @@ export interface SettingsWindowCallbacksDeps {
   setLoading: (loading: boolean) => void;
   setCodexLoading: (loading: boolean) => void;
   setCodexConfigLoading: (loading: boolean) => void;
+  // Tab status indicator setter
+  setTabStatusIndicatorEnabled?: (enabled: boolean) => void;
   // Sound notification setters
   setSoundNotificationEnabled?: (enabled: boolean) => void;
   setSoundOnlyWhenUnfocused?: (enabled: boolean) => void;
@@ -253,6 +255,16 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       }
     };
 
+    // Tab status indicator callback
+    window.updateTabStatusIndicator = (jsonStr: string) => {
+      try {
+        const data = JSON.parse(jsonStr);
+        d().setTabStatusIndicatorEnabled?.(data.tabStatusIndicatorEnabled ?? true);
+      } catch (error) {
+        console.error('[SettingsView] Failed to parse tab status indicator config:', error);
+      }
+    };
+
     // Agent callbacks
     const previousUpdateAgents = window.updateAgents;
     window.updateAgents = (jsonStr: string) => {
@@ -384,6 +396,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
     sendToJava('get_codex_sandbox_mode:');
     sendToJava('get_commit_prompt:');
     sendToJava('get_sound_notification_config:');
+    sendToJava('get_tab_status_indicator:');
 
     return () => {
       d().cleanupAgentsTimeout();
@@ -408,6 +421,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       }
       window.updateCommitPrompt = undefined;
       window.updateSoundNotificationConfig = undefined;
+      window.updateTabStatusIndicator = undefined;
       window.updateAgents = previousUpdateAgents;
       window.agentOperationResult = undefined;
       window.agentImportPreviewResult = undefined;

--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -129,6 +129,9 @@ const SettingsView = ({
     setSelectedSound,
     customSoundPath,
     setCustomSoundPath,
+    tabStatusIndicatorEnabled,
+    setTabStatusIndicatorEnabled,
+    handleTabStatusIndicatorEnabledChange,
     diffExpandedByDefault,
     setDiffExpandedByDefault,
     historyCompletionEnabled,
@@ -272,6 +275,7 @@ const SettingsView = ({
     addToast,
     onStreamingEnabledChangeProp,
     onSendShortcutChangeProp,
+    setTabStatusIndicatorEnabled,
     setSoundNotificationEnabled,
     setSoundOnlyWhenUnfocused,
     setSelectedSound,
@@ -410,6 +414,8 @@ const SettingsView = ({
               onUserMsgColorChange={setUserMsgColor}
               diffExpandedByDefault={diffExpandedByDefault}
               onDiffExpandedByDefaultChange={setDiffExpandedByDefault}
+              tabStatusIndicatorEnabled={tabStatusIndicatorEnabled}
+              onTabStatusIndicatorEnabledChange={handleTabStatusIndicatorEnabledChange}
               soundNotificationEnabled={soundNotificationEnabled}
               onSoundNotificationEnabledChange={handleSoundNotificationEnabledChange}
               soundOnlyWhenUnfocused={soundOnlyWhenUnfocused}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -241,6 +241,11 @@ interface Window {
   updateSoundNotificationConfig?: (json: string) => void;
 
   /**
+   * Update tab status indicator configuration
+   */
+  updateTabStatusIndicator?: (json: string) => void;
+
+  /**
    * Update current Claude config
    */
   updateCurrentClaudeConfig?: (json: string) => void;


### PR DESCRIPTION
## Summary
- Add toggle in Settings → Behavior to enable/disable tab title indicators ("..." while streaming, "(Completed)" when done)
- Default: enabled (preserves current behavior)
- Setting persists via `PropertiesComponent` (application-level, survives IDE restarts)

## Changes
**Java backend (3 files):**
- `ChatWindowDelegate.java` — reads setting on every `updateTabStatus()` call, conditionally applies suffixes
- `ProjectConfigHandler.java` — `handleGetTabStatusIndicator()` / `handleSetTabStatusIndicator()` via `PropertiesComponent`
- `SettingsHandler.java` — routes `get_tab_status_indicator` / `set_tab_status_indicator`

**Webview frontend (6 files):**
- `BehaviorTab.tsx` — toggle UI
- `BasicConfigSection/index.tsx` — props plumbing
- `settings/index.tsx` — props plumbing
- `useSettingsBasicActions.ts` — state + handler (explicit handler instead of useEffect to avoid overwriting persisted value on mount)
- `useSettingsWindowCallbacks.ts` — callback registration + initial load
- `global.d.ts` — type declaration

## Test plan
- [ ] Toggle OFF → tab title stays unchanged during streaming and after completion
- [ ] Toggle ON → "..." appears while streaming, "(Completed)" after stream ends
- [ ] Setting persists after closing/reopening Settings
- [ ] Setting persists after IDE restart