### PR TITLE
fix: cursor shows default arrow over scrollbars instead of I-beam

### DIFF
--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -7,7 +7,6 @@
     overscroll-behavior-y: contain;
     padding: 0;
     background: var(--bg-chat);
-    cursor: text;
 }
 
 /* Collapsed messages indicator */
@@ -378,6 +377,7 @@
     color: var(--text-primary);
     word-wrap: break-word;
     overflow-wrap: break-word;
+    cursor: text;
 }
 
 .message.user .markdown-content {
@@ -410,11 +410,17 @@
     line-height: var(--idea-editor-line-spacing, 1.5);
     max-width: 100%; /* 防止超出容器 */
     box-sizing: border-box; /* 包含 padding 在宽度内 */
+    cursor: default;
+
+    code {
+        cursor: text;
+    }
 }
 
 .code-block-wrapper {
     position: relative;
     margin: 10px 0;
+    cursor: default;
 
     pre {
         margin: 0;


### PR DESCRIPTION
## Summary
`cursor: text` on `.messages-container` (added in 085d06a for macOS JCEF cursor support, refined in 84e920c) is inherited by all children including scrollbars, causing the I-beam cursor to appear when hovering over horizontal scrollbars in code blocks and tables.

Fix: move `cursor: text` from `.messages-container` to `.markdown-content` (text areas only), and set `cursor: default` on scrollable containers (`pre`, `.code-block-wrapper`) with `cursor: text` on their text content (`code`). This preserves the macOS JCEF cursor mapping (Chromium still reports `cursor: text` for text areas) while preventing scrollbars from inheriting the I-beam.

## Context
- Builds on 085d06a (`fix: show correct cursor types in JCEF WebView on macOS`) which added `cursor: text` to `.messages-container`
- Builds on 84e920c (`refactor(cursor): extract CursorHandler and throttle mousemove with rAF`) which removed `cursor: text` from `body` but kept it on `.messages-container`

## Changes
- `webview/src/styles/less/components/message.less` — 5 cursor rules adjusted:
  - Remove `cursor: text` from `.messages-container`
  - Add `cursor: text` to `.markdown-content` (more granular)
  - Add `cursor: default` on `.markdown-content pre` with `cursor: text` on nested `code`
  - Add `cursor: default` on `.code-block-wrapper`

## Test plan
- [ ] Hover over horizontal scrollbar of a code block — cursor shows arrow (not I-beam)
- [ ] Hover over text in code blocks — cursor shows I-beam
- [ ] Hover over text in messages — cursor shows I-beam
- [ ] Hover over vertical chat scrollbar — cursor shows arrow
- [ ] macOS: JCEF cursor mapping still works (text areas show I-beam in Swing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)