### PR TITLE
fix(ui): move cursor updates to EDT and stop watcher threads promptly

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/CursorHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CursorHandler.java
@@ -2,9 +2,13 @@ package com.github.claudecodegui.handler;
 
 import com.github.claudecodegui.handler.core.BaseMessageHandler;
 import com.github.claudecodegui.handler.core.HandlerContext;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.ui.jcef.JBCefBrowser;
 
 import java.awt.Cursor;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JComponent;
 
 /**
@@ -16,35 +20,38 @@ public class CursorHandler extends BaseMessageHandler {
 
     private static final String[] SUPPORTED_TYPES = {"cursor_change"};
 
-    private static final Map<String, Integer> CSS_TO_SWING_CURSOR = Map.ofEntries(
-        Map.entry("text", Cursor.TEXT_CURSOR),
-        Map.entry("pointer", Cursor.HAND_CURSOR),
-        Map.entry("crosshair", Cursor.CROSSHAIR_CURSOR),
-        Map.entry("wait", Cursor.WAIT_CURSOR),
-        Map.entry("progress", Cursor.WAIT_CURSOR),
-        Map.entry("move", Cursor.MOVE_CURSOR),
-        Map.entry("grab", Cursor.MOVE_CURSOR),
-        Map.entry("grabbing", Cursor.MOVE_CURSOR),
-        Map.entry("col-resize", Cursor.E_RESIZE_CURSOR),
-        Map.entry("ew-resize", Cursor.E_RESIZE_CURSOR),
-        Map.entry("e-resize", Cursor.E_RESIZE_CURSOR),
-        Map.entry("w-resize", Cursor.E_RESIZE_CURSOR),
-        Map.entry("row-resize", Cursor.N_RESIZE_CURSOR),
-        Map.entry("ns-resize", Cursor.N_RESIZE_CURSOR),
-        Map.entry("n-resize", Cursor.N_RESIZE_CURSOR),
-        Map.entry("s-resize", Cursor.N_RESIZE_CURSOR),
-        Map.entry("nesw-resize", Cursor.NE_RESIZE_CURSOR),
-        Map.entry("ne-resize", Cursor.NE_RESIZE_CURSOR),
-        Map.entry("sw-resize", Cursor.NE_RESIZE_CURSOR),
-        Map.entry("nwse-resize", Cursor.NW_RESIZE_CURSOR),
-        Map.entry("nw-resize", Cursor.NW_RESIZE_CURSOR),
-        Map.entry("se-resize", Cursor.NW_RESIZE_CURSOR),
-        Map.entry("not-allowed", Cursor.DEFAULT_CURSOR),
-        Map.entry("no-drop", Cursor.DEFAULT_CURSOR),
-        Map.entry("help", Cursor.HAND_CURSOR),
-        Map.entry("zoom-in", Cursor.HAND_CURSOR),
-        Map.entry("zoom-out", Cursor.HAND_CURSOR)
+    private static final Map<String, Cursor> CSS_TO_SWING_CURSOR = Map.ofEntries(
+        Map.entry("text", Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR)),
+        Map.entry("pointer", Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)),
+        Map.entry("crosshair", Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR)),
+        Map.entry("wait", Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR)),
+        Map.entry("progress", Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR)),
+        Map.entry("move", Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)),
+        Map.entry("grab", Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)),
+        Map.entry("grabbing", Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR)),
+        Map.entry("col-resize", Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)),
+        Map.entry("ew-resize", Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)),
+        Map.entry("e-resize", Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)),
+        Map.entry("w-resize", Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)),
+        Map.entry("row-resize", Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
+        Map.entry("ns-resize", Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
+        Map.entry("n-resize", Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
+        Map.entry("s-resize", Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
+        Map.entry("nesw-resize", Cursor.getPredefinedCursor(Cursor.NE_RESIZE_CURSOR)),
+        Map.entry("ne-resize", Cursor.getPredefinedCursor(Cursor.NE_RESIZE_CURSOR)),
+        Map.entry("sw-resize", Cursor.getPredefinedCursor(Cursor.NE_RESIZE_CURSOR)),
+        Map.entry("nwse-resize", Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR)),
+        Map.entry("nw-resize", Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR)),
+        Map.entry("se-resize", Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR)),
+        Map.entry("not-allowed", Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)),
+        Map.entry("no-drop", Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)),
+        Map.entry("help", Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)),
+        Map.entry("zoom-in", Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)),
+        Map.entry("zoom-out", Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))
     );
+
+    private final AtomicReference<Cursor> pendingCursor = new AtomicReference<>(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+    private final AtomicBoolean updateScheduled = new AtomicBoolean(false);
 
     public CursorHandler(HandlerContext context) {
         super(context);
@@ -63,14 +70,43 @@ public class CursorHandler extends BaseMessageHandler {
         if (content == null || content.isEmpty()) {
             return true;
         }
-        int swingCursorType = CSS_TO_SWING_CURSOR.getOrDefault(content, Cursor.DEFAULT_CURSOR);
-        var browser = context.getBrowser();
-        if (browser != null) {
-            JComponent comp = browser.getComponent();
-            if (comp != null) {
-                comp.setCursor(Cursor.getPredefinedCursor(swingCursorType));
-            }
+        this.pendingCursor.set(CSS_TO_SWING_CURSOR.getOrDefault(
+                content,
+                Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)
+        ));
+        if (this.updateScheduled.compareAndSet(false, true)) {
+            ApplicationManager.getApplication().invokeLater(this::flushCursorUpdate);
         }
         return true;
+    }
+
+    private void flushCursorUpdate() {
+        if (this.context.isDisposed()) {
+            this.updateScheduled.set(false);
+            return;
+        }
+        Cursor targetCursor = this.pendingCursor.get();
+        updateCursor(targetCursor);
+        this.updateScheduled.set(false);
+        if (!this.context.isDisposed()
+                && this.pendingCursor.get() != targetCursor
+                && this.updateScheduled.compareAndSet(false, true)) {
+            ApplicationManager.getApplication().invokeLater(this::flushCursorUpdate);
+        }
+    }
+
+    private void updateCursor(Cursor targetCursor) {
+        if (this.context.isDisposed()) {
+            return;
+        }
+        JBCefBrowser browser = this.context.getBrowser();
+        if (browser == null) {
+            return;
+        }
+        JComponent comp = browser.getComponent();
+        if (targetCursor.equals(comp.getCursor())) {
+            return;
+        }
+        comp.setCursor(targetCursor);
     }
 }

--- a/src/main/java/com/github/claudecodegui/permission/PermissionRequestWatcher.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionRequestWatcher.java
@@ -61,6 +61,7 @@ class PermissionRequestWatcher {
     void stop() {
         running = false;
         if (watchThread != null) {
+            watchThread.interrupt();
             try {
                 watchThread.join(1000);
             } catch (InterruptedException e) {
@@ -100,6 +101,9 @@ class PermissionRequestWatcher {
                 dispatchFiles(planApprovalFiles, "PLAN_APPROVAL_FOUND", handler::handlePlanApprovalRequest);
 
                 Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             } catch (Exception e) {
                 debugLog.accept("POLL_ERROR", "Error in poll loop: " + e.getMessage());
                 LOG.error("Error occurred", e);


### PR DESCRIPTION
Avoid IDE freezes by coalescing cursor updates onto the EDT and skipping them after the handler context is disposed. Also interrupt permission watcher threads during shutdown so background polling exits promptly.

Fixes #781