### PR TITLE
fix: harden tool window and detached session cleanup

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
+++ b/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
@@ -44,7 +44,8 @@ public class CreateNewTabAction extends AnAction {
             return;
         }
 
-        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+                .getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
         if (toolWindow == null) {
             LOG.error("[CreateNewTabAction] Tool window not found");
             return;
@@ -61,6 +62,7 @@ public class CreateNewTabAction extends AnAction {
         Content content = contentFactory.createContent(newChatWindow.getContent(), tabName, false);
         content.setCloseable(true);
         newChatWindow.setParentContent(content);
+        content.setDisposer(newChatWindow::dispose);
 
         ContentManager contentManager = toolWindow.getContentManager();
         contentManager.addContent(content);

--- a/src/main/java/com/github/claudecodegui/handler/TabHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/TabHandler.java
@@ -6,7 +6,6 @@ import com.github.claudecodegui.handler.core.HandlerContext;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.github.claudecodegui.settings.TabStateService;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
@@ -53,10 +52,11 @@ public class TabHandler extends BaseMessageHandler {
     private void handleCreateNewTab() {
         Project project = context.getProject();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
             try {
                 // Get the tool window
-                ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+                ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+                        .getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
                 if (toolWindow == null) {
                     LOG.error("[TabHandler] Tool window not found");
                     callJavaScript("addErrorMessage", escapeJs("无法找到 CCG 工具窗口"));
@@ -88,6 +88,7 @@ public class TabHandler extends BaseMessageHandler {
                 Content content = contentFactory.createContent(newChatWindow.getContent(), tabName, false);
                 content.setCloseable(true);
                 newChatWindow.setParentContent(content);
+                content.setDisposer(newChatWindow::dispose);
 
                 contentManager.addContent(content);
                 contentManager.setSelectedContent(content);

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -18,12 +18,14 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
 import org.cef.handler.CefLoadHandlerAdapter;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
@@ -72,26 +74,6 @@ public class WebviewInitializer {
     }
 
     /**
-     * If an ai-bridge directory exists under the project root, prefer using it.
-     */
-    public void overrideBridgePathIfAvailable() {
-        try {
-            String basePath = host.getProject().getBasePath();
-            if (basePath == null) return;
-            File bridgeDir = new File(basePath, "ai-bridge");
-            File channelManager = new File(bridgeDir, "channel-manager.js");
-            if (bridgeDir.exists() && bridgeDir.isDirectory() && channelManager.exists()) {
-                host.getClaudeSDKBridge().setSdkTestDir(bridgeDir.getAbsolutePath());
-                LOG.info("Overriding ai-bridge path to project directory: " + bridgeDir.getAbsolutePath());
-            } else {
-                LOG.info("Project ai-bridge not found, using default resolver");
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to override bridge path: " + e.getMessage());
-        }
-    }
-
-    /**
      * Create and configure UI components (browser, JS bridge, drag-and-drop).
      */
     public void createUIComponents() {
@@ -110,7 +92,7 @@ public class WebviewInitializer {
                 if (ready) {
                     reinitializeAfterExtraction();
                 } else {
-                    ApplicationManager.getApplication().invokeLater(this::showErrorPanel);
+                    invokeLaterForToolWindow(this::showErrorPanel);
                 }
             });
             return;
@@ -150,7 +132,7 @@ public class WebviewInitializer {
                     if (ready) {
                         reinitializeAfterExtraction();
                     } else {
-                        ApplicationManager.getApplication().invokeLater(this::showErrorPanel);
+                        invokeLaterForToolWindow(this::showErrorPanel);
                     }
                 });
                 return;
@@ -460,11 +442,20 @@ public class WebviewInitializer {
         LOG.info("[ClaudeSDKToolWindow] Showing loading panel while bridge extracts...");
     }
 
+    private void invokeLaterForToolWindow(@NotNull Runnable runnable) {
+        Project project = this.host.getProject();
+        if (project != null && !project.isDisposed()) {
+            ToolWindowManager.getInstance(project).invokeLater(runnable);
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(runnable);
+    }
+
     /**
      * Reinitialize UI after bridge extraction completes.
      */
     private void reinitializeAfterExtraction() {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        invokeLaterForToolWindow(() -> {
             LOG.info("[ClaudeSDKToolWindow] Bridge extraction complete, reinitializing UI...");
             JPanel mainPanel = host.getMainPanel();
             mainPanel.removeAll();
@@ -483,7 +474,7 @@ public class WebviewInitializer {
 
         if (attempt >= MAX_RETRIES) {
             LOG.warn("[ClaudeSDKToolWindow] All " + MAX_RETRIES + " retry attempts failed after extraction completion");
-            ApplicationManager.getApplication().invokeLater(this::showErrorPanel);
+            invokeLaterForToolWindow(this::showErrorPanel);
             return;
         }
 
@@ -497,7 +488,7 @@ public class WebviewInitializer {
                 Thread.currentThread().interrupt();
             }
         }).thenRun(() -> {
-            ApplicationManager.getApplication().invokeLater(() -> {
+            invokeLaterForToolWindow(() -> {
                 if (host.getClaudeSDKBridge().checkEnvironment()) {
                     LOG.info("[ClaudeSDKToolWindow] Retry attempt " + (attempt + 1) + " succeeded after extraction completion");
                     reinitializeAfterExtraction();
@@ -554,7 +545,7 @@ public class WebviewInitializer {
                 }
             }
 
-            ApplicationManager.getApplication().invokeLater(() -> {
+            invokeLaterForToolWindow(() -> {
                 mainPanel.removeAll();
                 createUIComponents();
                 mainPanel.revalidate();

--- a/src/main/java/com/github/claudecodegui/ui/detached/DetachedChatFrame.java
+++ b/src/main/java/com/github/claudecodegui/ui/detached/DetachedChatFrame.java
@@ -3,20 +3,23 @@ package com.github.claudecodegui.ui.detached;
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
+import com.intellij.ide.ui.LafManager;
 import com.intellij.ide.ui.LafManagerListener;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
-import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
@@ -37,8 +40,8 @@ public class DetachedChatFrame extends JFrame {
     private final String originalTabName;
     private final int originalTabIndex;
     private final JComponent originalContent;
+    private final Disposable frameDisposable = Disposer.newDisposable("DetachedChatFrame");
     private JPanel toolbar;
-    private MessageBusConnection themeBusConnection;
     private volatile boolean disposed = false;
 
     /**
@@ -59,7 +62,7 @@ public class DetachedChatFrame extends JFrame {
         }
 
         // Get original tab index before removing from ContentManager
-        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
         if (toolWindow != null) {
             ContentManager contentManager = toolWindow.getContentManager();
             this.originalTabIndex = contentManager.getIndexOfContent(content);
@@ -156,10 +159,14 @@ public class DetachedChatFrame extends JFrame {
         updateThemeColors();
 
         // Listen for IDE theme changes to keep the detached window in sync
-        themeBusConnection = ApplicationManager.getApplication().getMessageBus().connect();
-        themeBusConnection.subscribe(LafManagerListener.TOPIC, source ->
-            ApplicationManager.getApplication().invokeLater(this::updateThemeColors)
-        );
+        ApplicationManager.getApplication().getMessageBus().connect(this.frameDisposable)
+                .subscribe(LafManagerListener.TOPIC,
+                        new LafManagerListener() {
+                            @Override
+                            public void lookAndFeelChanged(@NotNull LafManager source) {
+                                ApplicationManager.getApplication().invokeLater(DetachedChatFrame.this::updateThemeColors);
+                            }
+                        });
     }
 
     /**
@@ -213,20 +220,21 @@ public class DetachedChatFrame extends JFrame {
     public void reattachToToolWindow() {
         LOG.info("[DetachedChatFrame] Reattaching to tool window: " + originalTabName);
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        ToolWindowManager.getInstance(this.project).invokeLater(() -> {
             try {
                 // If project is disposed, cannot reattach — clean up instead
-                if (project.isDisposed()) {
+                if (this.project.isDisposed()) {
                     LOG.warn("[DetachedChatFrame] Project is disposed, cannot reattach");
                     disposeSession();
                     return;
                 }
 
-                ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+                ToolWindow toolWindow = ToolWindowManager.getInstance(this.project)
+                        .getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
                 if (toolWindow == null) {
                     LOG.error("[DetachedChatFrame] Tool window not found");
                     Messages.showErrorDialog(
-                            project,
+                            this.project,
                             ClaudeCodeGuiBundle.message("detachedWindow.reattach.error.noToolWindow"),
                             ClaudeCodeGuiBundle.message("detachedWindow.reattach.error.title")
                     );
@@ -242,7 +250,8 @@ public class DetachedChatFrame extends JFrame {
                 ContentFactory factory = ContentFactory.getInstance();
                 Content content = factory.createContent(originalContent, originalTabName, false);
                 content.setCloseable(true);
-                chatWindow.setParentContent(content);
+                content.setDisposer(this.chatWindow::dispose);
+                this.chatWindow.setParentContent(content);
 
                 // Add back to ContentManager at original index if possible
                 if (originalTabIndex >= 0 && originalTabIndex < contentManager.getContentCount()) {
@@ -260,7 +269,7 @@ public class DetachedChatFrame extends JFrame {
                 originalContent.repaint();
 
                 // Unregister from DetachedWindowManager before disposing the frame
-                DetachedWindowManager.unregisterDetached(project, chatWindow.getSessionId());
+                DetachedWindowManager.unregisterDetached(this.project, this.chatWindow.getSessionId());
 
                 // Close this window
                 dispose();
@@ -269,7 +278,7 @@ public class DetachedChatFrame extends JFrame {
             } catch (Exception e) {
                 LOG.error("[DetachedChatFrame] Error reattaching to tool window", e);
                 Messages.showErrorDialog(
-                        project,
+                        this.project,
                         ClaudeCodeGuiBundle.message("detachedWindow.reattach.error.failed") + ": " + e.getMessage(),
                         ClaudeCodeGuiBundle.message("detachedWindow.reattach.error.title")
                 );
@@ -283,39 +292,47 @@ public class DetachedChatFrame extends JFrame {
     private void disposeSession() {
         LOG.info("[DetachedChatFrame] Disposing session: " + originalTabName);
 
-        ApplicationManager.getApplication().invokeLater(() -> {
-            try {
-                // Unregister from DetachedWindowManager
-                DetachedWindowManager.unregisterDetached(project, chatWindow.getSessionId());
+        if (this.project.isDisposed()) {
+            disposeSessionImmediately(false);
+            return;
+        }
 
-                // Dispose the chat window (this will clean up all resources)
-                if (chatWindow != null) {
-                    chatWindow.dispose();
-                }
+        ToolWindowManager.getInstance(this.project).invokeLater(() -> disposeSessionImmediately(true));
+    }
 
-                // Sync TabStateService with the actual ContentManager tab count
-                // to prevent phantom tabs on next IDE restart
-                if (!project.isDisposed()) {
-                    try {
-                        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
-                        if (toolWindow != null) {
-                            int actualCount = toolWindow.getContentManager().getContentCount();
-                            com.github.claudecodegui.settings.TabStateService.getInstance(project)
-                                    .saveTabCount(actualCount);
-                        }
-                    } catch (Exception e) {
-                        LOG.warn("[DetachedChatFrame] Failed to sync tab state: " + e.getMessage());
-                    }
-                }
+    private void disposeSessionImmediately(boolean syncTabState) {
+        try {
+            // Unregister from DetachedWindowManager
+            DetachedWindowManager.unregisterDetached(this.project, this.chatWindow.getSessionId());
 
-                // Close this window
-                dispose();
+            // Dispose the chat window (this will clean up all resources)
+            this.chatWindow.dispose();
 
-                LOG.info("[DetachedChatFrame] Session disposed: " + originalTabName);
-            } catch (Exception e) {
-                LOG.error("[DetachedChatFrame] Error disposing session", e);
+            if (syncTabState && !this.project.isDisposed()) {
+                syncTabStateWithToolWindow();
             }
-        });
+
+            // Close this window
+            dispose();
+
+            LOG.info("[DetachedChatFrame] Session disposed: " + originalTabName);
+        } catch (Exception e) {
+            LOG.error("[DetachedChatFrame] Error disposing session", e);
+        }
+    }
+
+    private void syncTabStateWithToolWindow() {
+        try {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(this.project)
+                    .getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
+            if (toolWindow != null) {
+                int actualCount = toolWindow.getContentManager().getContentCount();
+                com.github.claudecodegui.settings.TabStateService.getInstance(this.project)
+                        .saveTabCount(actualCount);
+            }
+        } catch (Exception e) {
+            LOG.warn("[DetachedChatFrame] Failed to sync tab state: " + e.getMessage());
+        }
     }
 
     @Override
@@ -325,11 +342,7 @@ public class DetachedChatFrame extends JFrame {
 
         LOG.info("[DetachedChatFrame] Disposing window: " + originalTabName);
 
-        // Disconnect theme change listener
-        if (themeBusConnection != null) {
-            themeBusConnection.disconnect();
-            themeBusConnection = null;
-        }
+        Disposer.dispose(this.frameDisposable);
 
         // Remove all window listeners
         for (WindowListener listener : getWindowListeners()) {

--- a/src/main/java/com/github/claudecodegui/ui/detached/DetachedWindowManager.java
+++ b/src/main/java/com/github/claudecodegui/ui/detached/DetachedWindowManager.java
@@ -158,6 +158,28 @@ public class DetachedWindowManager {
     }
 
     /**
+     * Collect all ClaudeChatWindow instances from detached windows for a project.
+     *
+     * @param project The project
+     * @return a set of ClaudeChatWindow instances in detached windows for the project
+     */
+    @NotNull
+    public static Set<ClaudeChatWindow> getAllDetachedChatWindows(@NotNull Project project) {
+        Set<ClaudeChatWindow> windows = new HashSet<>();
+        Map<String, DetachedChatFrame> projectWindows = detachedWindows.get(projectKey(project));
+        if (projectWindows == null) {
+            return windows;
+        }
+        for (DetachedChatFrame frame : projectWindows.values()) {
+            ClaudeChatWindow chatWindow = frame.getChatWindow();
+            if (chatWindow != null) {
+                windows.add(chatWindow);
+            }
+        }
+        return windows;
+    }
+
+    /**
      * Collect all ClaudeChatWindow instances from detached windows across all projects.
      * Used by the shutdown hook to ensure all Node.js processes are cleaned up.
      *

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.jcef.JBCefBrowser;
 
@@ -245,17 +246,16 @@ public class ClaudeChatWindow {
 
         setupSessionCallbacks();
         initializeSessionInfo();
-        webviewInitializer.overrideBridgePathIfAvailable();
 
         // Delay JCEF browser creation to avoid service initialization conflicts
         // during JBCefApp$Holder class init (ProxyMigrationService dependency).
         // Operations that depend on browser readiness are also deferred.
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (!disposed) {
-                webviewInitializer.createUIComponents();
+        ToolWindowManager.getInstance(this.project).invokeLater(() -> {
+            if (!this.disposed) {
+                this.webviewInitializer.createUIComponents();
                 registerSessionLoadListener();
                 this.initialized = true;
-                LOG.info("Window instance fully initialized, project: " + project.getName());
+                LOG.info("Window instance fully initialized, project: " + this.project.getName());
             }
         });
 
@@ -321,6 +321,15 @@ public class ClaudeChatWindow {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    /**
+     * Get the project associated with this chat window.
+     *
+     * @return the current project.
+     */
+    public Project getProject() {
+        return this.project;
     }
 
     public String getSessionId() {
@@ -523,8 +532,9 @@ public class ClaudeChatWindow {
 
     // ==================== Dispose ====================
 
-    public void dispose() {
-        if (disposed) return;
+    public synchronized void dispose() {
+        if (this.disposed) return;
+        this.disposed = true;
 
         chatWindowDelegate.dispose();
         editorContextTracker.dispose();
@@ -550,7 +560,6 @@ public class ClaudeChatWindow {
 
         LOG.info("Starting window resource cleanup, project: " + project.getName());
 
-        disposed = true;
         handlerContext.setDisposed(true);
 
         if (parentContent != null) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
@@ -11,6 +11,8 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
@@ -21,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.*;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -112,6 +115,68 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         contentToWindowMap.remove(content);
     }
 
+    private static Set<ClaudeChatWindow> collectProjectChatWindows(@NotNull Project project) {
+        Set<ClaudeChatWindow> windows = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        ClaudeChatWindow mainWindow = instances.get(project);
+        if (mainWindow != null) {
+            windows.add(mainWindow);
+        }
+        for (ClaudeChatWindow window : contentToWindowMap.values()) {
+            if (window != null && project.equals(window.getProject())) {
+                windows.add(window);
+            }
+        }
+        windows.addAll(DetachedWindowManager.getAllDetachedChatWindows(project));
+        return windows;
+    }
+
+    private static Set<ClaudeChatWindow> collectAllChatWindows() {
+        Set<ClaudeChatWindow> windows = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        windows.addAll(instances.values());
+        windows.addAll(contentToWindowMap.values());
+        windows.addAll(DetachedWindowManager.getAllDetachedChatWindows());
+        return windows;
+    }
+
+    private static String resolveRestoredTabName(@NotNull TabStateService tabStateService, int index) {
+        String savedName = tabStateService.getTabName(index);
+        if (savedName != null && !savedName.isEmpty()) {
+            LOG.info("[TabManager] Restored tab " + index + " name from storage: " + savedName);
+            return savedName;
+        }
+        return TAB_NAME_PREFIX + (index + 1);
+    }
+
+    private static void cleanupWindowProcesses(@NotNull ClaudeChatWindow window) {
+        try {
+            if (window.getClaudeSDKBridge() != null) {
+                window.getClaudeSDKBridge().cleanupAllProcesses();
+            }
+            if (window.getCodexSDKBridge() != null) {
+                window.getCodexSDKBridge().cleanupAllProcesses();
+            }
+        } catch (Exception e) {
+            LOG.error("[ShutdownHook] Error cleaning up processes: " + e.getMessage(), e);
+        }
+    }
+
+    private static void disposeProjectChatWindows(@NotNull Project project) {
+        Set<ClaudeChatWindow> windows = collectProjectChatWindows(project);
+        if (windows.isEmpty()) {
+            return;
+        }
+        LOG.info("[ToolWindow] Disposing " + windows.size() + " chat window(s) for project: " + project.getName());
+        for (ClaudeChatWindow window : new HashSet<>(windows)) {
+            if (window != null && !window.isDisposed()) {
+                try {
+                    window.dispose();
+                } catch (Exception e) {
+                    LOG.error("[ToolWindow] Failed to dispose chat window for project: " + project.getName(), e);
+                }
+            }
+        }
+    }
+
     /**
      * Mark a Content as being detached (moving to a floating window).
      * This prevents the contentRemoved listener from disposing the associated ClaudeChatWindow.
@@ -158,7 +223,7 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         // Check if ai-bridge is ready
         if (BridgePreloader.isBridgeReady()) {
             LOG.info("[ToolWindow] ai-bridge ready, creating chat window directly");
-            createChatWindowContent(project, toolWindow, contentFactory, contentManager);
+            createChatWindowContent(project, contentFactory, contentManager);
         } else {
             LOG.info("[ToolWindow] ai-bridge not ready, showing loading panel");
             JPanel loadingPanel = createLoadingPanel();
@@ -173,12 +238,12 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
                     if (project.isDisposed()) return;
 
-                    ApplicationManager.getApplication().invokeLater(() -> {
+                    ToolWindowManager.getInstance(project).invokeLater(() -> {
                         if (project.isDisposed()) return;
 
                         if (ready != null && ready) {
                             LOG.info("[ToolWindow] ai-bridge ready, replacing loading panel with chat window");
-                            replaceLoadingPanelWithChatWindow(project, toolWindow, contentFactory, contentManager, loadingContent);
+                            replaceLoadingPanelWithChatWindow(project, contentFactory, contentManager, loadingContent);
                         } else {
                             LOG.error("[ToolWindow] ai-bridge preparation failed");
                             updateLoadingPanelWithError(loadingPanel, "AI Bridge preparation failed. Please restart IDE.");
@@ -186,14 +251,14 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
                     });
                 } catch (TimeoutException e) {
                     LOG.error("[ToolWindow] ai-bridge preparation timeout");
-                    ApplicationManager.getApplication().invokeLater(() -> {
+                    ToolWindowManager.getInstance(project).invokeLater(() -> {
                         if (!project.isDisposed()) {
                             updateLoadingPanelWithError(loadingPanel, "AI Bridge preparation timeout. Please restart IDE.");
                         }
                     });
                 } catch (Exception e) {
                     LOG.error("[ToolWindow] ai-bridge preparation error: " + e.getMessage());
-                    ApplicationManager.getApplication().invokeLater(() -> {
+                    ToolWindowManager.getInstance(project).invokeLater(() -> {
                         if (!project.isDisposed()) {
                             updateLoadingPanelWithError(loadingPanel, "Error: " + e.getMessage());
                         }
@@ -343,7 +408,7 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
         JLabel iconLabel = new JLabel("⚠");
         iconLabel.setFont(iconLabel.getFont().deriveFont(48f));
-        iconLabel.setForeground(Color.ORANGE);
+        iconLabel.setForeground(JBColor.ORANGE);
         iconLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
         centerPanel.add(iconLabel);
 
@@ -361,7 +426,6 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
     private void replaceLoadingPanelWithChatWindow(
             @NotNull Project project,
-            @NotNull ToolWindow toolWindow,
             ContentFactory contentFactory,
             ContentManager contentManager,
             Content loadingContent
@@ -371,41 +435,20 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         LOG.info("[TabManager] Restoring " + savedTabCount + " tabs from storage");
 
         ClaudeChatWindow firstChatWindow = new ClaudeChatWindow(project, false);
-
-        String firstTabName;
-        String savedFirstName = tabStateService.getTabName(0);
-        if (savedFirstName != null && !savedFirstName.isEmpty()) {
-            firstTabName = savedFirstName;
-            LOG.info("[TabManager] Restored tab 0 name from storage: " + firstTabName);
-        } else {
-            firstTabName = TAB_NAME_PREFIX + "1";
-        }
+        String firstTabName = resolveRestoredTabName(tabStateService, 0);
 
         loadingContent.setComponent(firstChatWindow.getContent());
         loadingContent.setDisplayName(firstTabName);
         firstChatWindow.setParentContent(loadingContent);
-
-        loadingContent.setDisposer(() -> {
-            ClaudeChatWindow window = instances.get(project);
-            if (window != null) {
-                window.dispose();
-            }
-        });
+        loadingContent.setDisposer(firstChatWindow::dispose);
 
         for (int i = 1; i < savedTabCount; i++) {
             ClaudeChatWindow chatWindow = new ClaudeChatWindow(project, true);
-
-            String tabName;
-            String savedName = tabStateService.getTabName(i);
-            if (savedName != null && !savedName.isEmpty()) {
-                tabName = savedName;
-                LOG.info("[TabManager] Restored tab " + i + " name from storage: " + tabName);
-            } else {
-                tabName = TAB_NAME_PREFIX + (i + 1);
-            }
+            String tabName = resolveRestoredTabName(tabStateService, i);
 
             Content content = contentFactory.createContent(chatWindow.getContent(), tabName, false);
             chatWindow.setParentContent(content);
+            content.setDisposer(chatWindow::dispose);
             contentManager.addContent(content);
         }
 
@@ -414,7 +457,6 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
     private void createChatWindowContent(
             @NotNull Project project,
-            @NotNull ToolWindow toolWindow,
             ContentFactory contentFactory,
             ContentManager contentManager
     ) {
@@ -425,29 +467,13 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         for (int i = 0; i < savedTabCount; i++) {
             boolean isFirstTab = (i == 0);
             ClaudeChatWindow chatWindow = new ClaudeChatWindow(project, !isFirstTab);
-
-            String tabName;
-            String savedName = tabStateService.getTabName(i);
-            if (savedName != null && !savedName.isEmpty()) {
-                tabName = savedName;
-                LOG.info("[TabManager] Restored tab " + i + " name from storage: " + tabName);
-            } else {
-                tabName = TAB_NAME_PREFIX + (i + 1);
-            }
+            String tabName = resolveRestoredTabName(tabStateService, i);
 
             Content content = contentFactory.createContent(chatWindow.getContent(), tabName, false);
             chatWindow.setParentContent(content);
             chatWindow.setOriginalTabName(tabName);
+            content.setDisposer(chatWindow::dispose);
             contentManager.addContent(content);
-
-            if (isFirstTab) {
-                content.setDisposer(() -> {
-                    ClaudeChatWindow window = instances.get(project);
-                    if (window != null) {
-                        window.dispose();
-                    }
-                });
-            }
         }
 
         updateTabCloseableState(contentManager);
@@ -465,23 +491,9 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             try {
                 Future<?> future = executor.submit(() -> {
-                    // Collect all unique windows from both maps and detached windows
-                    java.util.Set<ClaudeChatWindow> allWindows = java.util.Collections.newSetFromMap(
-                        new java.util.IdentityHashMap<>());
-                    allWindows.addAll(instances.values());
-                    allWindows.addAll(contentToWindowMap.values());
-                    allWindows.addAll(DetachedWindowManager.getAllDetachedChatWindows());
-
-                    for (ClaudeChatWindow window : allWindows) {
-                        try {
-                            if (window != null && window.getClaudeSDKBridge() != null) {
-                                window.getClaudeSDKBridge().cleanupAllProcesses();
-                            }
-                            if (window != null && window.getCodexSDKBridge() != null) {
-                                window.getCodexSDKBridge().cleanupAllProcesses();
-                            }
-                        } catch (Exception e) {
-                            LOG.error("[ShutdownHook] Error cleaning up processes: " + e.getMessage());
+                    for (ClaudeChatWindow window : collectAllChatWindows()) {
+                        if (window != null) {
+                            cleanupWindowProcesses(window);
                         }
                     }
                 });
@@ -507,20 +519,24 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
     }
 
     /**
-     * Register project closing listener to dispose all detached windows for the project.
+     * Register project closing listener to dispose all chat windows for the project.
      * This ensures proper cleanup when a project is closed.
      *
      * @param project The project to listen to
      */
     private void registerProjectCloseListener(@NotNull Project project) {
-        project.getMessageBus().connect(project).subscribe(
+        ToolWindowLifecycleDisposableService lifecycleDisposable = ToolWindowLifecycleDisposableService.getInstance(project);
+        if (!lifecycleDisposable.markProjectCloseListenerRegistered()) {
+            return;
+        }
+        project.getMessageBus().connect(lifecycleDisposable).subscribe(
                 com.intellij.openapi.project.ProjectManager.TOPIC,
                 new com.intellij.openapi.project.ProjectManagerListener() {
                     @Override
                     public void projectClosing(@NotNull Project closingProject) {
                         if (closingProject.equals(project)) {
-                            LOG.info("[ToolWindow] Project closing, disposing detached windows for: " + project.getName());
-                            DetachedWindowManager.disposeAllDetached(project);
+                            LOG.info("[ToolWindow] Project closing, disposing chat windows for: " + project.getName());
+                            disposeProjectChatWindows(project);
                         }
                     }
                 }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ToolWindowLifecycleDisposableService.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ToolWindowLifecycleDisposableService.java
@@ -1,0 +1,43 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Project-scoped disposable holder for tool window listeners.
+ */
+@Service(Service.Level.PROJECT)
+public final class ToolWindowLifecycleDisposableService implements Disposable {
+
+    private final AtomicBoolean projectCloseListenerRegistered = new AtomicBoolean(false);
+
+    public ToolWindowLifecycleDisposableService(@NotNull Project project) {
+        Objects.requireNonNull(project, "project");
+    }
+
+    /**
+     * Get the project-scoped disposable service instance.
+     */
+    public static ToolWindowLifecycleDisposableService getInstance(@NotNull Project project) {
+        return project.getService(ToolWindowLifecycleDisposableService.class);
+    }
+
+    /**
+     * Mark the project-closing listener as registered.
+     *
+     * @return true when the caller should perform registration.
+     */
+    public boolean markProjectCloseListenerRegistered() {
+        return this.projectCloseListenerRegistered.compareAndSet(false, true);
+    }
+
+    @Override
+    public void dispose() {
+        // No-op. This service provides a project-scoped disposable parent.
+    }
+}


### PR DESCRIPTION
Ensure tool window tabs own ClaudeChatWindow disposal, route tool-window UI work through ToolWindowManager, and add project-scoped cleanup so detached sessions and project shutdown release resources reliably.