### PR TITLE
fix: preserve thinking block content during streaming reconciliation

### DIFF
--- a/webview/package.json
+++ b/webview/package.json
@@ -8,7 +8,7 @@
     "prebuild": "node scripts/extract-version.mjs",
     "build": "tsc && vite build",
     "postbuild": "node scripts/copy-dist.mjs",
-    "test": "vitest run && tsc -p tsconfig.test.json --noEmit",
+    "test": "node scripts/run-tests.mjs",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/webview/scripts/run-tests.mjs
+++ b/webview/scripts/run-tests.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const forwardedArgs = process.argv.slice(2);
+
+const vitestArgs = ['vitest', 'run', ...forwardedArgs];
+const vitestResult = spawnSync('npx', vitestArgs, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (vitestResult.status !== 0) {
+  process.exit(vitestResult.status ?? 1);
+}
+
+const tscResult = spawnSync('npx', ['tsc', '-p', 'tsconfig.test.json', '--noEmit'], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+process.exit(tscResult.status ?? 1);

--- a/webview/src/ARCHITECTURE.md
+++ b/webview/src/ARCHITECTURE.md
@@ -102,7 +102,7 @@ Manages streaming message state and rendering helpers.
 - `streamingContentRef`, `isStreamingRef` - Current streaming state
 - `findLastAssistantIndex()` - Find last assistant message
 - `extractRawBlocks()` - Extract content blocks from raw message
-- `getOrCreateStreamingAssistantIndex()` - Get/create streaming message index
+- `findStreamingAssistantIndex()` - Find streaming assistant message index
 - `patchAssistantForStreaming()` - Patch message with streaming segments
 
 ### useDialogManagement

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -29,6 +29,7 @@ import { formatTime } from './utils/helpers';
 import { extractMarkdownContent } from './utils/copyUtils';
 import { applyDiffTheme, getStoredDiffTheme } from './utils/diffTheme';
 import { extractTodosFromToolUse } from './utils/todoToolNormalization';
+import { findToolResultBlock } from './utils/messageUtils';
 import type { Attachment, ChatInputBoxHandle } from './components/ChatInputBox/types';
 import { StatusPanel, StatusPanelErrorBoundary } from './components/StatusPanel';
 import { ToastContainer, type ToastMessage } from './components/Toast';
@@ -132,14 +133,14 @@ const App = () => {
 
   // ── Streaming messages ──
   const {
-    streamingContentRef, isStreamingRef, useBackendStreamingRenderRef,
+    streamingContentRef, isStreamingRef,
     streamingMessageIndexRef, streamingTextSegmentsRef, activeTextSegmentIndexRef,
     streamingThinkingSegmentsRef, activeThinkingSegmentIndexRef,
     seenToolUseCountRef, contentUpdateTimeoutRef, thinkingUpdateTimeoutRef,
     lastContentUpdateRef, lastThinkingUpdateRef, autoExpandedThinkingKeysRef,
     streamingTurnIdRef, turnIdCounterRef,
     findLastAssistantIndex, extractRawBlocks,
-    getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
+    findStreamingAssistantIndex, patchAssistantForStreaming,
   } = useStreamingMessages();
 
   // ── Toast helpers ──
@@ -237,7 +238,7 @@ const App = () => {
     setContextInfo, setSelectedAgent,
     currentProviderRef, messagesContainerRef, isUserAtBottomRef, userPausedRef,
     suppressNextStatusToastRef,
-    streamingContentRef, isStreamingRef, useBackendStreamingRenderRef,
+    streamingContentRef, isStreamingRef,
     autoExpandedThinkingKeysRef,
     streamingTextSegmentsRef, activeTextSegmentIndexRef,
     streamingThinkingSegmentsRef, activeThinkingSegmentIndexRef,
@@ -246,7 +247,7 @@ const App = () => {
     lastContentUpdateRef, contentUpdateTimeoutRef,
     lastThinkingUpdateRef, thinkingUpdateTimeoutRef,
     findLastAssistantIndex, extractRawBlocks,
-    getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
+    findStreamingAssistantIndex, patchAssistantForStreaming,
     syncActiveProviderModelMapping,
     openPermissionDialog, openAskUserQuestionDialog, openPlanApprovalDialog,
     customSessionTitleRef, currentSessionIdRef, updateHistoryTitle,
@@ -261,22 +262,9 @@ const App = () => {
   // Find tool result (stable ref to avoid re-renders)
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
-  const findToolResult = useCallback((toolUseId?: string, messageIndex?: number): ToolResultBlock | null => {
+  const findToolResult = useCallback((toolUseId?: string, messageIndex?: number, anchorMessage?: ClaudeMessage): ToolResultBlock | null => {
     if (!toolUseId || typeof messageIndex !== 'number') return null;
-    const currentMessages = messagesRef.current;
-    for (let i = 0; i < currentMessages.length; i += 1) {
-      const candidate = currentMessages[i];
-      const raw = candidate.raw;
-      if (!raw || typeof raw === 'string') continue;
-      const content = raw.content ?? raw.message?.content;
-      if (!Array.isArray(content)) continue;
-      const resultBlock = content.find(
-        (block): block is ToolResultBlock =>
-          Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
-      );
-      if (resultBlock) return resultBlock;
-    }
-    return null;
+    return findToolResultBlock(messagesRef.current, toolUseId, messageIndex, anchorMessage);
   }, []);
 
   // ── Message sender ──

--- a/webview/src/components/ChatInputBox/hooks/useChatInputAttachmentsCoordinator.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useChatInputAttachmentsCoordinator.test.ts
@@ -34,18 +34,25 @@ describe('useChatInputAttachmentsCoordinator', () => {
     expect(onRemoveAttachment).toHaveBeenCalledWith('a1');
   });
 
-  it('manages internal attachments in uncontrolled mode', () => {
+  it('manages internal attachments in uncontrolled mode', async () => {
     const originalFileReader = globalThis.FileReader;
 
-    const mockReadAsDataURL = vi.fn(function (this: FileReader) {
-      (this as unknown as { result?: string }).result = 'data:text/plain;base64,SGVsbG8=';
-      this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
-    });
-
+    // Create a proper mock FileReader that calls onload synchronously
     class MockFileReader {
-      public result: string | null = null;
+      public result: string | ArrayBuffer | null = null;
       public onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
-      readAsDataURL = mockReadAsDataURL as unknown as (blob: Blob) => void;
+      public onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+      public onabort: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+
+      readAsDataURL(_blob: Blob): void {
+        // Set result as a data URL format
+        this.result = 'data:text/plain;base64,SGVsbG8=';
+        // Call onload synchronously with a proper event object
+        if (this.onload) {
+          const event = new ProgressEvent('load') as ProgressEvent<FileReader>;
+          this.onload.call(this as unknown as FileReader, event);
+        }
+      }
     }
 
     // @ts-expect-error test override
@@ -65,7 +72,11 @@ describe('useChatInputAttachmentsCoordinator', () => {
         result.current.handleAddAttachment(list);
       });
 
-      expect(mockReadAsDataURL).toHaveBeenCalled();
+      // Wait for state update
+      await act(async () => {
+        await Promise.resolve();
+      });
+
       expect(result.current.attachments).toHaveLength(1);
 
       const attachment = result.current.attachments[0] as Attachment;

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -1,5 +1,5 @@
 import type { TFunction } from 'i18next';
-import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
+import type { ClaudeContentBlock, ClaudeMessage, ToolResultBlock } from '../../types';
 
 import MarkdownBlock from '../MarkdownBlock';
 import CollapsibleTextBlock from '../CollapsibleTextBlock';
@@ -34,6 +34,7 @@ function getExtension(fileName?: string): string {
 
 export interface ContentBlockRendererProps {
   block: ClaudeContentBlock;
+  message: ClaudeMessage;
   messageIndex: number;
   messageType: string;
   isStreaming: boolean;
@@ -43,11 +44,12 @@ export interface ContentBlockRendererProps {
   isLastBlock?: boolean;
   t: TFunction;
   onToggleThinking: () => void;
-  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
+  findToolResult: (toolId: string | undefined, messageIndex: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null | undefined;
 }
 
 export function ContentBlockRenderer({
   block,
+  message,
   messageIndex,
   messageType,
   isStreaming,
@@ -182,7 +184,7 @@ export function ContentBlockRenderer({
         <TaskExecutionBlock
           name={block.name}
           input={block.input}
-          result={findToolResult(block.id, messageIndex)}
+          result={findToolResult(block.id, messageIndex, message)}
         />
       );
     }
@@ -192,7 +194,7 @@ export function ContentBlockRenderer({
         <EditToolBlock
           name={block.name}
           input={block.input}
-          result={findToolResult(block.id, messageIndex)}
+          result={findToolResult(block.id, messageIndex, message)}
           toolId={block.id}
         />
       );
@@ -203,7 +205,7 @@ export function ContentBlockRenderer({
         <BashToolBlock
           name={block.name}
           input={block.input}
-          result={findToolResult(block.id, messageIndex)}
+          result={findToolResult(block.id, messageIndex, message)}
           toolId={block.id}
         />
       );
@@ -213,7 +215,7 @@ export function ContentBlockRenderer({
       <GenericToolBlock
         name={block.name}
         input={block.input}
-        result={findToolResult(block.id, messageIndex)}
+        result={findToolResult(block.id, messageIndex, message)}
         toolId={block.id}
       />
     );

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -28,7 +28,7 @@ export interface MessageItemProps {
   t: TFunction;
   getMessageText: (message: ClaudeMessage) => string;
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
-  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
+  findToolResult: (toolId: string | undefined, messageIndex: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null | undefined;
   extractMarkdownContent: (message: ClaudeMessage) => string;
   onNodeRef?: (id: string, node: HTMLDivElement | null) => void;
   onNavigateToProviderSettings?: () => void;
@@ -376,7 +376,7 @@ export const MessageItem = memo(function MessageItem({
           return {
             name: block.name,
             input: block.input,
-            result: findToolResult(block.id, messageIndex),
+            result: findToolResult(block.id, messageIndex, message),
           };
         });
 
@@ -401,7 +401,7 @@ export const MessageItem = memo(function MessageItem({
           return {
             name: block.name,
             input: block.input,
-            result: findToolResult(block.id, messageIndex),
+            result: findToolResult(block.id, messageIndex, message),
           };
         });
 
@@ -430,7 +430,7 @@ export const MessageItem = memo(function MessageItem({
           return {
             name: block.name,
             input: block.input,
-            result: findToolResult(block.id, messageIndex),
+            result: findToolResult(block.id, messageIndex, message),
             toolId: block.id,
           };
         });
@@ -461,7 +461,7 @@ export const MessageItem = memo(function MessageItem({
           return {
             name: block.name,
             input: block.input,
-            result: findToolResult(block.id, messageIndex),
+            result: findToolResult(block.id, messageIndex, message),
           };
         });
 
@@ -470,6 +470,7 @@ export const MessageItem = memo(function MessageItem({
             <div key={`${messageIndex}-searchgroup-${grouped.startIndex}`} className="content-block">
               <ContentBlockRenderer
                 block={grouped.blocks[0]}
+                message={message}
                 messageIndex={messageIndex}
                 messageType={message.type}
                 isStreaming={isMessageStreaming}
@@ -498,6 +499,7 @@ export const MessageItem = memo(function MessageItem({
         <div key={`${messageIndex}-${blockIndex}`} className="content-block">
           <ContentBlockRenderer
             block={block}
+            message={message}
             messageIndex={messageIndex}
             messageType={message.type}
             isStreaming={isMessageStreaming}

--- a/webview/src/components/MessageList.test.tsx
+++ b/webview/src/components/MessageList.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MessageList } from './MessageList';
+import type { ClaudeMessage, ToolResultBlock } from '../types';
+
+const messageItemSpy = vi.fn();
+
+vi.mock('./MessageItem', () => ({
+  MessageItem: ({ message, toolResultSignature }: { message: ClaudeMessage; toolResultSignature?: string }) => {
+    messageItemSpy(message, toolResultSignature);
+    return <div>{message.content}</div>;
+  },
+}));
+
+vi.mock('./WaitingIndicator', () => ({
+  default: () => <div>waiting</div>,
+}));
+
+vi.mock('./ContextMenu', () => ({
+  ContextMenu: () => null,
+}));
+
+vi.mock('../hooks/useContextMenu.js', () => ({
+  useContextMenu: () => ({
+    visible: false,
+    x: 0,
+    y: 0,
+    close: vi.fn(),
+    open: vi.fn(),
+    savedRange: null,
+    selectedText: '',
+  }),
+  copySelection: vi.fn(),
+}));
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === 'chat.showEarlierMessages') return `show ${String(options?.count)}`;
+  return key;
+}) as any;
+
+const makeMessage = (index: number, prefix: string, sessionSeed = 'a'): ClaudeMessage => ({
+  type: index % 2 === 0 ? 'user' : 'assistant',
+  content: `${prefix}-${index}`,
+  timestamp: `2026-03-31T00:${sessionSeed}:${String(index).padStart(2, '0')}Z`,
+});
+
+describe('MessageList', () => {
+  it('resets collapsed state when the first rendered message identity changes', () => {
+    const initialMessages = Array.from({ length: 18 }, (_, i) => makeMessage(i, 'session-a', '00'));
+    const nextMessages = Array.from({ length: 18 }, (_, i) => makeMessage(i, 'session-b', '01'));
+
+    const { rerender } = render(
+      <MessageList
+        messages={initialMessages}
+        streamingActive={false}
+        isThinking={false}
+        loading={false}
+        loadingStartTime={null}
+        t={t}
+        getMessageText={(message) => message.content || ''}
+        getContentBlocks={() => []}
+        findToolResult={() => null}
+        extractMarkdownContent={() => ''}
+        messagesEndRef={{ current: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('show 3'));
+    expect(screen.queryByText('show 3')).toBeNull();
+    expect(screen.getByText('session-a-0')).toBeTruthy();
+
+    rerender(
+      <MessageList
+        messages={nextMessages}
+        streamingActive={false}
+        isThinking={false}
+        loading={false}
+        loadingStartTime={null}
+        t={t}
+        getMessageText={(message) => message.content || ''}
+        getContentBlocks={() => []}
+        findToolResult={() => null}
+        extractMarkdownContent={() => ''}
+        messagesEndRef={{ current: null }}
+      />,
+    );
+
+    expect(screen.getByText('show 3')).toBeTruthy();
+    expect(screen.queryByText('session-b-0')).toBeNull();
+  });
+
+  it('computes tool result signature using the rendered message as anchor', () => {
+    messageItemSpy.mockClear();
+    const assistantMessage: ClaudeMessage = {
+      type: 'assistant',
+      content: 'tool call',
+      __turnId: 7,
+      raw: {
+        message: {
+          content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: {} }],
+        },
+      } as any,
+    };
+
+    const findToolResult = vi.fn<(...args: [string | undefined, number, ClaudeMessage?]) => ToolResultBlock | null>(() => ({
+      type: 'tool_result',
+      tool_use_id: 'tool-1',
+      content: 'done',
+    }));
+
+    render(
+      <MessageList
+        messages={[assistantMessage]}
+        streamingActive={false}
+        isThinking={false}
+        loading={false}
+        loadingStartTime={null}
+        t={t}
+        getMessageText={(message) => message.content || ''}
+        getContentBlocks={() => [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: {} }]}
+        findToolResult={findToolResult}
+        extractMarkdownContent={() => ''}
+        messagesEndRef={{ current: null }}
+      />,
+    );
+
+    expect(findToolResult).toHaveBeenCalledWith('tool-1', 0, assistantMessage);
+    expect(messageItemSpy).toHaveBeenCalledWith(
+      assistantMessage,
+      'tool-1:ok:4:done',
+    );
+  });
+});

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -31,7 +31,7 @@ function getMessageToolResultSignature(
   message: ClaudeMessage,
   messageIndex: number,
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
-  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined,
+  findToolResult: (toolId: string | undefined, messageIndex: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null | undefined,
 ): string {
   const toolUses = getContentBlocks(message).filter(
     (block): block is Extract<ClaudeContentBlock, { type: 'tool_use' }> => block.type === 'tool_use',
@@ -39,7 +39,7 @@ function getMessageToolResultSignature(
   if (toolUses.length === 0) return '';
 
   return toolUses
-    .map((block) => `${block.id ?? 'unknown'}:${extractToolResultPreview(findToolResult(block.id, messageIndex))}`)
+    .map((block) => `${block.id ?? 'unknown'}:${extractToolResultPreview(findToolResult(block.id, messageIndex, message))}`)
     .join('|');
 }
 
@@ -52,7 +52,7 @@ interface MessageListProps {
   t: TFunction;
   getMessageText: (message: ClaudeMessage) => string;
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
-  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
+  findToolResult: (toolId: string | undefined, messageIndex: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null | undefined;
   extractMarkdownContent: (message: ClaudeMessage) => string;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
   onMessageNodeRef?: (id: string, node: HTMLDivElement | null) => void;
@@ -88,15 +88,15 @@ export const MessageList = memo(function MessageList({
     }
   }, [ctxMenu.open]);
 
-  // Reset showAll when a new session starts (first message ID changes)
-  const firstMsgIdRef = useRef(messages[0]?.id);
+  // Reset showAll when a new session starts (first rendered message identity changes)
+  const firstMessageKey = messages[0] ? getMessageKey(messages[0], 0) : undefined;
+  const firstMsgIdRef = useRef(firstMessageKey);
   useEffect(() => {
-    const currentFirstId = messages[0]?.id;
-    if (currentFirstId !== firstMsgIdRef.current) {
+    if (firstMessageKey !== firstMsgIdRef.current) {
       setShowAll(false);
     }
-    firstMsgIdRef.current = currentFirstId;
-  }, [messages]);
+    firstMsgIdRef.current = firstMessageKey;
+  }, [firstMessageKey]);
 
   const shouldCollapse = !showAll && messages.length > VISIBLE_MESSAGE_WINDOW;
   const collapsedCount = shouldCollapse ? messages.length - VISIBLE_MESSAGE_WINDOW : 0;

--- a/webview/src/hooks/toolResultAnchoring.test.ts
+++ b/webview/src/hooks/toolResultAnchoring.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ClaudeContentBlock, ClaudeMessage, ToolResultBlock } from '../types';
+import { useSubagents } from './useSubagents';
+import { useFileChanges } from './useFileChanges';
+
+function makeAssistantMessage(content: ClaudeContentBlock[], extra?: Partial<ClaudeMessage>): ClaudeMessage {
+  return {
+    type: 'assistant',
+    raw: { message: { content } } as any,
+    ...extra,
+  };
+}
+
+describe('tool result anchor regressions', () => {
+  it('useSubagents passes the assistant message as anchor when resolving task status', () => {
+    const assistant = makeAssistantMessage([
+      {
+        type: 'tool_use',
+        id: 'task-1',
+        name: 'Task',
+        input: {
+          subagent_type: 'Explore',
+          description: 'Inspect history hydration',
+          prompt: 'Check tool result resolution after history load',
+        },
+      },
+    ], {
+      __turnId: 8,
+      content: 'run task',
+    });
+
+    const messages: ClaudeMessage[] = [assistant];
+    const findToolResultCalls: Array<[string | undefined, number | undefined, ClaudeMessage | undefined]> = [];
+    const completedResult: ToolResultBlock = {
+      type: 'tool_result',
+      tool_use_id: 'task-1',
+      content: 'done',
+    };
+
+    const { result } = renderHook(() => useSubagents({
+      messages,
+      getContentBlocks: (message) => ((message.raw as any)?.message?.content ?? []) as ClaudeContentBlock[],
+      findToolResult: (toolUseId, messageIndex, anchorMessage) => {
+        findToolResultCalls.push([toolUseId, messageIndex, anchorMessage]);
+        return completedResult;
+      },
+    }));
+
+    expect(findToolResultCalls).toEqual([['task-1', 0, assistant]]);
+    expect(result.current).toEqual([
+      {
+        id: 'task-1',
+        type: 'Explore',
+        description: 'Inspect history hydration',
+        prompt: 'Check tool result resolution after history load',
+        status: 'completed',
+        messageIndex: 0,
+      },
+    ]);
+  });
+
+  it('useFileChanges passes the assistant message as anchor and keeps successful history-loaded edits', () => {
+    const assistant = makeAssistantMessage([
+      {
+        type: 'tool_use',
+        id: 'edit-1',
+        name: 'Edit',
+        input: {
+          file_path: '/tmp/demo.txt',
+          old_string: 'before',
+          new_string: 'after',
+        },
+      },
+    ], {
+      __turnId: 11,
+      content: 'edit file',
+    });
+
+    const messages: ClaudeMessage[] = [assistant];
+    const findToolResultCalls: Array<[string | undefined, number | undefined, ClaudeMessage | undefined]> = [];
+    const successfulResult: ToolResultBlock = {
+      type: 'tool_result',
+      tool_use_id: 'edit-1',
+      content: 'ok',
+    };
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => ((message.raw as any)?.message?.content ?? []) as ClaudeContentBlock[],
+      findToolResult: (toolUseId, messageIndex, anchorMessage) => {
+        findToolResultCalls.push([toolUseId, messageIndex, anchorMessage]);
+        return successfulResult;
+      },
+    }));
+
+    expect(findToolResultCalls).toEqual([['edit-1', 0, assistant]]);
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      filePath: '/tmp/demo.txt',
+      fileName: 'demo.txt',
+      status: 'M',
+      additions: 1,
+      deletions: 1,
+    });
+  });
+});

--- a/webview/src/hooks/useFileChanges.ts
+++ b/webview/src/hooks/useFileChanges.ts
@@ -192,7 +192,7 @@ function isSuccessfulResult(result?: ToolResultBlock | null): boolean {
 interface UseFileChangesParams {
   messages: ClaudeMessage[];
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
-  findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
+  findToolResult: (toolUseId?: string, messageIndex?: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null;
   /** Start processing messages from this index (for Keep All feature) */
   startFromIndex?: number;
 }
@@ -235,7 +235,7 @@ export function useFileChanges({
         if (!filePath) return;
 
         // Check if operation completed successfully
-        const result = findToolResult(block.id, messageIndex);
+        const result = findToolResult(block.id, messageIndex, message);
         if (!isSuccessfulResult(result)) return;
 
         const { oldString, newString, replaceAll } = extractStrings(input);

--- a/webview/src/hooks/useStreamingMessages.ts
+++ b/webview/src/hooks/useStreamingMessages.ts
@@ -1,13 +1,279 @@
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import type { ClaudeMessage } from '../types';
+import { normalizeStreamingNewlines } from './windowCallbacks/messageSync';
 
 export const THROTTLE_INTERVAL = 50; // 50ms throttle interval
+
+/**
+ * Base content block types that appear in assistant messages.
+ * These are the streaming blocks that get rebuilt during reconciliation.
+ */
+export type StreamingContentBlock =
+  | { type: 'thinking'; thinking: string }
+  | { type: 'text'; text: string };
+
+/**
+ * Stable backend block types that are preserved during streaming reconciliation.
+ * These blocks (tool_use, tool_result, custom) are not rebuilt and serve as anchors.
+ *
+ * NOTE: The catch-all branch uses `string & Record<never, never>` instead of plain
+ * `string` to prevent TypeScript from collapsing the `ContentBlock` union — a plain
+ * `string` type field would absorb `StreamingContentBlock`'s literal types ('thinking'
+ * | 'text'), defeating compile-time discrimination. Runtime correctness is enforced
+ * by `isStreamingBlock` / `isStableBackendBlock` guard functions regardless.
+ */
+export type StableBackendBlock =
+  | { type: 'tool_use'; id: string; name: string; input?: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string | unknown[]; is_error?: boolean }
+  | { type: string & Record<never, never>; [key: string]: unknown };
+
+/**
+ * Union type for all possible content blocks in an assistant message.
+ */
+export type ContentBlock = StreamingContentBlock | StableBackendBlock;
+
+/**
+ * State object passed to patchAssistantForStreaming for deterministic block rebuilding.
+ * All fields are optional - missing fields are derived from current streaming refs.
+ */
+export interface StreamingPatchState {
+  /** Canonical text content (preferred over streamingContentRef.current) */
+  canonicalText?: string;
+  /** Canonical thinking content (preferred over streamingThinkingSegmentsRef) */
+  canonicalThinking?: string;
+  /** Existing blocks to preserve stable backend blocks (tool_use, tool_result, etc.) */
+  existingBlocks?: ContentBlock[];
+}
+
+// ---------------------------------------------------------------------------
+// Module-level pure utility functions for block type classification.
+// Extracted from the hook to avoid per-render recreation (rerender-use-ref-transient-values)
+// and enable independent testing.
+// ---------------------------------------------------------------------------
+
+/** Check if a thinking block has meaningful (non-whitespace) content. */
+const hasMeaningfulThinking = (thinking: string): boolean => thinking.trim().length > 0;
+
+/** Check if a block is a streaming content block (thinking or text). */
+export const isStreamingBlock = (block: unknown): block is StreamingContentBlock => {
+  return !!block && typeof block === 'object' && ((block as StreamingContentBlock).type === 'thinking' || (block as StreamingContentBlock).type === 'text');
+};
+
+/** Check if a block is a stable backend block (not thinking or text). */
+export const isStableBackendBlock = (block: unknown): block is StableBackendBlock => {
+  return !!block && typeof block === 'object' && !isStreamingBlock(block);
+};
+
+// ---------------------------------------------------------------------------
+// Module-level pure block-building functions (S2: split dual-mode logic).
+// Hoisted out of the hook body to avoid per-render recreation
+// (rerender-use-ref-transient-values, rendering-hoist-jsx).
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple (non-interleaved) mode: rebuild canonical blocks in the middle.
+ * Stable blocks are partitioned into prefix (before any streaming block)
+ * and suffix (after any streaming block), with canonical thinking and text
+ * blocks placed in between.
+ */
+const buildSimpleStreamingBlocks = (
+  existingBlocks: ContentBlock[],
+  canonicalText: string,
+  canonicalThinking: string,
+): ContentBlock[] => {
+  const canonicalBlocks: ContentBlock[] = [];
+  if (hasMeaningfulThinking(canonicalThinking)) {
+    canonicalBlocks.push({ type: 'thinking', thinking: canonicalThinking });
+  }
+  if (canonicalText.length > 0) {
+    canonicalBlocks.push({ type: 'text', text: canonicalText });
+  }
+
+  const stablePrefix: ContentBlock[] = [];
+  const stableSuffix: ContentBlock[] = [];
+  const existingStreamingBlocks: ContentBlock[] = [];
+  let encounteredStreamingBlock = false;
+  let existingThinking = '';
+  let existingText = '';
+
+  existingBlocks.forEach((block) => {
+    if (!block || typeof block !== 'object') return;
+
+    if (isStreamingBlock(block)) {
+      encounteredStreamingBlock = true;
+      existingStreamingBlocks.push(block);
+      if (block.type === 'thinking') {
+        existingThinking += block.thinking || '';
+      } else if (block.type === 'text') {
+        existingText += block.text || '';
+      }
+      return;
+    }
+
+    if (!isStableBackendBlock(block)) return;
+
+    if (encounteredStreamingBlock) {
+      stableSuffix.push(block);
+    } else {
+      stablePrefix.push(block);
+    }
+  });
+
+  const trailingBlocks: ContentBlock[] = [];
+  const canAppendTrailingThinking =
+    stableSuffix.length > 0 &&
+    hasMeaningfulThinking(canonicalThinking) &&
+    existingThinking.length > 0 &&
+    canonicalThinking.startsWith(existingThinking) &&
+    canonicalThinking.length > existingThinking.length;
+  const canAppendTrailingText =
+    stableSuffix.length > 0 &&
+    canonicalText.length > 0 &&
+    existingText.length > 0 &&
+    canonicalText.startsWith(existingText) &&
+    canonicalText.length > existingText.length;
+
+  if (canAppendTrailingThinking) {
+    trailingBlocks.push({
+      type: 'thinking',
+      thinking: canonicalThinking.slice(existingThinking.length),
+    });
+  }
+  if (canAppendTrailingText) {
+    trailingBlocks.push({
+      type: 'text',
+      text: canonicalText.slice(existingText.length),
+    });
+  }
+
+  if (trailingBlocks.length > 0) {
+    return [...stablePrefix, ...existingStreamingBlocks, ...stableSuffix, ...trailingBlocks];
+  }
+
+  return [...stablePrefix, ...canonicalBlocks, ...stableSuffix];
+};
+
+/**
+ * Interleaved mode: preserve the original block ordering from the backend.
+ * Each block keeps its existing content; only the LAST thinking and LAST text
+ * block may be extended with newly streamed content that the backend snapshot
+ * has not yet reflected.
+ */
+const buildInterleavedStreamingBlocks = (
+  existingBlocks: ContentBlock[],
+  canonicalText: string,
+  canonicalThinking: string,
+  lastThinkingIdx: number,
+  lastTextIdx: number,
+): ContentBlock[] => {
+  // Shallow-copy the array only (not individual elements) — only the two slots
+  // at lastThinkingIdx / lastTextIdx are overwritten with new objects below;
+  // all other elements are never mutated, so per-element cloning is wasteful.
+  const result = [...existingBlocks];
+
+  // Update the last thinking block
+  if (lastThinkingIdx >= 0 && hasMeaningfulThinking(canonicalThinking)) {
+    let priorThinking = '';
+    for (let i = 0; i < lastThinkingIdx; i += 1) {
+      const b = result[i];
+      if (b && typeof b === 'object' && b.type === 'thinking') {
+        // ContentBlock union: thinking blocks have either `thinking` or `text` field.
+        const tb = b as StreamingContentBlock & { type: 'thinking'; text?: string };
+        priorThinking += tb.thinking || tb.text || '';
+      }
+    }
+    if (canonicalThinking.startsWith(priorThinking) && canonicalThinking.length > priorThinking.length) {
+      const trailingThinking = canonicalThinking.slice(priorThinking.length);
+      result[lastThinkingIdx] = { type: 'thinking', thinking: trailingThinking } as ContentBlock;
+    }
+    // else: keep backend value (canonical doesn't extend prior — likely a correction)
+  }
+
+  // Update the last text block
+  if (lastTextIdx >= 0 && canonicalText.length > 0) {
+    let priorText = '';
+    for (let i = 0; i < lastTextIdx; i += 1) {
+      const b = result[i];
+      if (b && typeof b === 'object' && b.type === 'text') {
+        priorText += (b as StreamingContentBlock & { type: 'text' }).text || '';
+      }
+    }
+    if (canonicalText.startsWith(priorText) && canonicalText.length > priorText.length) {
+      const trailingText = canonicalText.slice(priorText.length);
+      result[lastTextIdx] = { type: 'text', text: trailingText } as ContentBlock;
+    }
+    // else: keep backend value
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Shared ref-clearing utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Refs that hold streaming data (not throttle timing).
+ * Used by `clearStreamingDataRefs` to reset refs from multiple call-sites
+ * (resetStreamingState, onStreamEnd) without duplicating the reset list.
+ */
+export interface StreamingDataRefs {
+  streamingContentRef: React.MutableRefObject<string>;
+  streamingTextSegmentsRef: React.MutableRefObject<string[]>;
+  activeTextSegmentIndexRef: React.MutableRefObject<number>;
+  streamingThinkingSegmentsRef: React.MutableRefObject<string[]>;
+  activeThinkingSegmentIndexRef: React.MutableRefObject<number>;
+  seenToolUseCountRef: React.MutableRefObject<number>;
+  streamingMessageIndexRef: React.MutableRefObject<number>;
+  streamingTurnIdRef: React.MutableRefObject<number>;
+  autoExpandedThinkingKeysRef: React.MutableRefObject<Set<string>>;
+}
+
+/**
+ * Reset all streaming data refs to their initial values.
+ * Idempotent — safe under React StrictMode double-invocation.
+ * Does NOT clear throttle timing refs (lastContentUpdateRef, etc.) or timeouts;
+ * callers that need a full reset should clear those separately.
+ */
+export const clearStreamingDataRefs = (refs: StreamingDataRefs): void => {
+  refs.streamingContentRef.current = '';
+  refs.streamingTextSegmentsRef.current = [];
+  refs.activeTextSegmentIndexRef.current = -1;
+  refs.streamingThinkingSegmentsRef.current = [];
+  refs.activeThinkingSegmentIndexRef.current = -1;
+  refs.seenToolUseCountRef.current = 0;
+  refs.streamingMessageIndexRef.current = -1;
+  refs.streamingTurnIdRef.current = -1;
+  refs.autoExpandedThinkingKeysRef.current.clear();
+};
+
+// ---------------------------------------------------------------------------
+// Module-level pure helper functions.
+// Extracted from the hook body so they are created once per module load,
+// not on every render (rendering-hoist-jsx, rerender-use-ref-transient-values).
+// ---------------------------------------------------------------------------
+
+/** Find the index of the last assistant message in a list. */
+export const findLastAssistantIndex = (list: ClaudeMessage[]): number => {
+  for (let i = list.length - 1; i >= 0; i -= 1) {
+    if (list[i]?.type === 'assistant') return i;
+  }
+  return -1;
+};
+
+/** Extract content blocks from a raw message object. */
+export const extractRawBlocks = (raw: unknown): ContentBlock[] => {
+  if (!raw || typeof raw !== 'object') return [];
+  const rawObj = raw as Record<string, unknown>;
+  const messageObj = rawObj.message as Record<string, unknown> | undefined;
+  const blocks = rawObj.content ?? messageObj?.content;
+  return Array.isArray(blocks) ? (blocks as ContentBlock[]) : [];
+};
 
 interface UseStreamingMessagesReturn {
   // Content refs
   streamingContentRef: React.MutableRefObject<string>;
   isStreamingRef: React.MutableRefObject<boolean>;
-  useBackendStreamingRenderRef: React.MutableRefObject<boolean>;
   streamingMessageIndexRef: React.MutableRefObject<number>;
 
   // Text segment refs
@@ -36,10 +302,10 @@ interface UseStreamingMessagesReturn {
 
   // Helper functions
   findLastAssistantIndex: (list: ClaudeMessage[]) => number;
-  extractRawBlocks: (raw: unknown) => any[];
-  buildStreamingBlocks: (existingBlocks: any[]) => any[];
-  getOrCreateStreamingAssistantIndex: (list: ClaudeMessage[]) => number;
-  patchAssistantForStreaming: (assistant: ClaudeMessage) => ClaudeMessage;
+  extractRawBlocks: (raw: unknown) => ContentBlock[];
+  buildStreamingBlocks: (existingBlocks: ContentBlock[], patchState?: StreamingPatchState) => ContentBlock[];
+  findStreamingAssistantIndex: (list: ClaudeMessage[]) => number;
+  patchAssistantForStreaming: (assistant: ClaudeMessage, patchState?: StreamingPatchState) => ClaudeMessage;
 
   // Reset function
   resetStreamingState: () => void;
@@ -52,14 +318,21 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
   // Content refs
   const streamingContentRef = useRef('');
   const isStreamingRef = useRef(false);
-  const useBackendStreamingRenderRef = useRef(false);
   const streamingMessageIndexRef = useRef<number>(-1);
 
   // Text segment refs
+  // NOTE: Currently operates in single-element mode — segments[0] always holds the
+  // full accumulated text (same value as streamingContentRef.current). The array
+  // structure is retained for forward compatibility with future multi-segment support
+  // (e.g., text segments separated by tool_use blocks), but callers should not assume
+  // actual segmentation semantics today.
   const streamingTextSegmentsRef = useRef<string[]>([]);
   const activeTextSegmentIndexRef = useRef<number>(-1);
 
   // Thinking segment refs
+  // NOTE: Same single-element mode as text segments above. segments[0] holds the
+  // full accumulated thinking content. See Decision 3 in design.md — single thinking
+  // block per turn until the bridge exposes explicit block lifecycle signals.
   const streamingThinkingSegmentsRef = useRef<string[]>([]);
   const activeThinkingSegmentIndexRef = useRef<number>(-1);
 
@@ -79,145 +352,166 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
   const streamingTurnIdRef = useRef(-1);
   const turnIdCounterRef = useRef(0);
 
-  // Helper: Find last assistant message index
-  const findLastAssistantIndex = (list: ClaudeMessage[]): number => {
-    for (let i = list.length - 1; i >= 0; i -= 1) {
-      if (list[i]?.type === 'assistant') return i;
+  /**
+   * Build streaming blocks by dispatching to mode-specific module-level functions.
+   * Thin wrapper that computes default values from refs when patchState is incomplete.
+   * The actual logic lives in `buildSimpleStreamingBlocks` and
+   * `buildInterleavedStreamingBlocks` (module level, created once per module load).
+   */
+  // useCallback: buildStreamingBlocks reads refs (not state), so deps are empty.
+  // Prevents reference changes on every render for consumers that may shallow-compare (I1).
+  const buildStreamingBlocks = useCallback((existingBlocks: ContentBlock[], patchState?: StreamingPatchState): ContentBlock[] => {
+    const canonicalThinking = normalizeStreamingNewlines(
+      patchState?.canonicalThinking ?? streamingThinkingSegmentsRef.current.join(''),
+    );
+    const canonicalText = patchState?.canonicalText ?? streamingContentRef.current;
+
+    // Early exit: arrays with ≤ 2 blocks cannot be interleaved (I2: js-early-exit + js-length-check-first).
+    // Interleaving requires at least 3 blocks (e.g. [thinking, tool_use, thinking]).
+    if (existingBlocks.length <= 2) {
+      return buildSimpleStreamingBlocks(existingBlocks, canonicalText, canonicalThinking);
     }
-    return -1;
-  };
 
-  // Helper: Extract raw blocks from message
-  const extractRawBlocks = (raw: unknown): any[] => {
-    if (!raw || typeof raw !== 'object') return [];
-    const rawObj: any = raw;
-    const blocks = rawObj.content ?? rawObj.message?.content;
-    return Array.isArray(blocks) ? blocks : [];
-  };
+    // Detect interleaved structure in a strict O(n) single pass using tracking flags
+    // instead of nested inner loops (S1: avoids O(n²) worst-case from B1 review).
+    let thinkingBlockCount = 0;
+    let textBlockCount = 0;
+    let hasStableBetweenThinkingBlocks = false;
+    let hasStableBetweenTextBlocks = false;
+    let sawStableSinceLastThinking = false;
+    let sawStableSinceLastText = false;
+    let lastThinkingIdx = -1;
+    let lastTextIdx = -1;
 
-  const normalizeThinking = (thinking: string): string => {
-    return thinking
-      .replace(/\r\n?/g, '\n')
-      .replace(/\n[ \t]*\n+/g, '\n')
-      .replace(/^\n+/, '')
-      .replace(/\n+$/, '');
-  };
+    for (let i = 0; i < existingBlocks.length; i += 1) {
+      const block = existingBlocks[i];
+      if (!block || typeof block !== 'object') continue;
 
-  // Helper: Build streaming blocks from segments
-  const buildStreamingBlocks = (existingBlocks: any[]): any[] => {
-    const textSegments = streamingTextSegmentsRef.current;
-    const thinkingSegments = streamingThinkingSegmentsRef.current;
-
-    const output: any[] = [];
-    let thinkingIdx = 0;
-    let textIdx = 0;
-
-    for (const block of existingBlocks) {
-      if (!block || typeof block !== 'object') {
-        continue;
-      }
+      // Check specific streaming types first, then classify everything else as stable.
+      // Avoids TypeScript narrowing ContentBlock to `never` after isStableBackendBlock
+      // guard (the catch-all StableBackendBlock structurally subsumes StreamingContentBlock).
       if (block.type === 'thinking') {
-        const thinking = thinkingSegments[thinkingIdx];
-        thinkingIdx += 1;
-        if (typeof thinking === 'string' && thinking.length > 0) {
-          const normalized = normalizeThinking(thinking);
-          if (normalized.length > 0) {
-            output.push({ type: 'thinking', thinking: normalized });
-          }
-        }
-        continue;
-      }
-      if (block.type === 'text') {
-        const text = textSegments[textIdx];
-        textIdx += 1;
-        if (typeof text === 'string' && text.length > 0) {
-          output.push({ type: 'text', text });
-        }
-        continue;
-      }
-
-      output.push(block);
-    }
-
-    const phasesCount = Math.max(textSegments.length, thinkingSegments.length);
-    const appendFromPhase = Math.max(textIdx, thinkingIdx);
-    for (let phase = appendFromPhase; phase < phasesCount; phase += 1) {
-      const thinking = thinkingSegments[phase];
-      if (typeof thinking === 'string' && thinking.length > 0) {
-        const normalized = normalizeThinking(thinking);
-        if (normalized.length > 0) {
-          output.push({ type: 'thinking', thinking: normalized });
-        }
-      }
-      const text = textSegments[phase];
-      if (typeof text === 'string' && text.length > 0) {
-        output.push({ type: 'text', text });
+        thinkingBlockCount += 1;
+        if (sawStableSinceLastThinking) hasStableBetweenThinkingBlocks = true;
+        sawStableSinceLastThinking = false;
+        lastThinkingIdx = i;
+      } else if (block.type === 'text') {
+        textBlockCount += 1;
+        if (sawStableSinceLastText) hasStableBetweenTextBlocks = true;
+        sawStableSinceLastText = false;
+        lastTextIdx = i;
+      } else {
+        // Any non-thinking, non-text block is a stable backend block.
+        if (lastThinkingIdx >= 0) sawStableSinceLastThinking = true;
+        if (lastTextIdx >= 0) sawStableSinceLastText = true;
       }
     }
 
-    return output;
-  };
+    const hasInterleavedStructure =
+      (thinkingBlockCount > 1 && hasStableBetweenThinkingBlocks) ||
+      (textBlockCount > 1 && hasStableBetweenTextBlocks);
+
+    if (hasInterleavedStructure) {
+      return buildInterleavedStreamingBlocks(
+        existingBlocks, canonicalText, canonicalThinking, lastThinkingIdx, lastTextIdx,
+      );
+    }
+
+    return buildSimpleStreamingBlocks(existingBlocks, canonicalText, canonicalThinking);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
-   * Get or create streaming assistant message index.
-   * NOTE: This function MUTATES the passed list array by pushing a new message
-   * if no assistant message exists. Call this only with a copied array (e.g., [...prev]).
-   * @param list - Mutable message array (should be a copy, not the original state)
-   * @returns The index of the assistant message
+   * Find the streaming assistant message index in the given list.
+   * This is a pure lookup — it does NOT mutate the passed array.
+   * Returns -1 if no assistant message is found; callers should handle this
+   * via their idx bounds check and return `prev` unchanged.
+   *
+   * @sideEffect Updates `streamingMessageIndexRef` when the cached index is
+   * stale (out-of-range or pointing to a non-assistant slot). This write is
+   * idempotent — the same input always produces the same ref value — so it is
+   * safe under React StrictMode double-invocation.
+   *
+   * @param list - Read-only message array (safe to pass React state directly)
+   * @returns The index of the assistant message, or -1 if not found
    */
-  const getOrCreateStreamingAssistantIndex = (list: ClaudeMessage[]): number => {
+  const findStreamingAssistantIndex = (list: ClaudeMessage[]): number => {
     const currentIdx = streamingMessageIndexRef.current;
-    if (currentIdx >= 0 && currentIdx < list.length && list[currentIdx]?.type === 'assistant') {
-      return currentIdx;
+    if (currentIdx >= 0 && currentIdx < list.length) {
+      const current = list[currentIdx];
+      if (
+        current?.type === 'assistant' &&
+        (
+          streamingTurnIdRef.current <= 0 ||
+          current.__turnId === streamingTurnIdRef.current
+        )
+      ) {
+        return currentIdx;
+      }
     }
+
+    if (streamingTurnIdRef.current > 0) {
+      for (let i = list.length - 1; i >= 0; i -= 1) {
+        const message = list[i];
+        if (message?.type === 'assistant' && message.__turnId === streamingTurnIdRef.current) {
+          streamingMessageIndexRef.current = i;
+          return i;
+        }
+      }
+      return -1;
+    }
+
     const lastAssistantIdx = findLastAssistantIndex(list);
     if (lastAssistantIdx >= 0) {
       streamingMessageIndexRef.current = lastAssistantIdx;
       return lastAssistantIdx;
     }
-    // No assistant: append a placeholder (mutates the list)
-    streamingMessageIndexRef.current = list.length;
-    list.push({
-      type: 'assistant',
-      content: '',
-      isStreaming: true,
-      timestamp: new Date().toISOString(),
-      raw: { message: { content: [] } } as ClaudeMessage['raw'],
-    });
-    return streamingMessageIndexRef.current;
+    return -1;
   };
 
   // Helper: Patch assistant message for streaming
-  const patchAssistantForStreaming = (assistant: ClaudeMessage): ClaudeMessage => {
-    const existingRaw = (assistant.raw && typeof assistant.raw === 'object') ? (assistant.raw as any) : { message: { content: [] } };
-    const existingBlocks = extractRawBlocks(existingRaw);
-    const newBlocks = buildStreamingBlocks(existingBlocks);
+  const patchAssistantForStreaming = (
+    assistant: ClaudeMessage,
+    patchState?: StreamingPatchState,
+  ): ClaudeMessage => {
+    const existingRaw = (assistant.raw && typeof assistant.raw === 'object')
+      ? (assistant.raw as Record<string, unknown>)
+      : { message: { content: [] } } as Record<string, unknown>;
+    const existingBlocks: ContentBlock[] = patchState?.existingBlocks ?? extractRawBlocks(existingRaw);
+    const canonicalText = patchState?.canonicalText ?? streamingContentRef.current;
+    const newBlocks = buildStreamingBlocks(existingBlocks, {
+      canonicalText,
+      canonicalThinking: patchState?.canonicalThinking,
+    });
 
-    const rawPatched = existingRaw.message
-      ? { ...existingRaw, message: { ...(existingRaw.message || {}), content: newBlocks } }
+    const messageField = existingRaw.message as Record<string, unknown> | undefined;
+    const rawPatched = messageField
+      ? { ...existingRaw, message: { ...messageField, content: newBlocks } }
       : { ...existingRaw, content: newBlocks };
 
     return {
       ...assistant,
-      content: streamingContentRef.current,
-      raw: rawPatched,
+      content: canonicalText,
+      raw: rawPatched as ClaudeMessage['raw'],
       isStreaming: true,
-    } as ClaudeMessage;
+    };
   };
 
   // Reset all streaming state
   const resetStreamingState = () => {
-    streamingContentRef.current = '';
-    streamingTextSegmentsRef.current = [];
-    streamingThinkingSegmentsRef.current = [];
-    streamingMessageIndexRef.current = -1;
-    activeTextSegmentIndexRef.current = -1;
-    activeThinkingSegmentIndexRef.current = -1;
-    seenToolUseCountRef.current = 0;
+    clearStreamingDataRefs({
+      streamingContentRef,
+      streamingTextSegmentsRef,
+      activeTextSegmentIndexRef,
+      streamingThinkingSegmentsRef,
+      activeThinkingSegmentIndexRef,
+      seenToolUseCountRef,
+      streamingMessageIndexRef,
+      streamingTurnIdRef,
+      autoExpandedThinkingKeysRef,
+    });
     lastContentUpdateRef.current = 0;
     lastThinkingUpdateRef.current = 0;
-    autoExpandedThinkingKeysRef.current.clear();
-    streamingTurnIdRef.current = -1;
 
     if (contentUpdateTimeoutRef.current) {
       clearTimeout(contentUpdateTimeoutRef.current);
@@ -233,7 +527,6 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
     // Content refs
     streamingContentRef,
     isStreamingRef,
-    useBackendStreamingRenderRef,
     streamingMessageIndexRef,
 
     // Text segment refs
@@ -264,7 +557,7 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
     findLastAssistantIndex,
     extractRawBlocks,
     buildStreamingBlocks,
-    getOrCreateStreamingAssistantIndex,
+    findStreamingAssistantIndex,
     patchAssistantForStreaming,
 
     // Reset function

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -6,7 +6,7 @@ import { normalizeToolName } from '../utils/toolConstants';
 interface UseSubagentsParams {
   messages: ClaudeMessage[];
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
-  findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
+  findToolResult: (toolUseId?: string, messageIndex?: number, anchorMessage?: ClaudeMessage) => ToolResultBlock | null;
 }
 
 /**
@@ -57,7 +57,7 @@ export function useSubagents({
         const prompt = String((input.prompt as string) ?? '');
 
         // Check tool result to determine status
-        const result = findToolResult(block.id, messageIndex);
+        const result = findToolResult(block.id, messageIndex, message);
         const status = determineStatus(result);
 
         subagents.push({

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1,4 +1,7 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
+import { useStreamingMessages } from './useStreamingMessages.js';
 import { useWindowCallbacks } from './useWindowCallbacks.js';
 import type { UseWindowCallbacksOptions } from './useWindowCallbacks.js';
 import type { ClaudeMessage } from '../types/index.js';
@@ -10,6 +13,14 @@ import type { ClaudeMessage } from '../types/index.js';
  */
 describe('useWindowCallbacks integration', () => {
   const t = ((key: string) => key) as any;
+
+  const flushDeferredUpdateMessages = async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+  };
 
   /** Build the full options object with vi.fn() stubs for every field. */
   const createOptions = (overrides?: Partial<UseWindowCallbacksOptions>): UseWindowCallbacksOptions => ({
@@ -57,7 +68,6 @@ describe('useWindowCallbacks integration', () => {
     suppressNextStatusToastRef: { current: false },
     streamingContentRef: { current: '' },
     isStreamingRef: { current: false },
-    useBackendStreamingRenderRef: { current: false },
     autoExpandedThinkingKeysRef: { current: new Set<string>() },
     streamingTextSegmentsRef: { current: [] },
     activeTextSegmentIndexRef: { current: -1 },
@@ -76,8 +86,8 @@ describe('useWindowCallbacks integration', () => {
     findLastAssistantIndex: (msgs: ClaudeMessage[]) =>
       msgs.reduce((acc, m, i) => (m.type === 'assistant' ? i : acc), -1),
     extractRawBlocks: () => [],
-    getOrCreateStreamingAssistantIndex: () => 0,
-    patchAssistantForStreaming: (msg: ClaudeMessage) => msg,
+    findStreamingAssistantIndex: () => 0,
+    patchAssistantForStreaming: (msg: ClaudeMessage, _patchState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => msg,
     syncActiveProviderModelMapping: vi.fn(),
     openPermissionDialog: vi.fn(),
     openAskUserQuestionDialog: vi.fn(),
@@ -96,6 +106,15 @@ describe('useWindowCallbacks integration', () => {
     (window as any).__sessionTransitionToken = null;
     (window as any).__deniedToolIds = new Set();
     window.sendToJava = vi.fn();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   // ===== historyLoadComplete releases transition guard =====
@@ -115,6 +134,34 @@ describe('useWindowCallbacks integration', () => {
 
     expect((window as any).__sessionTransitioning).toBe(false);
     expect((window as any).__sessionTransitionToken).toBeNull();
+  });
+
+  it('historyLoadComplete clones the last message object so tool-status selectors recompute after history hydration', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      (window as any).historyLoadComplete();
+    });
+
+    expect(opts.setMessages).toHaveBeenCalled();
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const lastMessage: ClaudeMessage = {
+      type: 'assistant',
+      content: 'tool call',
+      raw: { message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] } } as any,
+    };
+    const previous: ClaudeMessage[] = [
+      { type: 'user', content: 'hi', timestamp: new Date().toISOString() },
+      lastMessage,
+    ];
+
+    const next = updater(previous);
+
+    expect(next).not.toBe(previous);
+    expect(next[0]).toBe(previous[0]);
+    expect(next[1]).not.toBe(lastMessage);
+    expect(next[1]).toEqual(lastMessage);
   });
 
   // ===== setSessionId releases transition guard =====
@@ -189,7 +236,7 @@ describe('useWindowCallbacks integration', () => {
     });
 
     expect(opts.setMessages).toHaveBeenCalledTimes(1);
-    const updater = (opts.setMessages as any).mock.calls[0][0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
     const previous: ClaudeMessage[] = [
       {
         type: 'user',
@@ -310,6 +357,1044 @@ describe('useWindowCallbacks integration', () => {
     expect(turnIdCounterRef.current).toBe(10);
   });
 
+  it('useStreamingMessages preserves meaningful blank lines inside thinking blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingThinkingSegmentsRef.current = ['line 1\n\nline 2\n\n\nline 3'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([]);
+
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'line 1\n\nline 2\n\n\nline 3' },
+    ]);
+  });
+
+  it('useStreamingMessages suppresses whitespace-only thinking blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingThinkingSegmentsRef.current = ['  \n\t\n  '];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([]);
+
+    expect(blocks).toEqual([]);
+  });
+
+  it('useStreamingMessages keeps a single thinking block when text delta interleaves between thinking deltas', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.isStreamingRef.current = true;
+      result.current.streamingThinkingSegmentsRef.current = ['first'];
+      result.current.activeThinkingSegmentIndexRef.current = 0;
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingTextSegmentsRef.current = ['answer'];
+      result.current.activeTextSegmentIndexRef.current = 0;
+    });
+
+    const blocks = result.current.buildStreamingBlocks([]);
+
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'first' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('useStreamingMessages keeps stable backend blocks anchored before canonical text when they originally appear first', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingThinkingSegmentsRef.current = ['reasoning'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'custom_block', value: 'before' },
+      { type: 'text', text: 'stale intro' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+    ] as any);
+
+    expect(blocks).toEqual([
+      { type: 'custom_block', value: 'before' },
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+    ]);
+  });
+
+  it('useStreamingMessages keeps stable backend blocks anchored between rebuilt streaming blocks and trailing stable blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingThinkingSegmentsRef.current = ['reasoning'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'stale reasoning' },
+      { type: 'custom_block', value: 'middle' },
+      { type: 'text', text: 'stale answer' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ] as any);
+
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+      { type: 'custom_block', value: 'middle' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ]);
+  });
+
+  it('useStreamingMessages patchAssistantForStreaming honors explicit canonical patch state', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'stale text';
+      result.current.streamingThinkingSegmentsRef.current = ['stale thinking'];
+    });
+
+    const patched = result.current.patchAssistantForStreaming(
+      {
+        type: 'assistant',
+        content: 'old',
+        timestamp: new Date().toISOString(),
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'old thinking' },
+              { type: 'text', text: 'old text' },
+              { type: 'tool_use', id: 'tool-1', name: 'Read' },
+            ],
+          },
+        } as any,
+      },
+      {
+        canonicalText: 'fresh text',
+        canonicalThinking: 'fresh thinking',
+        existingBlocks: [
+          { type: 'thinking', thinking: 'old thinking' },
+          { type: 'text', text: 'old text' },
+          { type: 'tool_use', id: 'tool-1', name: 'Read' },
+        ],
+      },
+    );
+
+    expect(patched.content).toBe('fresh text');
+    expect((patched.raw as any)?.message?.content).toEqual([
+      { type: 'thinking', thinking: 'fresh thinking' },
+      { type: 'text', text: 'fresh text' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+    ]);
+  });
+
+  it('updateMessages upgrades canonical text when backend snapshot exceeds local streaming buffer', () => {
+    const streamingContentRef = { current: 'abc' };
+    const streamingTextSegmentsRef = { current: ['abc'] };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef,
+      streamingThinkingSegmentsRef: { current: ['reasoning'] },
+      activeThinkingSegmentIndexRef: { current: 0 },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, _canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: streamingContentRef.current,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'reasoning' },
+              { type: 'text', text: streamingContentRef.current },
+            ],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'abcdef',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'reasoning' },
+              { type: 'text', text: 'abcdef' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'abc',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'reasoning' },
+              { type: 'text', text: 'abc' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(streamingContentRef.current).toBe('abcdef');
+    expect(streamingTextSegmentsRef.current).toEqual(['abcdef']);
+    expect(next[0].content).toBe('abcdef');
+    expect((next[0].raw as any)?.message?.content).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'abcdef' },
+    ]);
+  });
+
+  it('updateMessages upgrades canonical thinking when backend snapshot exceeds local thinking buffer', () => {
+    const streamingContentRef = { current: 'answer' };
+    const streamingThinkingSegmentsRef = { current: ['think'] };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ['answer'] },
+      activeTextSegmentIndexRef: { current: 0 },
+      streamingThinkingSegmentsRef,
+      activeThinkingSegmentIndexRef: { current: 0 },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: canonicalState?.canonicalThinking ?? streamingThinkingSegmentsRef.current[0] },
+              { type: 'text', text: canonicalState?.canonicalText ?? streamingContentRef.current },
+            ],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'thinking expanded' },
+              { type: 'text', text: 'answer' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'think' },
+              { type: 'text', text: 'answer' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(streamingThinkingSegmentsRef.current).toEqual(['thinking expanded']);
+    expect((next[0].raw as any)?.message?.content).toEqual([
+      { type: 'thinking', thinking: 'thinking expanded' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('updateMessages stamps the active turn ID onto the backend assistant before preserving identity', () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 42 },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        raw: {
+          message: {
+            content: canonicalState?.existingBlocks ?? (msg.raw as any)?.message?.content ?? [],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'backend content',
+        timestamp: '2024-01-01T00:00:01.000Z',
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'backend content' }],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'placeholder',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        __turnId: 42,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'placeholder' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next[0].__turnId).toBe(42);
+    expect(next[0].timestamp).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('updateMessages keeps the streaming assistant after the latest user message during active streaming', () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 9 },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage) => ({
+        ...msg,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      { type: 'user', content: 'new question', timestamp: '2024-01-01T00:00:01.000Z' },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      { type: 'user', content: 'old question', timestamp: '2024-01-01T00:00:00.000Z' },
+      {
+        type: 'assistant',
+        content: 'streaming answer',
+        timestamp: '2024-01-01T00:00:00.500Z',
+        __turnId: 9,
+        isStreaming: true,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next).toHaveLength(2);
+    expect(next[0].type).toBe('user');
+    expect(next[0].content).toBe('new question');
+    expect(next[1].type).toBe('assistant');
+    expect(next[1].__turnId).toBe(9);
+  });
+
+
+  it('useStreamingMessages preserves all stable backend blocks in anchored original order', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingThinkingSegmentsRef.current = ['reasoning'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'metadata', label: 'before-tool' },
+      { type: 'text', text: 'stale intro' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'custom_block', value: 42 },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ] as any);
+
+    expect(blocks).toEqual([
+      { type: 'metadata', label: 'before-tool' },
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'custom_block', value: 42 },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ]);
+  });
+
+  it('updateMessages accepts structural assistant block changes even without tool_use blocks', async () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef: { current: 'buffered answer' },
+      streamingThinkingSegmentsRef: { current: ['reasoning'] },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, _canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: 'buffered answer',
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'reasoning' },
+              { type: 'text', text: 'buffered answer' },
+            ],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'backend',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'backend reasoning' },
+              { type: 'text', text: 'backend' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+    await flushDeferredUpdateMessages();
+
+    expect(opts.setMessages).toHaveBeenCalled();
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'partial',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'partial' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next).toHaveLength(1);
+    expect(next[0].content).toBe('buffered answer');
+    expect((next[0].raw as any)?.message?.content).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'buffered answer' },
+    ]);
+  });
+
+  it('updateMessages accepts same-length text block changes while streaming', async () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingContentRef: { current: 'buffered answer' },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'backend',
+        timestamp: new Date().toISOString(),
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'axc' }],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+    await flushDeferredUpdateMessages();
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'partial',
+        timestamp: new Date().toISOString(),
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'abc' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next).not.toBe(previous);
+  });
+
+  it('updateMessages preserves local streaming content when assistant blocks are otherwise unchanged', async () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingContentRef: { current: 'buffered answer' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'backend',
+        timestamp: new Date().toISOString(),
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'backend' }],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+    await flushDeferredUpdateMessages();
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'partial',
+        timestamp: new Date().toISOString(),
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'backend' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next).not.toBe(previous);
+    expect(next).toHaveLength(1);
+    expect(next[0].content).toBe('buffered answer');
+    expect(next[0].isStreaming).toBe(true);
+  });
+
+  // ===== Interleaved block structure tests =====
+
+  it('useStreamingMessages preserves interleaved block ordering', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'stale textanswer';
+      result.current.streamingThinkingSegmentsRef.current = ['stale thinking 1reasoning'];
+    });
+
+    // Interleaved structure: [thinking, text, custom, thinking, tool_result]
+    // The last thinking block should be updated with remaining canonical content
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'stale thinking 1' },
+      { type: 'text', text: 'stale text' },
+      { type: 'custom_block', value: 'middle' },
+      { type: 'thinking', thinking: 'stale thinking 2' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ] as any);
+
+    // Interleaved mode: preserves original block order, updates last thinking/text in-place
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'stale thinking 1' },
+      { type: 'text', text: 'stale textanswer' },
+      { type: 'custom_block', value: 'middle' },
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' },
+    ]);
+  });
+
+  it('useStreamingMessages handles empty existing blocks array', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'text content';
+      result.current.streamingThinkingSegmentsRef.current = ['thinking content'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([]);
+
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'thinking content' },
+      { type: 'text', text: 'text content' },
+    ]);
+  });
+
+  it('useStreamingMessages preserves multi-turn interleaved block order from backend', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    // Simulate accumulation across 2 turns: thinking1 + thinking2, text1 + text2
+    act(() => {
+      result.current.streamingContentRef.current = 'I will read the file.Here is the result:';
+      result.current.streamingThinkingSegmentsRef.current = ['Let me check.Now let me summarize.'];
+    });
+
+    // Multi-turn backend snapshot: thinking → text → tool_use → tool_result → thinking → text
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'Let me check.' },
+      { type: 'text', text: 'I will read the file.' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+      { type: 'thinking', thinking: 'Now let me summarize.' },
+      { type: 'text', text: 'Here is the result:' },
+    ] as any);
+
+    // Should preserve original interleaved order exactly
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'Let me check.' },
+      { type: 'text', text: 'I will read the file.' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+      { type: 'thinking', thinking: 'Now let me summarize.' },
+      { type: 'text', text: 'Here is the result:' },
+    ]);
+  });
+
+  it('useStreamingMessages extends last text block when streaming adds new content', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    // Canonical text has MORE content than backend blocks (still streaming)
+    act(() => {
+      result.current.streamingContentRef.current = 'I will read the file.Here is the result: the code looks';
+      result.current.streamingThinkingSegmentsRef.current = ['Let me check.Now summarizing.'];
+    });
+
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'Let me check.' },
+      { type: 'text', text: 'I will read the file.' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+      { type: 'thinking', thinking: 'Now summarize.' },
+      { type: 'text', text: 'Here is the result:' },
+    ] as any);
+
+    // Last text block extended with streaming content; last thinking block updated from canonical
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'Let me check.' },
+      { type: 'text', text: 'I will read the file.' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+      { type: 'thinking', thinking: 'Now summarizing.' },
+      { type: 'text', text: 'Here is the result: the code looks' },
+    ]);
+  });
+
+  it('useStreamingMessages handles existing blocks with only stable blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingThinkingSegmentsRef.current = ['reasoning'];
+    });
+
+    // Only stable blocks, no streaming blocks - all stable blocks become prefix
+    // because encounteredStreamingBlock never becomes true
+    const blocks = result.current.buildStreamingBlocks([
+      { type: 'metadata', label: 'start' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+    ] as any);
+
+    // All stable blocks become prefix, canonical blocks appended at end
+    expect(blocks).toEqual([
+      { type: 'metadata', label: 'start' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('useStreamingMessages handles invalid/null blocks in existing blocks array', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'answer';
+      result.current.streamingThinkingSegmentsRef.current = ['reasoning'];
+    });
+
+    // Contains null and invalid entries
+    const blocks = result.current.buildStreamingBlocks([
+      null,
+      undefined,
+      { type: 'thinking', thinking: 'stale' },
+      null,
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      undefined,
+    ] as any);
+
+    // Should filter out null/undefined and rebuild canonical blocks
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+    ]);
+  });
+
+  it('does not append a second thinking segment into the earlier thinking block before the next thinking block is explicit', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'First answer';
+      result.current.streamingThinkingSegmentsRef.current = ['First thinkingSecond thinking'];
+    });
+
+    const output = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'First thinking' },
+      { type: 'text', text: 'First answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+    ] as any);
+
+    expect(output).toEqual([
+      { type: 'thinking', thinking: 'First thinking' },
+      { type: 'text', text: 'First answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+      { type: 'thinking', thinking: 'Second thinking' },
+    ]);
+  });
+
+  it('does not move newly streamed assistant text ahead of tool_use before a later text block is explicit', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    act(() => {
+      result.current.streamingContentRef.current = 'First answerSecond answer';
+      result.current.streamingThinkingSegmentsRef.current = ['First thinking'];
+    });
+
+    const output = result.current.buildStreamingBlocks([
+      { type: 'thinking', thinking: 'First thinking' },
+      { type: 'text', text: 'First answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+    ] as any);
+
+    expect(output).toEqual([
+      { type: 'thinking', thinking: 'First thinking' },
+      { type: 'text', text: 'First answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+      { type: 'text', text: 'Second answer' },
+    ]);
+  });
+
+  it('updateMessages keeps tool_use blocks ahead of later assistant text when backend has not emitted the second text block yet', async () => {
+    const { result: streamingHook } = renderHook(() => useStreamingMessages());
+    streamingHook.current.streamingContentRef.current = 'First answerSecond answer';
+    streamingHook.current.streamingTextSegmentsRef.current = ['First answerSecond answer'];
+    streamingHook.current.streamingThinkingSegmentsRef.current = ['First thinking'];
+
+    const opts = createOptions({
+      isStreamingRef: streamingHook.current.isStreamingRef,
+      streamingTurnIdRef: streamingHook.current.streamingTurnIdRef,
+      streamingMessageIndexRef: streamingHook.current.streamingMessageIndexRef,
+      streamingContentRef: streamingHook.current.streamingContentRef,
+      streamingTextSegmentsRef: streamingHook.current.streamingTextSegmentsRef,
+      streamingThinkingSegmentsRef: streamingHook.current.streamingThinkingSegmentsRef,
+      activeThinkingSegmentIndexRef: streamingHook.current.activeThinkingSegmentIndexRef,
+      activeTextSegmentIndexRef: streamingHook.current.activeTextSegmentIndexRef,
+      seenToolUseCountRef: streamingHook.current.seenToolUseCountRef,
+      lastContentUpdateRef: streamingHook.current.lastContentUpdateRef,
+      lastThinkingUpdateRef: streamingHook.current.lastThinkingUpdateRef,
+      contentUpdateTimeoutRef: streamingHook.current.contentUpdateTimeoutRef,
+      thinkingUpdateTimeoutRef: streamingHook.current.thinkingUpdateTimeoutRef,
+      autoExpandedThinkingKeysRef: streamingHook.current.autoExpandedThinkingKeysRef,
+      extractRawBlocks: streamingHook.current.extractRawBlocks,
+      findStreamingAssistantIndex: streamingHook.current.findStreamingAssistantIndex,
+      patchAssistantForStreaming: streamingHook.current.patchAssistantForStreaming,
+      findLastAssistantIndex: streamingHook.current.findLastAssistantIndex,
+    });
+    opts.isStreamingRef.current = true;
+    opts.streamingTurnIdRef.current = 1;
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'First answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'First thinking' },
+              { type: 'text', text: 'First answer' },
+              { type: 'tool_use', id: 'tool-1', name: 'Read' },
+              { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'First answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'First thinking' },
+              { type: 'text', text: 'First answer' },
+              { type: 'tool_use', id: 'tool-1', name: 'Read' },
+              { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    const blocks = (next[0].raw as any)?.message?.content as any[];
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: 'First thinking' },
+      { type: 'text', text: 'First answer' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+      { type: 'text', text: 'Second answer' },
+    ]);
+  });
+
+  // ===== Order invariant tests (S1: guard against PR regressions) =====
+  // These tests verify the core ordering contract: if block A appears before
+  // block B in the input, then A must appear before B in the output (regardless
+  // of block type or streaming mode). This invariant is the root cause of the
+  // "blocks grouped by type" bug that frequently appears in PRs.
+
+  const assertOrderPreserved = (
+    input: Array<{ type: string; [key: string]: unknown }>,
+    output: Array<{ type: string; [key: string]: unknown }>,
+  ) => {
+    // For each pair of blocks (i, j) where i < j in input,
+    // verify that the same blocks appear with i before j in output.
+    // Use type+id as identity key for stable blocks.
+    const getKey = (b: Record<string, unknown>) => {
+      if (b.type === 'tool_use') return `tool_use:${b.id}`;
+      if (b.type === 'tool_result') return `tool_result:${b.tool_use_id}`;
+      return `${b.type}:${b.id ?? b.thinking ?? b.text ?? ''}`;
+    };
+    const outputKeys = output.map(getKey);
+    for (let i = 0; i < input.length; i += 1) {
+      const keyI = getKey(input[i]);
+      const idxI = outputKeys.indexOf(keyI);
+      if (idxI < 0) continue; // block may have been merged/replaced
+      for (let j = i + 1; j < input.length; j += 1) {
+        const keyJ = getKey(input[j]);
+        const idxJ = outputKeys.indexOf(keyJ);
+        if (idxJ < 0) continue;
+        expect(idxI).toBeLessThan(idxJ);
+      }
+    }
+  };
+
+  it('order invariant: interleaved thinking→text→tool→thinking→text preserves relative order', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+    const input = [
+      { type: 'thinking', thinking: 'Think 1' },
+      { type: 'text', text: 'Text 1' },
+      { type: 'tool_use', id: 't1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 't1', content: 'ok' },
+      { type: 'thinking', thinking: 'Think 2' },
+      { type: 'text', text: 'Text 2' },
+    ] as any[];
+
+    act(() => {
+      result.current.streamingContentRef.current = 'Text 1Text 2 extended';
+      result.current.streamingThinkingSegmentsRef.current = ['Think 1Think 2 extended'];
+    });
+
+    const output = result.current.buildStreamingBlocks(input);
+    assertOrderPreserved(input, output);
+  });
+
+  it('order invariant: simple mode — stable prefix stays before canonical blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+    const input = [
+      { type: 'tool_use', id: 't1', name: 'Read' },
+      { type: 'tool_result', tool_use_id: 't1', content: 'data' },
+      { type: 'thinking', thinking: 'old' },
+      { type: 'text', text: 'old' },
+    ] as any[];
+
+    act(() => {
+      result.current.streamingContentRef.current = 'new text';
+      result.current.streamingThinkingSegmentsRef.current = ['new thinking'];
+    });
+
+    const output = result.current.buildStreamingBlocks(input);
+    // tool_use and tool_result must remain before thinking and text
+    const toolIdx = output.findIndex((b) => (b as Record<string, unknown>).type === 'tool_use');
+    const thinkIdx = output.findIndex((b) => (b as Record<string, unknown>).type === 'thinking');
+    expect(toolIdx).toBeLessThan(thinkIdx);
+  });
+
+  it('order invariant: triple-turn interleaved structure', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+    const input = [
+      { type: 'thinking', thinking: 'T1' },
+      { type: 'text', text: 'X1' },
+      { type: 'tool_use', id: 't1', name: 'A' },
+      { type: 'tool_result', tool_use_id: 't1', content: 'r1' },
+      { type: 'thinking', thinking: 'T2' },
+      { type: 'text', text: 'X2' },
+      { type: 'tool_use', id: 't2', name: 'B' },
+      { type: 'tool_result', tool_use_id: 't2', content: 'r2' },
+      { type: 'thinking', thinking: 'T3' },
+      { type: 'text', text: 'X3' },
+    ] as any[];
+
+    act(() => {
+      result.current.streamingContentRef.current = 'X1X2X3 streaming';
+      result.current.streamingThinkingSegmentsRef.current = ['T1T2T3 streaming'];
+    });
+
+    const output = result.current.buildStreamingBlocks(input);
+    assertOrderPreserved(input, output);
+    expect(output).toHaveLength(10);
+  });
+
+  // ===== Original tests =====
+
+  it('stream end flushes throttled streaming refs into assistant raw blocks', () => {
+    const setMessages = vi.fn();
+    const opts = createOptions({
+      setMessages,
+      isStreamingRef: { current: true },
+      streamingContentRef: { current: 'final answer' },
+      streamingTextSegmentsRef: { current: ['final answer'] },
+      activeTextSegmentIndexRef: { current: 0 },
+      streamingThinkingSegmentsRef: { current: ['final reasoning'] },
+      activeThinkingSegmentIndexRef: { current: 0 },
+      streamingMessageIndexRef: { current: 0 },
+      patchAssistantForStreaming: (msg: ClaudeMessage, _canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'final reasoning' },
+              { type: 'text', text: 'final answer' },
+            ],
+          },
+        } as any,
+        content: 'final answer',
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      (window as any).onStreamEnd();
+    });
+
+    const updater = (setMessages as any).mock.calls[0][0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'partial',
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'partial' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    expect(next[0].isStreaming).toBe(false);
+    expect(next[0].content).toBe('final answer');
+    expect((next[0].raw as any).message.content).toEqual([
+      { type: 'thinking', thinking: 'final reasoning' },
+      { type: 'text', text: 'final answer' },
+    ]);
+  });
+
   // ===== Full failure scenario: load history fails, guard is released, new messages work =====
 
   it('full flow: history load failure releases guard so new messages can arrive', () => {
@@ -345,4 +1430,714 @@ describe('useWindowCallbacks integration', () => {
     });
     expect(opts.setMessages).toHaveBeenCalled();
   });
+
+  // ===== Boundary case tests for code review fixes =====
+
+  it('getContentHash detects changes in long thinking content suffix', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    // Create a long thinking content (>100 chars)
+    const longThinking = 'This is a very long thinking content that exceeds one hundred characters limit and the important change happens at the very end of this string: IMPORTANT_SUFFIX';
+
+    act(() => {
+      result.current.streamingThinkingSegmentsRef.current = [longThinking];
+    });
+
+    // Build blocks - should include the full thinking content
+    const blocks = result.current.buildStreamingBlocks([]);
+    expect(blocks).toEqual([
+      { type: 'thinking', thinking: longThinking },
+    ]);
+
+    // Now test with a different suffix - should still be detected
+    const differentSuffixThinking = longThinking.slice(0, -20) + 'DIFFERENT_SUFFIX';
+    act(() => {
+      result.current.streamingThinkingSegmentsRef.current = [differentSuffixThinking];
+    });
+
+    const blocksWithDifferentSuffix = result.current.buildStreamingBlocks([]);
+    expect(blocksWithDifferentSuffix).toEqual([
+      { type: 'thinking', thinking: differentSuffixThinking },
+    ]);
+  });
+
+  it('chooseMoreCompleteStreamingValue keeps current for whitespace-only differences', () => {
+    // This test verifies the fix for Issue 1: whitespace-only same-length changes
+    // should not cause unnecessary visual flicker
+    const streamingContentRef = { current: "hello\tworld" };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ["hello\tworld"] },
+      streamingThinkingSegmentsRef: { current: [] },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: canonicalState?.canonicalText ?? streamingContentRef.current,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: canonicalState?.canonicalText ?? streamingContentRef.current }],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // Backend sends same-length but whitespace-only difference (space vs tab, both 11 chars)
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'hello world', // Same length as "hello\tworld", whitespace-only difference
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'hello world' }],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: "hello\tworld",
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: "hello\tworld" }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    // Should keep current content since whitespace-only difference is not meaningful
+    expect(streamingContentRef.current).toBe("hello\tworld");
+    expect(next[0].content).toBe("hello\tworld");
+  });
+
+  it('chooseMoreCompleteStreamingValue switches for meaningful same-length changes', () => {
+    // This test verifies that typo fixes are still applied
+    const streamingContentRef = { current: 'abc' };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ['abc'] },
+      streamingThinkingSegmentsRef: { current: [] },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: canonicalState?.canonicalText ?? streamingContentRef.current,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: canonicalState?.canonicalText ?? streamingContentRef.current }],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // Backend sends typo fix - same length, meaningful content change
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'axc', // Typo fix: same length but different character
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'xyz' }], // Backend has even better content
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'abc',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'abc' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    // Should upgrade to backend's longer content (xyz > abc)
+    expect(streamingContentRef.current).toBe('xyz');
+    expect(next[0].content).toBe('xyz');
+  });
+
+  it('updateMessages handles empty backend snapshot during streaming', () => {
+    // Test for boundary case: empty array from backend
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef: { current: 'streaming content' },
+      streamingTextSegmentsRef: { current: ['streaming content'] },
+      streamingThinkingSegmentsRef: { current: ['thinking'] },
+      streamingMessageIndexRef: { current: 0 },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify([]));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'streaming content',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'thinking' },
+              { type: 'text', text: 'streaming content' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    // Should preserve the streaming assistant message
+    expect(next.length).toBeGreaterThanOrEqual(1);
+    expect(next[0].type).toBe('assistant');
+  });
+
+  it('selectMostCompleteStreamingText chooses longest from multiple sources', () => {
+    // Test for Issue 4: clear priority-based selection
+    const streamingContentRef = { current: 'short' };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ['short'] },
+      streamingThinkingSegmentsRef: { current: [] },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: canonicalState?.canonicalText ?? streamingContentRef.current,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: canonicalState?.canonicalText ?? streamingContentRef.current }],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // Backend has the longest content, assistant.content has medium
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'medium length content', // Medium: 20 chars
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'this is the longest backend content' }], // Longest: 36 chars
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    // Previous state has OLD content (short), not the new backend content
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'short',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'short' }],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    // Should select the longest content from backend (trimmed content differs)
+    expect(streamingContentRef.current).toBe('this is the longest backend content');
+    expect(next[0].content).toBe('this is the longest backend content');
+  });
+
+  it('updateMessages detects structural change in legacy thinking blocks with text field', () => {
+    // Regression test: backend sends { type: 'thinking', text: '...' } (legacy format)
+    // instead of { type: 'thinking', thinking: '...' }. getStructuralBlockSignature must
+    // fall back to block.text so hasStructuralBlockChange returns true.
+    const streamingContentRef = { current: 'answer' };
+    const streamingThinkingSegmentsRef = { current: ['old reasoning'] };
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 1 },
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ['answer'] },
+      activeTextSegmentIndexRef: { current: 0 },
+      streamingThinkingSegmentsRef,
+      activeThinkingSegmentIndexRef: { current: 0 },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: canonicalState?.canonicalText ?? streamingContentRef.current,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', text: canonicalState?.canonicalThinking ?? streamingThinkingSegmentsRef.current[0] },
+              { type: 'text', text: canonicalState?.canonicalText ?? streamingContentRef.current },
+            ],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // Backend sends legacy-format thinking block with updated content
+    const incoming: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', text: 'updated reasoning via legacy format' },
+              { type: 'text', text: 'answer' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'answer',
+        timestamp: new Date().toISOString(),
+        __turnId: 1,
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [
+              { type: 'thinking', text: 'old reasoning' },
+              { type: 'text', text: 'answer' },
+            ],
+          },
+        } as any,
+      },
+    ];
+
+    const next = updater(previous);
+    // Should NOT return prev (meaning the structural change was detected)
+    expect(next).not.toBe(previous);
+    // The thinking content should be upgraded to the longer legacy-format value
+    expect(streamingThinkingSegmentsRef.current).toEqual(['updated reasoning via legacy format']);
+  });
+
+  it('onStreamEnd early-clear blocks late delta callbacks', () => {
+    // Test for Issue 5: safety strategy for refs clearing
+    const streamingContentRef = { current: 'content before end' };
+    const isStreamingRef = { current: true };
+    const setMessages = vi.fn();
+    const opts = createOptions({
+      setMessages,
+      isStreamingRef,
+      streamingContentRef,
+      streamingTextSegmentsRef: { current: ['content before end'] },
+      streamingThinkingSegmentsRef: { current: [] },
+      streamingMessageIndexRef: { current: 0 },
+      patchAssistantForStreaming: (msg: ClaudeMessage, _canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: streamingContentRef.current,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: streamingContentRef.current }],
+          },
+        } as any,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // Call onStreamEnd
+    act(() => {
+      (window as any).onStreamEnd();
+    });
+
+    // Verify isStreamingRef was set to false early (before setMessages updater runs)
+    expect(isStreamingRef.current).toBe(false);
+
+    // The setMessages updater should have been called
+    expect(setMessages).toHaveBeenCalled();
+    const updater = setMessages.mock.calls[0][0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+
+    // Run the updater to simulate React processing it
+    const previous: ClaudeMessage[] = [
+      {
+        type: 'assistant',
+        content: 'content before end',
+        timestamp: new Date().toISOString(),
+        isStreaming: true,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'content before end' }],
+          },
+        } as any,
+      },
+    ];
+    updater(previous);
+
+    // Now refs should be cleared
+    expect(streamingContentRef.current).toBe('');
+
+    // Try to send a late delta - should be blocked because isStreamingRef is false
+    const contentBeforeDelta = streamingContentRef.current;
+    act(() => {
+      (window as any).onContentDelta(' late content');
+    });
+
+    // Content should not have changed because delta was blocked
+    expect(streamingContentRef.current).toBe(contentBeforeDelta);
+  });
+
+  // ===== Full interleaving integration test (Decision 30 — post-review) =====
+
+  it('preserves user-before-assistant order when updateMessages restores the current user before streaming assistant recovery', () => {
+    const opts = createOptions({
+      isStreamingRef: { current: true },
+      streamingTurnIdRef: { current: 2 },
+      streamingMessageIndexRef: { current: 1 },
+      streamingContentRef: { current: 'partial answer' },
+      streamingTextSegmentsRef: { current: ['partial answer'] },
+      streamingThinkingSegmentsRef: { current: [] },
+      extractRawBlocks: (raw) => {
+        if (!raw || typeof raw !== 'object') return [];
+        const content = (raw as any).message?.content;
+        return Array.isArray(content) ? content : [];
+      },
+      patchAssistantForStreaming: (msg: ClaudeMessage, canonicalState?: { canonicalText?: string; canonicalThinking?: string; existingBlocks?: any[] }) => ({
+        ...msg,
+        content: canonicalState?.canonicalText ?? msg.content,
+        isStreaming: true,
+      }),
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const incoming: ClaudeMessage[] = [
+      { type: 'user', content: 'previous user', timestamp: '2024-01-01T00:00:00.000Z' },
+      { type: 'assistant', content: 'previous assistant', timestamp: '2024-01-01T00:00:01.000Z' },
+      { type: 'user', content: 'current user', timestamp: '2024-01-01T00:00:02.000Z' },
+    ];
+
+    act(() => {
+      (window as any).updateMessages(JSON.stringify(incoming));
+    });
+
+    const updater = (opts.setMessages as any).mock.calls.at(-1)[0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previous: ClaudeMessage[] = [
+      { type: 'user', content: 'previous user', timestamp: '2024-01-01T00:00:00.000Z' },
+      { type: 'assistant', content: 'previous assistant', timestamp: '2024-01-01T00:00:01.000Z' },
+      { type: 'assistant', content: 'partial answer', timestamp: '2024-01-01T00:00:03.000Z', __turnId: 2, isStreaming: true },
+    ];
+
+    const next = updater(previous);
+    expect(next.map((message) => message.type)).toEqual(['user', 'assistant', 'user', 'assistant']);
+    expect(next[2].content).toBe('current user');
+    expect(next[3].__turnId).toBe(2);
+  });
+
+  it('keeps the latest user ahead of a new streaming placeholder when addUserMessage follows onStreamStart', () => {
+    let messages: ClaudeMessage[] = [];
+    const setMessages = vi.fn((updater: unknown) => {
+      messages = typeof updater === 'function'
+        ? (updater as (prev: ClaudeMessage[]) => ClaudeMessage[])(messages)
+        : updater as ClaudeMessage[];
+    });
+
+    const { result: streamingHook } = renderHook(() => useStreamingMessages());
+    const opts = createOptions({
+      setMessages,
+      streamingContentRef: streamingHook.current.streamingContentRef,
+      streamingThinkingSegmentsRef: streamingHook.current.streamingThinkingSegmentsRef,
+      streamingTextSegmentsRef: streamingHook.current.streamingTextSegmentsRef,
+      activeThinkingSegmentIndexRef: streamingHook.current.activeThinkingSegmentIndexRef,
+      activeTextSegmentIndexRef: streamingHook.current.activeTextSegmentIndexRef,
+      isStreamingRef: streamingHook.current.isStreamingRef,
+      streamingTurnIdRef: streamingHook.current.streamingTurnIdRef,
+      turnIdCounterRef: streamingHook.current.turnIdCounterRef,
+      seenToolUseCountRef: streamingHook.current.seenToolUseCountRef,
+      streamingMessageIndexRef: streamingHook.current.streamingMessageIndexRef,
+      lastContentUpdateRef: streamingHook.current.lastContentUpdateRef,
+      lastThinkingUpdateRef: streamingHook.current.lastThinkingUpdateRef,
+      contentUpdateTimeoutRef: streamingHook.current.contentUpdateTimeoutRef,
+      thinkingUpdateTimeoutRef: streamingHook.current.thinkingUpdateTimeoutRef,
+      autoExpandedThinkingKeysRef: streamingHook.current.autoExpandedThinkingKeysRef,
+      extractRawBlocks: streamingHook.current.extractRawBlocks,
+      findStreamingAssistantIndex: streamingHook.current.findStreamingAssistantIndex,
+      patchAssistantForStreaming: streamingHook.current.patchAssistantForStreaming,
+      findLastAssistantIndex: streamingHook.current.findLastAssistantIndex,
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    messages = [
+      { type: 'user', content: 'previous user', timestamp: '2024-01-01T00:00:00.000Z' },
+      { type: 'assistant', content: 'previous assistant', timestamp: '2024-01-01T00:00:01.000Z' },
+    ];
+
+    act(() => { (window as any).onStreamStart(); });
+    act(() => { (window as any).addUserMessage('current user'); });
+
+    expect(messages.map((message) => message.type)).toEqual(['user', 'assistant', 'user', 'assistant']);
+    expect(messages[2].content).toBe('current user');
+    expect(messages[3].type).toBe('assistant');
+    expect(messages[3].__turnId).toBe(1);
+  });
+
+  it('content delta fallback never patches an older assistant when the current turn placeholder is temporarily missing', () => {
+    let messages: ClaudeMessage[] = [
+      { type: 'assistant', content: 'old assistant', timestamp: '2024-01-01T00:00:00.000Z', __turnId: 1 },
+    ];
+    const setMessages = vi.fn((updater: unknown) => {
+      messages = typeof updater === 'function'
+        ? (updater as (prev: ClaudeMessage[]) => ClaudeMessage[])(messages)
+        : updater as ClaudeMessage[];
+    });
+
+    const { result: streamingHook } = renderHook(() => useStreamingMessages());
+    const opts = createOptions({
+      setMessages,
+      streamingContentRef: streamingHook.current.streamingContentRef,
+      streamingThinkingSegmentsRef: streamingHook.current.streamingThinkingSegmentsRef,
+      streamingTextSegmentsRef: streamingHook.current.streamingTextSegmentsRef,
+      activeThinkingSegmentIndexRef: streamingHook.current.activeThinkingSegmentIndexRef,
+      activeTextSegmentIndexRef: streamingHook.current.activeTextSegmentIndexRef,
+      isStreamingRef: streamingHook.current.isStreamingRef,
+      streamingTurnIdRef: streamingHook.current.streamingTurnIdRef,
+      turnIdCounterRef: streamingHook.current.turnIdCounterRef,
+      seenToolUseCountRef: streamingHook.current.seenToolUseCountRef,
+      streamingMessageIndexRef: streamingHook.current.streamingMessageIndexRef,
+      lastContentUpdateRef: streamingHook.current.lastContentUpdateRef,
+      lastThinkingUpdateRef: streamingHook.current.lastThinkingUpdateRef,
+      contentUpdateTimeoutRef: streamingHook.current.contentUpdateTimeoutRef,
+      thinkingUpdateTimeoutRef: streamingHook.current.thinkingUpdateTimeoutRef,
+      autoExpandedThinkingKeysRef: streamingHook.current.autoExpandedThinkingKeysRef,
+      extractRawBlocks: streamingHook.current.extractRawBlocks,
+      findStreamingAssistantIndex: streamingHook.current.findStreamingAssistantIndex,
+      patchAssistantForStreaming: streamingHook.current.patchAssistantForStreaming,
+      findLastAssistantIndex: streamingHook.current.findLastAssistantIndex,
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    opts.isStreamingRef.current = true;
+    opts.streamingTurnIdRef.current = 2;
+    opts.streamingMessageIndexRef.current = -1;
+
+    act(() => {
+      opts.streamingContentRef.current = 'current turn answer';
+      (window as any).onContentDelta('!');
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('old assistant');
+    expect(messages[0].__turnId).toBe(1);
+  });
+
+  it('content delta fallback never patches an older assistant when the current turn placeholder is temporarily missing', () => {
+    let messages: ClaudeMessage[] = [
+      { type: 'assistant', content: 'old assistant', timestamp: '2024-01-01T00:00:00.000Z', __turnId: 1 },
+    ];
+    const setMessages = vi.fn((updater: unknown) => {
+      messages = typeof updater === 'function'
+        ? (updater as (prev: ClaudeMessage[]) => ClaudeMessage[])(messages)
+        : updater as ClaudeMessage[];
+    });
+
+    const { result: streamingHook } = renderHook(() => useStreamingMessages());
+    const opts = createOptions({
+      setMessages,
+      streamingContentRef: streamingHook.current.streamingContentRef,
+      streamingThinkingSegmentsRef: streamingHook.current.streamingThinkingSegmentsRef,
+      streamingTextSegmentsRef: streamingHook.current.streamingTextSegmentsRef,
+      activeThinkingSegmentIndexRef: streamingHook.current.activeThinkingSegmentIndexRef,
+      activeTextSegmentIndexRef: streamingHook.current.activeTextSegmentIndexRef,
+      isStreamingRef: streamingHook.current.isStreamingRef,
+      streamingTurnIdRef: streamingHook.current.streamingTurnIdRef,
+      turnIdCounterRef: streamingHook.current.turnIdCounterRef,
+      seenToolUseCountRef: streamingHook.current.seenToolUseCountRef,
+      streamingMessageIndexRef: streamingHook.current.streamingMessageIndexRef,
+      lastContentUpdateRef: streamingHook.current.lastContentUpdateRef,
+      lastThinkingUpdateRef: streamingHook.current.lastThinkingUpdateRef,
+      contentUpdateTimeoutRef: streamingHook.current.contentUpdateTimeoutRef,
+      thinkingUpdateTimeoutRef: streamingHook.current.thinkingUpdateTimeoutRef,
+      autoExpandedThinkingKeysRef: streamingHook.current.autoExpandedThinkingKeysRef,
+      extractRawBlocks: streamingHook.current.extractRawBlocks,
+      findStreamingAssistantIndex: streamingHook.current.findStreamingAssistantIndex,
+      patchAssistantForStreaming: streamingHook.current.patchAssistantForStreaming,
+      findLastAssistantIndex: streamingHook.current.findLastAssistantIndex,
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    opts.isStreamingRef.current = true;
+    opts.streamingTurnIdRef.current = 2;
+    opts.streamingMessageIndexRef.current = -1;
+    opts.streamingContentRef.current = 'current turn answer';
+
+    act(() => {
+      (window as any).onContentDelta('!');
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('old assistant');
+    expect(messages[0].__turnId).toBe(1);
+  });
+
+  it('preserves content integrity when thinking_delta, content_delta, and updateMessages interleave', () => {
+    vi.useFakeTimers();
+
+    // Use real useStreamingMessages hook for authentic refs + functions
+    const { result: streamingHook } = renderHook(() => useStreamingMessages());
+
+    let messages: ClaudeMessage[] = [];
+    const setMessages = vi.fn((updater: unknown) => {
+      if (typeof updater === 'function') {
+        messages = (updater as (prev: ClaudeMessage[]) => ClaudeMessage[])(messages);
+      } else {
+        messages = updater as ClaudeMessage[];
+      }
+    });
+
+    const opts = createOptions({
+      setMessages,
+      // Wire all refs + functions from the real hook
+      streamingContentRef: streamingHook.current.streamingContentRef,
+      streamingThinkingSegmentsRef: streamingHook.current.streamingThinkingSegmentsRef,
+      streamingTextSegmentsRef: streamingHook.current.streamingTextSegmentsRef,
+      activeThinkingSegmentIndexRef: streamingHook.current.activeThinkingSegmentIndexRef,
+      activeTextSegmentIndexRef: streamingHook.current.activeTextSegmentIndexRef,
+      isStreamingRef: streamingHook.current.isStreamingRef,
+      streamingTurnIdRef: streamingHook.current.streamingTurnIdRef,
+      turnIdCounterRef: streamingHook.current.turnIdCounterRef,
+      seenToolUseCountRef: streamingHook.current.seenToolUseCountRef,
+      streamingMessageIndexRef: streamingHook.current.streamingMessageIndexRef,
+      lastContentUpdateRef: streamingHook.current.lastContentUpdateRef,
+      lastThinkingUpdateRef: streamingHook.current.lastThinkingUpdateRef,
+      contentUpdateTimeoutRef: streamingHook.current.contentUpdateTimeoutRef,
+      thinkingUpdateTimeoutRef: streamingHook.current.thinkingUpdateTimeoutRef,
+      autoExpandedThinkingKeysRef: streamingHook.current.autoExpandedThinkingKeysRef,
+      extractRawBlocks: streamingHook.current.extractRawBlocks,
+      findStreamingAssistantIndex: streamingHook.current.findStreamingAssistantIndex,
+      patchAssistantForStreaming: streamingHook.current.patchAssistantForStreaming,
+      findLastAssistantIndex: streamingHook.current.findLastAssistantIndex,
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    // 1. Start stream
+    act(() => { (window as any).onStreamStart(); });
+
+    // 2. First thinking delta
+    act(() => { (window as any).onThinkingDelta('think part 1'); });
+    vi.advanceTimersByTime(60);
+
+    // 3. First content delta
+    act(() => { (window as any).onContentDelta('text part 1'); });
+    vi.advanceTimersByTime(60);
+
+    // 4. Stale updateMessages snapshot (shorter content than local buffers)
+    const staleSnapshot: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: 'text',
+      timestamp: new Date().toISOString(),
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'think' },
+            { type: 'text', text: 'text' },
+          ],
+        },
+      } as any,
+    }];
+    act(() => { (window as any).updateMessages(JSON.stringify(staleSnapshot)); });
+
+    // 5. More thinking arrives after stale snapshot
+    act(() => { (window as any).onThinkingDelta(' think part 2'); });
+    vi.advanceTimersByTime(60);
+
+    // 6. End stream
+    act(() => { (window as any).onStreamEnd(); });
+
+    // Verify: content must not have been lost to the stale snapshot
+    const lastAssistantIdx = messages.findIndex((m) => m.type === 'assistant');
+    expect(lastAssistantIdx).toBeGreaterThanOrEqual(0);
+    const assistant = messages[lastAssistantIdx];
+
+    expect(assistant.content).toBe('text part 1');
+    expect(assistant.isStreaming).toBe(false);
+
+    const blocks = (assistant.raw as any)?.message?.content as any[];
+    const thinkingBlock = blocks?.find((b: any) => b.type === 'thinking');
+    const textBlock = blocks?.find((b: any) => b.type === 'text');
+
+    expect(thinkingBlock?.thinking).toBe('think part 1 think part 2');
+    expect(textBlock?.text).toBe('text part 1');
+
+    vi.useRealTimers();
+  });
 });
+

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import type { TFunction } from 'i18next';
 import type { MutableRefObject, RefObject } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, HistoryData } from '../types';
+import type { StreamingPatchState, ContentBlock } from './useStreamingMessages';
 import type { PermissionMode, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ProviderConfig } from '../types/provider';
 import type { PermissionRequest } from '../components/PermissionDialog';
@@ -67,7 +68,6 @@ export interface UseWindowCallbacksOptions {
   // Streaming refs from useStreamingMessages
   streamingContentRef: MutableRefObject<string>;
   isStreamingRef: MutableRefObject<boolean>;
-  useBackendStreamingRenderRef: MutableRefObject<boolean>;
   autoExpandedThinkingKeysRef: MutableRefObject<Set<string>>;
   streamingTextSegmentsRef: MutableRefObject<string[]>;
   activeTextSegmentIndexRef: MutableRefObject<number>;
@@ -84,9 +84,9 @@ export interface UseWindowCallbacksOptions {
 
   // Functions from useStreamingMessages
   findLastAssistantIndex: (messages: ClaudeMessage[]) => number;
-  extractRawBlocks: (raw: ClaudeRawMessage | string | undefined) => Array<Record<string, unknown>>;
-  getOrCreateStreamingAssistantIndex: (messages: ClaudeMessage[]) => number;
-  patchAssistantForStreaming: (msg: ClaudeMessage) => ClaudeMessage;
+  extractRawBlocks: (raw: ClaudeRawMessage | string | undefined) => ContentBlock[];
+  findStreamingAssistantIndex: (messages: ClaudeMessage[]) => number;
+  patchAssistantForStreaming: (msg: ClaudeMessage, patchState?: StreamingPatchState) => ClaudeMessage;
 
   // Other functions
   syncActiveProviderModelMapping: (provider: ProviderConfig) => void;
@@ -113,6 +113,19 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
 
   useEffect(() => {
     registerWindowCallbacks(options, tRef);
+
+    // Cleanup pending streaming timeouts on unmount to prevent
+    // setMessages calls on an unmounted component (resource leak).
+    return () => {
+      if (options.contentUpdateTimeoutRef.current) {
+        clearTimeout(options.contentUpdateTimeoutRef.current);
+        options.contentUpdateTimeoutRef.current = null;
+      }
+      if (options.thinkingUpdateTimeoutRef.current) {
+        clearTimeout(options.thinkingUpdateTimeoutRef.current);
+        options.thinkingUpdateTimeoutRef.current = null;
+      }
+    };
     // Callbacks are registered once on mount; re-registration would cause duplicate handlers.
     // Options object reference is intentionally excluded from deps.
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/webview/src/hooks/windowCallbacks/__tests__/messageCallbacksPure.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageCallbacksPure.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Direct unit tests for the pure utility functions in messageCallbacks.ts.
+ * These complement the integration tests in useWindowCallbacks.test.ts by
+ * verifying boundary/edge cases of individual functions in isolation.
+ */
+import { describe, expect, it } from 'vitest';
+import type { ClaudeMessage } from '../../../types';
+import {
+  _chooseMoreCompleteStreamingValue as chooseMore,
+  _selectMostCompleteStreamingText as selectBest,
+  _computeCanonicalStreamingState as computeCanonical,
+  _getContentHash as getContentHash,
+  _getStructuralBlockSignature as getSig,
+  _hasStructuralBlockChange as hasChange,
+  _collectAssistantBlocks as collectAssistantBlocks,
+  _extractCanonicalTextFromBlocks as extractText,
+  _extractCanonicalThinkingFromBlocks as extractThinking,
+} from '../registerCallbacks/messageCallbacks';
+import type { ContentBlock } from '../../useStreamingMessages';
+import { extractRawBlocks } from '../../useStreamingMessages';
+
+// ---------------------------------------------------------------------------
+// chooseMoreCompleteStreamingValue
+// ---------------------------------------------------------------------------
+describe('chooseMoreCompleteStreamingValue', () => {
+  it('returns current when candidate is empty', () => {
+    expect(chooseMore('hello', '')).toBe('hello');
+  });
+
+  it('returns candidate when current is empty', () => {
+    expect(chooseMore('', 'world')).toBe('world');
+  });
+
+  it('returns candidate when candidate is longer', () => {
+    expect(chooseMore('abc', 'abcdef')).toBe('abcdef');
+  });
+
+  it('returns current when current is longer', () => {
+    expect(chooseMore('abcdef', 'abc')).toBe('abcdef');
+  });
+
+  it('returns candidate for same-length meaningful difference', () => {
+    expect(chooseMore('axc', 'abc')).toBe('abc');
+  });
+
+  it('returns current for same-length whitespace-only difference', () => {
+    expect(chooseMore('a  b', 'a\tb')).toBe('a  b');
+  });
+
+  it('returns current when both are identical', () => {
+    expect(chooseMore('same', 'same')).toBe('same');
+  });
+
+  it('returns empty string when both are empty', () => {
+    expect(chooseMore('', '')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectMostCompleteStreamingText
+// ---------------------------------------------------------------------------
+describe('selectMostCompleteStreamingText', () => {
+  it('returns streaming when it is the only source', () => {
+    expect(selectBest('only', '', '')).toBe('only');
+  });
+
+  it('returns empty string when all sources are empty', () => {
+    expect(selectBest('', '', '')).toBe('');
+  });
+
+  it('selects longest across three sources', () => {
+    expect(selectBest('a', 'ab', 'abc')).toBe('abc');
+  });
+
+  it('backend wins on same-length meaningful difference (implicit priority)', () => {
+    // streaming=abc, assistant=abc, backend=xyz — all length 3
+    // Pairwise: best=abc, chooseMore(abc,abc)=abc, chooseMore(abc,xyz)=xyz
+    expect(selectBest('abc', 'abc', 'xyz')).toBe('xyz');
+  });
+
+  it('returns assistant when streaming and backend are empty', () => {
+    expect(selectBest('', 'assistant content', '')).toBe('assistant content');
+  });
+
+  it('returns backend when streaming and assistant are empty', () => {
+    expect(selectBest('', '', 'backend content')).toBe('backend content');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCanonicalStreamingState
+// ---------------------------------------------------------------------------
+describe('computeCanonicalStreamingState', () => {
+  const mkAssistant = (content: string, raw?: unknown) => ({
+    type: 'assistant' as const,
+    content,
+    timestamp: new Date().toISOString(),
+    raw: raw as any,
+  });
+
+  it('prefers longer backend text over shorter streaming snapshot', () => {
+    const assistant = mkAssistant('short', {
+      message: { content: [{ type: 'text', text: 'longer backend text' }] },
+    });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'short', '');
+    expect(result.nextText).toBe('longer backend text');
+  });
+
+  it('preserves longer streaming snapshot when backend text is shorter', () => {
+    const assistant = mkAssistant('short', {
+      message: { content: [{ type: 'text', text: 'short' }] },
+    });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'longer streaming content', '');
+    expect(result.nextText).toBe('longer streaming content');
+  });
+
+  it('handles empty raw blocks gracefully', () => {
+    const assistant = mkAssistant('streaming', { message: { content: [] } });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'streaming', '');
+    expect(result.nextText).toBe('streaming');
+    expect(result.nextThinking).toBe('');
+  });
+
+  it('handles undefined raw gracefully', () => {
+    const assistant = mkAssistant('streaming', undefined);
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'streaming', '');
+    expect(result.nextText).toBe('streaming');
+  });
+
+  it('merges thinking from backend when it exceeds snapshot', () => {
+    const assistant = mkAssistant('text', {
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'longer backend thinking content' },
+          { type: 'text', text: 'text' },
+        ],
+      },
+    });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'text', 'short');
+    expect(result.nextThinking).toBe('longer backend thinking content');
+  });
+
+  it('preserves streaming thinking when it exceeds backend', () => {
+    const assistant = mkAssistant('text', {
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'short' },
+          { type: 'text', text: 'text' },
+        ],
+      },
+    });
+    const result = computeCanonical(
+      assistant, extractRawBlocks(assistant.raw), 'text', 'longer streaming thinking',
+    );
+    expect(result.nextThinking).toBe('longer streaming thinking');
+  });
+
+  it('returns assistant with updated content', () => {
+    const assistant = mkAssistant('old', {
+      message: { content: [{ type: 'text', text: 'new longer text' }] },
+    });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'old', '');
+    expect(result.assistant.content).toBe('new longer text');
+  });
+
+  it('handles legacy thinking blocks with text field instead of thinking field', () => {
+    const assistant = mkAssistant('content', {
+      message: {
+        content: [
+          { type: 'thinking', text: 'legacy thinking via text field' },
+          { type: 'text', text: 'content' },
+        ],
+      },
+    });
+    const result = computeCanonical(assistant, extractRawBlocks(assistant.raw), 'content', '');
+    expect(result.nextThinking).toBe('legacy thinking via text field');
+  });
+
+  it('produces identical results when called twice with same inputs (StrictMode safety)', () => {
+    const assistant = mkAssistant('text', {
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'think' },
+          { type: 'text', text: 'longer text content' },
+        ],
+      },
+    });
+    const blocks = extractRawBlocks(assistant.raw);
+    const r1 = computeCanonical(assistant, blocks, 'text', 'think');
+    const r2 = computeCanonical(assistant, blocks, 'text', 'think');
+    expect(r1.nextText).toBe(r2.nextText);
+    expect(r1.nextThinking).toBe(r2.nextThinking);
+    expect(r1.assistant.content).toBe(r2.assistant.content);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getContentHash
+// ---------------------------------------------------------------------------
+describe('getContentHash', () => {
+  it('returns "empty" for empty string', () => {
+    expect(getContentHash('')).toBe('empty');
+  });
+
+  it('returns full text for short content (<=100 chars)', () => {
+    expect(getContentHash('hello')).toBe('5:hello');
+  });
+
+  it('returns length:hash for long content (>100 chars)', () => {
+    const long = 'a'.repeat(101);
+    const hash = getContentHash(long);
+    expect(hash).toMatch(/^101:[0-9a-f]+$/);
+  });
+
+  it('different long strings produce different hashes', () => {
+    const a = 'a'.repeat(101);
+    const b = 'b'.repeat(101);
+    expect(getContentHash(a)).not.toBe(getContentHash(b));
+  });
+
+  it('same long string is deterministic', () => {
+    const s = 'x'.repeat(200);
+    expect(getContentHash(s)).toBe(getContentHash(s));
+  });
+
+  it('returns full text at exactly 100 chars (boundary)', () => {
+    const exact = 'z'.repeat(100);
+    expect(getContentHash(exact)).toBe(`100:${exact}`);
+  });
+
+  it('returns hash at 101 chars (boundary)', () => {
+    const over = 'z'.repeat(101);
+    expect(getContentHash(over)).toMatch(/^101:[0-9a-f]+$/);
+  });
+
+  it('detects suffix changes in long content', () => {
+    const base = 'a'.repeat(100);
+    const a = base + 'X';
+    const b = base + 'Y';
+    expect(getContentHash(a)).not.toBe(getContentHash(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStructuralBlockSignature
+// ---------------------------------------------------------------------------
+describe('getStructuralBlockSignature', () => {
+  it('returns "invalid" for null', () => {
+    expect(getSig(null)).toBe('invalid');
+  });
+
+  it('returns "invalid" for undefined', () => {
+    expect(getSig(undefined)).toBe('invalid');
+  });
+
+  it('generates thinking signature with hash for long content', () => {
+    const block = { type: 'thinking', thinking: 'a'.repeat(200) } as ContentBlock;
+    const sig = getSig(block);
+    expect(sig).toMatch(/^thinking\|\|200:[0-9a-f]+$/);
+  });
+
+  it('generates text signature with hash for long content', () => {
+    const block = { type: 'text', text: 'b'.repeat(150) } as ContentBlock;
+    const sig = getSig(block);
+    expect(sig).toMatch(/^text\|150:[0-9a-f]+$/);
+  });
+
+  it('generates text signature with full content for short text', () => {
+    const block = { type: 'text', text: 'hello' } as ContentBlock;
+    expect(getSig(block)).toBe('text|5:hello');
+  });
+
+  it('generates tool_use signature', () => {
+    const block = { type: 'tool_use', id: 'abc', name: 'read' } as ContentBlock;
+    expect(getSig(block)).toBe('tool_use|abc|read');
+  });
+
+  it('generates tool_result signature', () => {
+    const block = { type: 'tool_result', tool_use_id: 'abc', content: 'ok' } as ContentBlock;
+    expect(getSig(block)).toBe('tool_result|abc|false');
+  });
+
+  it('generates tool_result signature with is_error=true', () => {
+    const block = { type: 'tool_result', tool_use_id: 'abc', content: 'err', is_error: true } as ContentBlock;
+    expect(getSig(block)).toBe('tool_result|abc|true');
+  });
+
+  it('uses type + identity fields for unknown block types', () => {
+    const block = { type: 'custom', foo: 'bar' } as ContentBlock;
+    const sig = getSig(block);
+    // N1: lightweight signature using type + id/name fields
+    expect(sig).toBe('custom||');
+  });
+
+  it('uses type + id + name for unknown block types with those fields', () => {
+    const block = { type: 'custom', id: 'c1', name: 'MyBlock' } as ContentBlock;
+    const sig = getSig(block);
+    expect(sig).toBe('custom|c1|MyBlock');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasStructuralBlockChange
+// ---------------------------------------------------------------------------
+describe('hasStructuralBlockChange', () => {
+  it('returns true when lengths differ', () => {
+    const a = [{ type: 'text', text: 'a' }] as ContentBlock[];
+    const b = [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }] as ContentBlock[];
+    expect(hasChange(a, b)).toBe(true);
+  });
+
+  it('returns false when blocks are identical', () => {
+    const blocks = [
+      { type: 'thinking', thinking: 'think' },
+      { type: 'text', text: 'text' },
+    ] as ContentBlock[];
+    expect(hasChange(blocks, [...blocks])).toBe(false);
+  });
+
+  it('detects change in thinking content', () => {
+    const a = [{ type: 'thinking', thinking: 'v1' }] as ContentBlock[];
+    const b = [{ type: 'thinking', thinking: 'v2' }] as ContentBlock[];
+    expect(hasChange(a, b)).toBe(true);
+  });
+
+  it('detects change in text content', () => {
+    const a = [{ type: 'text', text: 'v1' }] as ContentBlock[];
+    const b = [{ type: 'text', text: 'v2' }] as ContentBlock[];
+    expect(hasChange(a, b)).toBe(true);
+  });
+
+  it('returns false for two empty arrays', () => {
+    expect(hasChange([], [])).toBe(false);
+  });
+
+  it('detects structural change when an earlier assistant fragment gains a tool_use block', () => {
+    const previous = [
+      { type: 'thinking', thinking: 'plan' },
+      { type: 'text', text: 'final' },
+    ] as ContentBlock[];
+    const next = [
+      { type: 'thinking', thinking: 'plan' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'text', text: 'final' },
+    ] as ContentBlock[];
+    expect(hasChange(previous, next)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectAssistantBlocks
+// ---------------------------------------------------------------------------
+describe('collectAssistantBlocks', () => {
+  it('collects blocks from all assistant messages in order', () => {
+    const messages = [
+      {
+        type: 'assistant',
+        raw: { message: { content: [{ type: 'thinking', thinking: 'plan' }, { type: 'tool_use', id: 'tool-1', name: 'Read' }] } },
+      },
+      {
+        type: 'user',
+        raw: { message: { content: [{ type: 'text', text: 'ignored' }] } },
+      },
+      {
+        type: 'assistant',
+        raw: { message: { content: [{ type: 'text', text: 'answer' }] } },
+      },
+    ] as ClaudeMessage[];
+
+    expect(collectAssistantBlocks(messages, extractRawBlocks)).toEqual([
+      { type: 'thinking', thinking: 'plan' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCanonicalTextFromBlocks / extractCanonicalThinkingFromBlocks
+// ---------------------------------------------------------------------------
+describe('extractCanonicalTextFromBlocks', () => {
+  it('extracts text from text blocks', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'text', text: 'hello ' },
+      { type: 'text', text: 'world' },
+    ];
+    expect(extractText(blocks)).toBe('hello world');
+  });
+
+  it('ignores thinking blocks', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'think' },
+      { type: 'text', text: 'only text' },
+    ];
+    expect(extractText(blocks)).toBe('only text');
+  });
+
+  it('returns empty string when no text blocks', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'think' },
+    ];
+    expect(extractText(blocks)).toBe('');
+  });
+});
+
+describe('extractCanonicalThinkingFromBlocks', () => {
+  it('extracts thinking from thinking field', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'thought' },
+    ];
+    expect(extractThinking(blocks)).toBe('thought');
+  });
+
+  it('falls back to text field for legacy format', () => {
+    const blocks = [
+      { type: 'thinking', text: 'legacy thought' },
+    ] as ContentBlock[];
+    expect(extractThinking(blocks)).toBe('legacy thought');
+  });
+
+  it('joins multiple thinking blocks', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'a' },
+      { type: 'thinking', thinking: 'b' },
+    ];
+    expect(extractThinking(blocks)).toBe('ab');
+  });
+
+  it('normalizes CRLF in thinking content', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'line1\r\nline2' },
+    ];
+    expect(extractThinking(blocks)).toBe('line1\nline2');
+  });
+});

--- a/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import type { MutableRefObject } from 'react';
 import type { ClaudeMessage } from '../../../types';
 import {
   OPTIMISTIC_MESSAGE_TIME_WINDOW,
@@ -15,8 +14,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
 
 const findLastAssistantIndex = (msgs: ClaudeMessage[]): number =>
   msgs.reduce((acc, m, i) => (m.type === 'assistant' ? i : acc), -1);
@@ -291,12 +288,33 @@ describe('preserveLastAssistantIdentity', () => {
 // ---------------------------------------------------------------------------
 
 describe('preserveStreamingAssistantContent', () => {
+  it('preserves longer backend-upgraded canonical content across later shorter snapshots', () => {
+    const localPatchAssistantForStreaming = (msg: ClaudeMessage): ClaudeMessage => ({
+      ...msg,
+      isStreaming: true,
+    });
+    const prev = [makeAssistantMsg('abcdef')];
+    const shorterNext = [makeAssistantMsg('abc')];
+
+    const result = preserveStreamingAssistantContent(
+      prev,
+      shorterNext,
+      true,
+      'abcdef',
+      findLastAssistantIndex,
+      localPatchAssistantForStreaming,
+    );
+
+    expect(result[0].content).toBe('abcdef');
+    expect(result[0].isStreaming).toBe(true);
+  });
+
   it('returns nextList unchanged when not streaming', () => {
     const prev = [makeAssistantMsg('streamed long content here')];
     const next = [makeAssistantMsg('short')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(false), ref('streamed long content here'),
+      prev, next, false, 'streamed long content here',
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).toBe(next);
@@ -307,7 +325,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('response')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(''),
+      prev, next, true, '',
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).toBe(next);
@@ -318,7 +336,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeUserMsg('user reply')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(''),
+      prev, next, true, '',
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).toBe(next);
@@ -329,7 +347,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('longer backend content')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref('short'),
+      prev, next, true, 'short',
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).toBe(next);
@@ -341,7 +359,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('short stale')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(longStreamed),
+      prev, next, true, longStreamed,
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).not.toBe(next);
@@ -356,7 +374,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('stale short')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(bufferedContent),
+      prev, next, true, bufferedContent,
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result[0].content).toBe(bufferedContent);
@@ -368,7 +386,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('short stale')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(''),
+      prev, next, true, '',
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result[0].content).toBe(prevContent);
@@ -380,7 +398,7 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeUserMsg('q'), makeAssistantMsg('stale snapshot')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(longContent),
+      prev, next, true, longContent,
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result[0]).toBe(next[0]); // user message unchanged
@@ -393,34 +411,52 @@ describe('preserveStreamingAssistantContent', () => {
     const next = [makeAssistantMsg('short', { __turnId: 2 })];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(longContent),
+      prev, next, true, longContent,
       findLastAssistantIndex, patchAssistantForStreaming,
     );
     expect(result).toBe(next);
   });
 
-  it('allows merge when both have same turn ID', () => {
-    const longContent = 'long streamed content';
+  it('does not merge content when next assistant is missing turn ID', () => {
+    const longContent = 'long content from turn 1';
     const prev = [makeAssistantMsg(longContent, { __turnId: 1 })];
-    const next = [makeAssistantMsg('short', { __turnId: 1 })];
-
-    const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(longContent),
-      findLastAssistantIndex, patchAssistantForStreaming,
-    );
-    expect(result[0].content).toBe(longContent);
-  });
-
-  it('allows merge when neither has turn ID (backward compat)', () => {
-    const longContent = 'long content without turn ID';
-    const prev = [makeAssistantMsg(longContent)];
     const next = [makeAssistantMsg('short')];
 
     const result = preserveStreamingAssistantContent(
-      prev, next, ref(true), ref(longContent),
+      prev, next, true, longContent,
       findLastAssistantIndex, patchAssistantForStreaming,
     );
-    expect(result[0].content).toBe(longContent);
+    expect(result).toBe(next);
+    expect(result[0].content).toBe('short');
+  });
+
+
+  it('prefers previous longer content when backend snapshot text is shorter during streaming', () => {
+    const prev = [
+      makeAssistantMsg('complete streamed answer', {
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'complete streamed answer' }],
+          },
+        } as any,
+      }),
+    ];
+    const next = [
+      makeAssistantMsg('partial', {
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'partial' }],
+          },
+        } as any,
+      }),
+    ];
+
+    const result = preserveStreamingAssistantContent(
+      prev, next, true, 'complete streamed answer',
+      findLastAssistantIndex, patchAssistantForStreaming,
+    );
+
+    expect(result[0].content).toBe('complete streamed answer');
   });
 });
 
@@ -457,13 +493,14 @@ describe('preserveLastAssistantIdentity — turn ID guards', () => {
     expect(result[0].timestamp).toBe(prevTs);
   });
 
-  it('allows merge when only one has turn ID (Java message without turnId)', () => {
+  it('does not merge identity when next assistant is missing turn ID', () => {
     const prevTs = '2024-01-01T10:00:00.000Z';
     const prev = [makeAssistantMsg('a1', { timestamp: prevTs, __turnId: 1 })];
     const next = [makeAssistantMsg('a1', { timestamp: '2024-01-01T10:00:01.000Z' })];
 
     const result = preserveLastAssistantIdentity(prev, next, findLastAssistantIndex);
-    expect(result[0].timestamp).toBe(prevTs);
+    expect(result).toBe(next);
+    expect(result[0].timestamp).toBe('2024-01-01T10:00:01.000Z');
   });
 });
 
@@ -492,6 +529,19 @@ describe('ensureStreamingAssistantInList', () => {
     expect(list).toHaveLength(2);
     expect(list[1]).toBe(streamingMsg);
     expect(streamingIndex).toBe(1);
+  });
+
+  it('repositions recovered streaming assistant after the latest user message in resultList', () => {
+    const previousUser = makeUserMsg('old user');
+    const currentUser = makeUserMsg('current user');
+    const streamingMsg = makeAssistantMsg('streaming content', { __turnId: 7, isStreaming: true });
+    const prev = [previousUser, streamingMsg];
+    const result = [previousUser, currentUser];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, true, 7);
+
+    expect(list).toEqual([previousUser, currentUser, streamingMsg]);
+    expect(streamingIndex).toBe(2);
   });
 
   // ---- Fallback path (refs cleared — race condition) ----

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -6,8 +6,11 @@
  * dependencies and receive everything they need via parameters.
  */
 
-import type { MutableRefObject } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage } from '../../types';
+import type { StreamingPatchState } from '../useStreamingMessages';
+
+/** Normalize CRLF / CR line endings to LF for consistent streaming comparisons. */
+export const normalizeStreamingNewlines = (value: string): string => value.replace(/\r\n?/g, '\n');
 
 /** Time window (ms) for matching optimistic messages with backend messages. */
 export const OPTIMISTIC_MESSAGE_TIME_WINDOW = 5000;
@@ -25,7 +28,7 @@ export const getRawUuid = (msg: ClaudeMessage | undefined): string | undefined =
 
 export const stripUuidFromRaw = (raw: unknown): unknown => {
   if (!raw || typeof raw !== 'object') return raw;
-  const rawObj = raw as any;
+  const rawObj = raw as Record<string, unknown>;
   if (!('uuid' in rawObj)) return raw;
   const { uuid: _uuid, ...rest } = rawObj;
   return rest;
@@ -57,7 +60,7 @@ export const preserveMessageIdentity = (
   if (!prevUuid && nextUuid) {
     return {
       ...nextWithStableTimestamp,
-      raw: stripUuidFromRaw(nextWithStableTimestamp.raw) as any,
+      raw: stripUuidFromRaw(nextWithStableTimestamp.raw) as ClaudeMessage['raw'],
     };
   }
 
@@ -79,10 +82,22 @@ export const appendOptimisticMessageIfMissing = (
 
   const optimisticMsg = lastPrev;
 
+  // Extract optimistic raw object once, reused for both matching and attachment merge (I4: js-cache-property-access).
+  // NOTE: `as Record<string, unknown>` casts are used because ClaudeMessage.raw
+  // is typed as `ClaudeRawMessage | string | undefined` and we need uniform property access.
+  const optimisticRawObj = (optimisticMsg.raw && typeof optimisticMsg.raw === 'object')
+    ? optimisticMsg.raw as Record<string, unknown>
+    : undefined;
+  const optimisticMsgField = optimisticRawObj?.message as Record<string, unknown> | undefined;
+  const optimisticContentBlocks: unknown[] = Array.isArray(optimisticMsgField?.content)
+    ? optimisticMsgField!.content as unknown[]
+    : [];
+  const optimisticFirstText = (optimisticContentBlocks[0] as Record<string, unknown> | undefined)?.text;
+
   const matchFn = (m: ClaudeMessage) =>
     m.type === 'user' &&
     (m.content === optimisticMsg.content ||
-      m.content === (optimisticMsg.raw as any)?.message?.content?.[0]?.text) &&
+      m.content === optimisticFirstText) &&
     m.timestamp &&
     optimisticMsg.timestamp &&
     Math.abs(
@@ -97,27 +112,28 @@ export const appendOptimisticMessageIfMissing = (
   // Backend message matched the optimistic message.  Preserve attachment blocks
   // from the optimistic message into the backend message's raw data; otherwise
   // non-image file attachments won't be visible.
-  const optimisticRaw = optimisticMsg.raw as any;
-  const optimisticContent: unknown[] | undefined = optimisticRaw?.message?.content;
-  if (Array.isArray(optimisticContent)) {
-    const attachmentBlocks = optimisticContent.filter(
-      (b: any) => b && typeof b === 'object' && b.type === 'attachment',
+  if (optimisticContentBlocks.length > 0) {
+    const attachmentBlocks = optimisticContentBlocks.filter(
+      (b: unknown) => b && typeof b === 'object' && (b as Record<string, unknown>).type === 'attachment',
     );
     if (attachmentBlocks.length > 0) {
       const backendMsg = nextList[matchedIndex];
-      const backendRaw = (backendMsg.raw ?? {}) as any;
-      const backendContent: unknown[] = Array.isArray(backendRaw?.message?.content)
-        ? backendRaw.message.content
-        : Array.isArray(backendRaw?.content)
-          ? backendRaw.content
+      const backendRaw = (backendMsg.raw && typeof backendMsg.raw === 'object')
+        ? backendMsg.raw as Record<string, unknown>
+        : {} as Record<string, unknown>;
+      const backendMsgField = backendRaw.message as Record<string, unknown> | undefined;
+      const backendContent: unknown[] = Array.isArray(backendMsgField?.content)
+        ? backendMsgField!.content as unknown[]
+        : Array.isArray(backendRaw.content)
+          ? backendRaw.content as unknown[]
           : [];
       const mergedContent = [...attachmentBlocks, ...backendContent];
       const mergedRaw = {
         ...backendRaw,
-        message: { ...(backendRaw?.message ?? {}), content: mergedContent },
+        message: { ...(backendMsgField ?? {}), content: mergedContent },
       };
       const result = [...nextList];
-      result[matchedIndex] = { ...backendMsg, raw: mergedRaw };
+      result[matchedIndex] = { ...backendMsg, raw: mergedRaw as ClaudeMessage['raw'] };
       return result;
     }
   }
@@ -140,11 +156,12 @@ export const preserveLastAssistantIdentity = (
 
   const prevAssistant = prevList[prevAssistantIdx];
   const nextAssistant = nextList[nextAssistantIdx];
-  // Guard: do not merge identity across different streaming turns
-  // Only block when BOTH have __turnId and they differ; allow merge when either lacks __turnId (backward compat)
-  if (prevAssistant.__turnId !== undefined && nextAssistant.__turnId !== undefined &&
-      prevAssistant.__turnId !== nextAssistant.__turnId) {
-    return nextList;
+  // Guard: only preserve identity when both assistants prove they belong to the same turn.
+  // Missing nextAssistant.__turnId is treated as "cannot prove same turn", so fail closed.
+  if (prevAssistant.__turnId !== undefined) {
+    if (nextAssistant.__turnId === undefined || prevAssistant.__turnId !== nextAssistant.__turnId) {
+      return nextList;
+    }
   }
   const stabilized = preserveMessageIdentity(prevAssistant, nextAssistant);
   if (stabilized === nextAssistant) return nextList;
@@ -157,16 +174,19 @@ export const preserveLastAssistantIdentity = (
 /**
  * When streaming is active, prevent the backend from replacing the streamed
  * content with a shorter (stale) snapshot.
+ *
+ * Accepts primitive values (not refs) so callers can pass pre-snapshotted values,
+ * guaranteeing idempotent results under React StrictMode double-invocation.
  */
 export const preserveStreamingAssistantContent = (
   prevList: ClaudeMessage[],
   nextList: ClaudeMessage[],
-  isStreamingRef: MutableRefObject<boolean>,
-  streamingContentRef: MutableRefObject<string>,
+  isStreaming: boolean,
+  streamingContent: string,
   findLastAssistantIndex: (messages: ClaudeMessage[]) => number,
-  patchAssistantForStreaming: (msg: ClaudeMessage) => ClaudeMessage,
+  patchAssistantForStreaming: (msg: ClaudeMessage, patchState?: StreamingPatchState) => ClaudeMessage,
 ): ClaudeMessage[] => {
-  if (!isStreamingRef.current) return nextList;
+  if (!isStreaming) return nextList;
 
   const prevAssistantIdx = findLastAssistantIndex(prevList);
   const nextAssistantIdx = findLastAssistantIndex(nextList);
@@ -178,15 +198,16 @@ export const preserveStreamingAssistantContent = (
     return nextList;
   }
 
-  // Guard: do not merge content across different streaming turns
-  // Only block when BOTH have __turnId and they differ
-  if (prevAssistant.__turnId !== undefined && nextAssistant.__turnId !== undefined &&
-      prevAssistant.__turnId !== nextAssistant.__turnId) {
-    return nextList;
+  // Guard: only preserve streaming content when both assistants prove they belong to the same turn.
+  // Missing nextAssistant.__turnId is treated as "cannot prove same turn", so fail closed.
+  if (prevAssistant.__turnId !== undefined) {
+    if (nextAssistant.__turnId === undefined || prevAssistant.__turnId !== nextAssistant.__turnId) {
+      return nextList;
+    }
   }
 
   const previousContent = prevAssistant.content || '';
-  const bufferedContent = streamingContentRef.current || '';
+  const bufferedContent = streamingContent || '';
   const preferredContent =
     bufferedContent.length > previousContent.length ? bufferedContent : previousContent;
   const nextContent = nextAssistant.content || '';
@@ -200,6 +221,8 @@ export const preserveStreamingAssistantContent = (
     ...nextAssistant,
     content: preferredContent,
     isStreaming: true,
+  }, {
+    canonicalText: preferredContent,
   });
   return copy;
 };
@@ -236,13 +259,16 @@ export const preserveLatestMessagesOnShrink = (
 
 /**
  * Ensure a streaming assistant message is not lost when updateMessages replaces
- * the entire message list.  Returns the (possibly amended) result list and the
+ * the entire message list. Returns the (possibly amended) result list and the
  * index of the streaming assistant inside it.
  *
  * The function has two paths:
  * 1. Primary — refs are valid (normal streaming).
  * 2. Fallback — refs already cleared (race condition). Uses message-level
  *    `isStreaming` + `__turnId` markers to recover.
+ *
+ * Recovered assistants are inserted immediately after the latest user message in
+ * `resultList` so the current turn can never render assistant-before-user.
  */
 export const ensureStreamingAssistantInList = (
   prevList: ClaudeMessage[],
@@ -250,6 +276,19 @@ export const ensureStreamingAssistantInList = (
   isStreaming: boolean,
   streamingTurnId: number,
 ): { list: ClaudeMessage[]; streamingIndex: number } => {
+  const insertAfterLatestUser = (streamingAssistant: ClaudeMessage): { list: ClaudeMessage[]; streamingIndex: number } => {
+    for (let i = resultList.length - 1; i >= 0; i -= 1) {
+      if (resultList[i]?.type === 'user') {
+        const result = [...resultList];
+        result.splice(i + 1, 0, streamingAssistant);
+        return { list: result, streamingIndex: i + 1 };
+      }
+    }
+
+    const result = [...resultList, streamingAssistant];
+    return { list: result, streamingIndex: result.length - 1 };
+  };
+
   // Primary path: refs are still valid
   if (isStreaming && streamingTurnId > 0) {
     const existingIdx = resultList.findIndex(
@@ -260,7 +299,7 @@ export const ensureStreamingAssistantInList = (
     }
 
     let streamingAssistant: ClaudeMessage | undefined;
-    for (let i = prevList.length - 1; i >= 0; i--) {
+    for (let i = prevList.length - 1; i >= 0; i -= 1) {
       if (prevList[i].__turnId === streamingTurnId && prevList[i].type === 'assistant') {
         streamingAssistant = prevList[i];
         break;
@@ -268,8 +307,7 @@ export const ensureStreamingAssistantInList = (
     }
 
     if (streamingAssistant) {
-      const result = [...resultList, streamingAssistant];
-      return { list: result, streamingIndex: result.length - 1 };
+      return insertAfterLatestUser(streamingAssistant);
     }
 
     return { list: resultList, streamingIndex: -1 };
@@ -277,7 +315,7 @@ export const ensureStreamingAssistantInList = (
 
   // Fallback path: refs already cleared (race condition).
   // Only consider the most recent streaming assistant in prevList.
-  for (let i = prevList.length - 1; i >= 0; i--) {
+  for (let i = prevList.length - 1; i >= 0; i -= 1) {
     const msg = prevList[i];
     if (msg.type === 'assistant' && msg.isStreaming && msg.__turnId && msg.__turnId > 0) {
       const alreadyPresent = resultList.some((m) => {
@@ -286,12 +324,8 @@ export const ensureStreamingAssistantInList = (
         if (msg.timestamp && m.timestamp === msg.timestamp) return true;
         return false;
       });
-      const assistantAlreadyAtOrAfterPosition =
-        i < resultList.length && resultList.slice(i).some((m) => m.type === 'assistant');
-
-      if (!alreadyPresent && !assistantAlreadyAtOrAfterPosition) {
-        const result = [...resultList, msg];
-        return { list: result, streamingIndex: result.length - 1 };
+      if (!alreadyPresent) {
+        return insertAfterLatestUser(msg);
       }
       // Already in resultList — no recovery needed
       break;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -48,7 +48,6 @@ export function registerWindowCallbacks(
     setIsThinking: options.setIsThinking,
     setStreamingActive: options.setStreamingActive,
     isStreamingRef: options.isStreamingRef,
-    useBackendStreamingRenderRef: options.useBackendStreamingRenderRef,
     streamingMessageIndexRef: options.streamingMessageIndexRef,
     streamingContentRef: options.streamingContentRef,
     streamingTextSegmentsRef: options.streamingTextSegmentsRef,

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -9,11 +9,13 @@
 
 import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
 import type { ClaudeMessage } from '../../../types';
+import type { ContentBlock } from '../../useStreamingMessages';
 import { sendBridgeEvent } from '../../../utils/bridge';
 import {
   appendOptimisticMessageIfMissing,
   ensureStreamingAssistantInList,
   getRawUuid,
+  normalizeStreamingNewlines,
   preserveLastAssistantIdentity,
   preserveLatestMessagesOnShrink,
   preserveStreamingAssistantContent,
@@ -21,6 +23,258 @@ import {
 import { releaseSessionTransition } from '../sessionTransition';
 
 const isTruthy = (v: unknown) => v === true || v === 'true';
+
+/**
+ * Pre-compiled regex for collapsing whitespace sequences during streaming value comparison.
+ * Hoisted to module level to avoid per-call RegExp object creation (js-hoist-regexp).
+ * Safe to reuse with String.prototype.replace which does not depend on lastIndex.
+ */
+const WHITESPACE_COLLAPSE_RE = /\s+/g;
+
+/**
+ * Combined single-pass extraction of canonical text and thinking from backend blocks.
+ * Avoids iterating the blocks array twice (js-combine-array-iterations).
+ */
+const extractCanonicalContent = (blocks: ContentBlock[]): { text: string; thinking: string } => {
+  let text = '';
+  let thinking = '';
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text') {
+      // Runtime guard retained for defensive safety against SDK bridge data (N2).
+      const t = (block as Record<string, unknown>).text;
+      if (typeof t === 'string') text += t;
+    } else if (block.type === 'thinking') {
+      const b = block as Record<string, unknown>;
+      if (typeof b.thinking === 'string') thinking += b.thinking;
+      else if (typeof b.text === 'string') thinking += b.text as string;
+    }
+  }
+  return { text, thinking: normalizeStreamingNewlines(thinking) };
+};
+
+/** Extract canonical text from backend blocks. Thin wrapper over extractCanonicalContent. */
+const extractCanonicalTextFromBlocks = (blocks: ContentBlock[]): string =>
+  extractCanonicalContent(blocks).text;
+
+/** Extract canonical thinking text from backend blocks (checks both `thinking` and `text` fields). */
+const extractCanonicalThinkingFromBlocks = (blocks: ContentBlock[]): string =>
+  extractCanonicalContent(blocks).thinking;
+
+/**
+ * Choose the more complete streaming value between current and candidate.
+ *
+ * Used ONLY during streaming to detect same-length mutations (e.g., typo fixes)
+ * and prefer longer content. DO NOT use for non-streaming message merges.
+ *
+ * Selection priority:
+ * 1. If candidate is empty, keep current (preserve existing content)
+ * 2. If current is empty, use candidate (adopt new content)
+ * 3. If candidate is longer, use candidate (more complete content)
+ * 4. If same length but different content, use candidate only if it has
+ *    meaningful character differences (not just whitespace/formatting changes)
+ * 5. Otherwise, keep current (identical content)
+ *
+ * Note: Same-length different content checks for meaningful changes because:
+ * - Backend may correct typos without changing length (e.g., "axc" -> "abc")
+ * - Whitespace-only changes (e.g., "hello world" -> "hello  world") are less
+ *   likely to be intentional corrections and may cause visual flicker
+ * - This ensures UI shows the most accurate version while avoiding unnecessary updates
+ */
+const chooseMoreCompleteStreamingValue = (currentValue: string, candidateValue: string): string => {
+  if (!candidateValue) return currentValue;
+  if (!currentValue) return candidateValue;
+  if (candidateValue.length > currentValue.length) return candidateValue;
+  if (candidateValue.length === currentValue.length && candidateValue !== currentValue) {
+    // Check if the difference is meaningful (not just whitespace/formatting)
+    const currentTrimmed = currentValue.replace(WHITESPACE_COLLAPSE_RE, ' ').trim();
+    const candidateTrimmed = candidateValue.replace(WHITESPACE_COLLAPSE_RE, ' ').trim();
+    // Only switch if trimmed content differs (indicates real content change, not formatting)
+    if (candidateTrimmed !== currentTrimmed) {
+      return candidateValue;
+    }
+    // Whitespace-only difference: keep current to avoid visual flicker
+    return currentValue;
+  }
+  return currentValue;
+};
+
+/**
+ * Select the most complete text from multiple streaming sources.
+ * Delegates pairwise comparison to `chooseMoreCompleteStreamingValue` to avoid
+ * duplicating the whitespace-collapse / same-length heuristic.
+ *
+ * Implicit priority when candidates have equal length: the LAST candidate with a
+ * meaningful difference wins. Because candidates are collected in order
+ * [streamingContent, assistantContent, backendText], backendText receives the
+ * highest implicit priority — which is correct since the backend is the most
+ * authoritative source.
+ */
+const selectMostCompleteStreamingText = (
+  streamingContent: string,
+  assistantContent: string,
+  backendText: string,
+): string => {
+  // Fast path: single non-empty source (common during early streaming — js-early-exit)
+  if (!assistantContent && !backendText) return streamingContent || '';
+  if (!streamingContent && !backendText) return assistantContent || '';
+  if (!streamingContent && !assistantContent) return backendText || '';
+
+  // Pairwise reduction — order matters: later candidates win on tie (implicit priority).
+  // chooseMoreCompleteStreamingValue(current, candidate) keeps current when candidate
+  // is empty or shorter, and prefers candidate on same-length meaningful difference.
+  let best = streamingContent || '';
+  if (assistantContent) best = chooseMoreCompleteStreamingValue(best, assistantContent);
+  if (backendText) best = chooseMoreCompleteStreamingValue(best, backendText);
+  return best;
+};
+
+/**
+ * Result of canonical streaming state computation.
+ * Separated from ref mutation so the caller can apply ref updates outside the state updater.
+ */
+interface CanonicalStreamingResult {
+  assistant: ClaudeMessage;
+  nextText: string;
+  nextThinking: string;
+  /** Pre-extracted blocks from the assistant, returned to avoid redundant extraction. */
+  blocks: ContentBlock[];
+}
+
+/**
+ * Compute the canonical streaming state from backend blocks and snapshotted ref values.
+ * This is a PURE computation — it accepts plain values (not refs) to guarantee
+ * idempotent results under React StrictMode double-invocation.
+ *
+ * Accepts pre-extracted `blocks` to avoid redundant `extractRawBlocks` calls on the
+ * hot streaming reconciliation path (I3: js-combine-iterations).
+ *
+ * Callers MUST snapshot ref values BEFORE the state updater and pass those snapshots here.
+ */
+const computeCanonicalStreamingState = (
+  assistant: ClaudeMessage,
+  blocks: ContentBlock[],
+  snapshotStreamingContent: string,
+  snapshotThinkingContent: string,
+): CanonicalStreamingResult => {
+  const { text: backendText, thinking: backendThinking } = extractCanonicalContent(blocks);
+
+  // Use clear priority-based selection for text
+  const nextText = selectMostCompleteStreamingText(
+    snapshotStreamingContent,
+    assistant.content || '',
+    backendText,
+  );
+
+  // For thinking, use simpler comparison since we only have two sources
+  const currentThinking = normalizeStreamingNewlines(snapshotThinkingContent);
+  const nextThinking = chooseMoreCompleteStreamingValue(currentThinking, backendThinking);
+
+  return {
+    assistant: {
+      ...assistant,
+      content: nextText,
+    },
+    nextText,
+    nextThinking,
+    blocks,
+  };
+};
+
+/**
+ * Fast djb2-style string hash for structural comparison of thinking block content.
+ * Iterates the full string to guarantee that changes in any position are detected.
+ * Returns a 32-bit unsigned integer as a hex string.
+ */
+const djb2Hash = (str: string): string => {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  // eslint-disable-next-line no-bitwise
+  return (hash >>> 0).toString(16);
+};
+
+/**
+ * Generate a content hash for structural block signature comparison.
+ * Uses djb2 hash of the full content + length to reliably detect changes
+ * in any part of the content, avoiding the sampling blind spots
+ * of prefix/suffix approaches. For short content (<=100 chars), the full
+ * text is included directly to preserve human readability in debug output.
+ *
+ * Applied to both thinking and text blocks to avoid creating large temporary
+ * strings on the hot streaming reconciliation path (GC pressure reduction).
+ */
+const getContentHash = (content: string): string => {
+  if (!content) return 'empty';
+  if (content.length <= 100) return `${content.length}:${content}`;
+  return `${content.length}:${djb2Hash(content)}`;
+};
+
+const getStructuralBlockSignature = (block: ContentBlock | null | undefined): string => {
+  if (!block || typeof block !== 'object') return 'invalid';
+
+  // Cast to Record for uniform property access — all accesses use typeof guards below.
+  const b = block as Record<string, unknown>;
+  const type = typeof b.type === 'string' ? b.type : 'unknown';
+  // Use string template instead of JSON.stringify for the four common block types
+  // to avoid serialization overhead on the hot streaming reconciliation path.
+  switch (type) {
+    case 'thinking': {
+      // Fall back to b.text for legacy/variant formats (consistent with extractCanonicalThinkingFromBlocks).
+      const sig = typeof b.signature === 'string' ? b.signature : '';
+      const content = typeof b.thinking === 'string' ? (b.thinking as string) :
+        typeof b.text === 'string' ? (b.text as string) : '';
+      return `thinking|${sig}|${getContentHash(content)}`;
+    }
+    case 'text': {
+      const text = typeof b.text === 'string' ? (b.text as string) : '';
+      return `text|${getContentHash(text)}`;
+    }
+    case 'tool_use':
+      return `tool_use|${typeof b.id === 'string' ? b.id : ''}|${typeof b.name === 'string' ? b.name : ''}`;
+    case 'tool_result':
+      return `tool_result|${typeof b.tool_use_id === 'string' ? b.tool_use_id : ''}|${b.is_error === true}`;
+    default:
+      // Unknown block types: use type + key identity fields for lightweight comparison
+      // instead of full JSON.stringify (N1: avoids serialization overhead).
+      return `${type}|${typeof b.id === 'string' ? b.id : ''}|${typeof b.name === 'string' ? b.name : ''}`;
+  }
+};
+
+const hasStructuralBlockChange = (previousBlocks: ContentBlock[], nextBlocks: ContentBlock[]): boolean => {
+  // Early length check avoids expensive signature computation (js-length-check-first).
+  if (previousBlocks.length !== nextBlocks.length) return true;
+
+  // Compute signatures inline — each signature is used exactly once, so
+  // creating an intermediate array via .map() is unnecessary GC pressure
+  // on the hot streaming reconciliation path (I2).
+  for (let i = 0; i < nextBlocks.length; i += 1) {
+    if (getStructuralBlockSignature(previousBlocks[i]) !== getStructuralBlockSignature(nextBlocks[i])) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const collectAssistantBlocks = (
+  messages: ClaudeMessage[],
+  extractBlocks: (raw: ClaudeMessage['raw']) => ContentBlock[],
+): ContentBlock[] => {
+  const collected: ContentBlock[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (message?.type !== 'assistant') continue;
+    const blocks = extractBlocks(message.raw);
+    if (blocks.length > 0) {
+      collected.push(...blocks);
+    }
+  }
+  return collected;
+};
 
 export function registerMessageCallbacks(
   options: UseWindowCallbacksOptions,
@@ -40,8 +294,9 @@ export function registerMessageCallbacks(
     suppressNextStatusToastRef,
     streamingContentRef,
     isStreamingRef,
-    useBackendStreamingRenderRef,
+    streamingTextSegmentsRef,
     activeTextSegmentIndexRef,
+    streamingThinkingSegmentsRef,
     activeThinkingSegmentIndexRef,
     seenToolUseCountRef,
     streamingMessageIndexRef,
@@ -84,101 +339,19 @@ export function registerMessageCallbacks(
     try {
       const parsed = JSON.parse(json) as ClaudeMessage[];
 
+      // Snapshot ref values BEFORE the state updater for the primary
+      // reconciliation path (computeCanonicalStreamingState). Some intermediate
+      // steps (preserveStreamingAssistantContent, seenToolUseCountRef) still
+      // read refs directly — this is safe because their logic converges
+      // monotonically: content selection always picks the longest value, and
+      // tool-use count only increases. Ref mutations still happen inside the
+      // updater (same as onStreamEnd pattern) to ensure previously queued
+      // updaters still read valid refs when React processes them in enqueue order.
+      const snapshotStreamingContent = streamingContentRef.current;
+      const snapshotThinkingContent = streamingThinkingSegmentsRef.current.join('');
+
       setMessages((prev) => {
-        // If streaming is active, delegate to the streaming logic
-        if (isStreamingRef.current) {
-          if (useBackendStreamingRenderRef.current) {
-            let smartMerged = parsed.map((newMsg, i) => {
-              if (i === parsed.length - 1) return newMsg;
-              if (i < prev.length) {
-                const oldMsg = prev[i];
-                if (
-                  oldMsg.timestamp === newMsg.timestamp &&
-                  oldMsg.type === newMsg.type &&
-                  oldMsg.content === newMsg.content
-                ) {
-                  return oldMsg;
-                }
-              }
-              return newMsg;
-            });
-
-            smartMerged = preserveLastAssistantIdentity(prev, smartMerged, findLastAssistantIndex);
-            smartMerged = preserveStreamingAssistantContent(
-              prev,
-              smartMerged,
-              isStreamingRef,
-              streamingContentRef,
-              findLastAssistantIndex,
-              patchAssistantForStreaming,
-            );
-            const result = preserveLatestMessagesOnShrink(
-              prev,
-              appendOptimisticMessageIfMissing(prev, smartMerged),
-              options.currentProviderRef.current,
-            );
-
-            // FIX: In Claude mode, update streamingMessageIndexRef so that
-            // onContentDelta knows which assistant message to update.
-            let lastAssistantIdx = findLastAssistantIndex(result);
-            // Verify the found assistant belongs to the current streaming turn
-            if (lastAssistantIdx >= 0 && streamingTurnIdRef.current > 0 &&
-                result[lastAssistantIdx].__turnId !== streamingTurnIdRef.current) {
-              // Scan for the correct turn ID match (from end, consistent with findLastAssistantIndex)
-              for (let i = result.length - 1; i >= 0; i--) {
-                if (result[i].type === 'assistant' && result[i].__turnId === streamingTurnIdRef.current) {
-                  lastAssistantIdx = i;
-                  break;
-                }
-              }
-            }
-            if (lastAssistantIdx >= 0) {
-              streamingMessageIndexRef.current = lastAssistantIdx;
-
-              // Always stamp __turnId so ensureStreamingAssistantPreserved can find it,
-              // even before any content delta arrives (streamingContentRef may be empty).
-              if (result[lastAssistantIdx]?.__turnId !== streamingTurnIdRef.current) {
-                result[lastAssistantIdx] = {
-                  ...result[lastAssistantIdx],
-                  __turnId: streamingTurnIdRef.current,
-                };
-              }
-
-              // FIX: If there is buffered streaming content (onContentDelta may
-              // fire before updateMessages), apply it to the assistant message
-              // immediately to prevent content loss.
-              if (streamingContentRef.current && result[lastAssistantIdx]?.type === 'assistant') {
-                const backendContent = result[lastAssistantIdx].content || '';
-                if (streamingContentRef.current.length >= backendContent.length) {
-                  result[lastAssistantIdx] = patchAssistantForStreaming({
-                    ...result[lastAssistantIdx],
-                    content: streamingContentRef.current,
-                    isStreaming: true,
-                  });
-                } else {
-                  // Backend has more complete content; sync buffer
-                  streamingContentRef.current = backendContent;
-                }
-              }
-            }
-
-            return ensureStreamingAssistantPreserved(prev, result);
-          }
-
-          const lastAssistantIdx = findLastAssistantIndex(parsed);
-          if (lastAssistantIdx < 0) {
-            return ensureStreamingAssistantPreserved(
-              prev,
-              preserveLatestMessagesOnShrink(
-                prev,
-                appendOptimisticMessageIfMissing(prev, parsed),
-                options.currentProviderRef.current,
-              ),
-            );
-          }
-        }
-
-        // Non-streaming case (or streaming hasn't started yet)
+        // ── Non-streaming path ──
         if (!isStreamingRef.current) {
           // Smart merge: reuse old message objects for performance
           let smartMerged = parsed.map((newMsg, i) => {
@@ -201,38 +374,72 @@ export function registerMessageCallbacks(
           return ensureStreamingAssistantPreserved(prev, appendOptimisticMessageIfMissing(prev, smartMerged));
         }
 
-        // Streaming + !useBackendStreamingRender: accept any snapshot that introduces or preserves tool_use blocks.
-        let totalToolUseCount = 0;
-        for (const message of parsed) {
-          if (message.type !== 'assistant') continue;
-          const blocks = extractRawBlocks(message.raw);
-          totalToolUseCount += blocks.filter((b) => b?.type === 'tool_use').length;
+        // ── Streaming path ──
+        const lastAssistantIdx = findLastAssistantIndex(parsed);
+
+        // Backend snapshot has no assistant message — preserve existing streaming assistant
+        if (lastAssistantIdx < 0) {
+          return ensureStreamingAssistantPreserved(
+            prev,
+            preserveLatestMessagesOnShrink(
+              prev,
+              appendOptimisticMessageIfMissing(prev, parsed),
+              options.currentProviderRef.current,
+            ),
+          );
         }
 
-        if (totalToolUseCount < seenToolUseCountRef.current) {
-          seenToolUseCountRef.current = totalToolUseCount;
-        }
-        const hasNewToolUse = totalToolUseCount > seenToolUseCountRef.current;
-        const hasToolUse = totalToolUseCount > 0;
+        // Determine whether the backend snapshot contains a structural change worth accepting
+        const lastAssistant = parsed[lastAssistantIdx];
+        const lastAssistantBlocks = extractRawBlocks(lastAssistant.raw);
+        const aggregatedAssistantBlocks = collectAssistantBlocks(parsed, extractRawBlocks);
+        const previousAssistantBlocks = collectAssistantBlocks(prev, extractRawBlocks);
+        const toolUseCount = aggregatedAssistantBlocks.filter((b) => b?.type === 'tool_use').length;
+        // Never decrease seenToolUseCountRef — stale snapshots with fewer tool_use blocks
+        // must not reset the high-water mark, or a later snapshot with the original count
+        // would falsely trigger hasNewToolUse again.
+        const hasNewToolUse = toolUseCount > seenToolUseCountRef.current;
+        const hasToolUse = toolUseCount > 0;
+        const structuralBlockChanged = hasStructuralBlockChange(previousAssistantBlocks, aggregatedAssistantBlocks);
 
-        if (!hasNewToolUse && !hasToolUse) {
-          return prev;
+        // No meaningful structural change in the backend assistant snapshot.
+        // Still accept newly arrived non-assistant messages (for example, the current
+        // user message restored by Java) while preserving the active streaming assistant.
+        if (!hasNewToolUse && !hasToolUse && !structuralBlockChanged) {
+          let unchanged = [...parsed];
+          unchanged = appendOptimisticMessageIfMissing(prev, unchanged);
+          unchanged = preserveLastAssistantIdentity(prev, unchanged, findLastAssistantIndex);
+          unchanged = preserveStreamingAssistantContent(
+            prev,
+            unchanged,
+            isStreamingRef.current,
+            snapshotStreamingContent,
+            findLastAssistantIndex,
+            patchAssistantForStreaming,
+          );
+          return ensureStreamingAssistantPreserved(prev, unchanged);
         }
 
         if (hasNewToolUse) {
-          seenToolUseCountRef.current = totalToolUseCount;
+          seenToolUseCountRef.current = toolUseCount;
           activeTextSegmentIndexRef.current = -1;
           activeThinkingSegmentIndexRef.current = -1;
         }
 
         let patched = [...parsed];
+        if (patched[lastAssistantIdx]?.type === 'assistant' && streamingTurnIdRef.current > 0) {
+          patched[lastAssistantIdx] = {
+            ...patched[lastAssistantIdx],
+            __turnId: streamingTurnIdRef.current,
+          };
+        }
         patched = appendOptimisticMessageIfMissing(prev, patched);
         patched = preserveLastAssistantIdentity(prev, patched, findLastAssistantIndex);
         patched = preserveStreamingAssistantContent(
           prev,
           patched,
-          isStreamingRef,
-          streamingContentRef,
+          isStreamingRef.current,
+          snapshotStreamingContent,
           findLastAssistantIndex,
           patchAssistantForStreaming,
         );
@@ -241,9 +448,38 @@ export function registerMessageCallbacks(
         const patchedAssistantIdx = findLastAssistantIndex(patched);
         if (patchedAssistantIdx >= 0 && patched[patchedAssistantIdx]?.type === 'assistant') {
           streamingMessageIndexRef.current = patchedAssistantIdx;
-          patched[patchedAssistantIdx] = patchAssistantForStreaming({
-            ...patched[patchedAssistantIdx],
-            __turnId: streamingTurnIdRef.current,
+
+          // Step 1: PURE computation — determine canonical text/thinking from
+          // snapshotted ref values (captured before the updater for StrictMode safety).
+          // Reuses lastAssistantBlocks extracted earlier to avoid redundant extractRawBlocks (I3).
+          const result = computeCanonicalStreamingState(
+            {
+              ...patched[patchedAssistantIdx],
+              __turnId: streamingTurnIdRef.current,
+            },
+            lastAssistantBlocks,
+            snapshotStreamingContent,
+            snapshotThinkingContent,
+          );
+
+          // Step 2: Apply computed canonical values to refs.
+          // These ref writes are idempotent under StrictMode double-invocation because
+          // computeCanonicalStreamingState was called with snapshotted values (not refs),
+          // so result.nextText / result.nextThinking are identical across invocations.
+          // Kept inside the updater (same as onStreamEnd pattern) to ensure previously
+          // queued updaters still read valid refs when React processes them in enqueue order.
+          streamingContentRef.current = result.nextText;
+          streamingTextSegmentsRef.current = result.nextText ? [result.nextText] : [];
+          activeTextSegmentIndexRef.current = result.nextText ? 0 : -1;
+          streamingThinkingSegmentsRef.current = result.nextThinking ? [result.nextThinking] : [];
+          activeThinkingSegmentIndexRef.current = result.nextThinking ? 0 : -1;
+
+          // Step 3: Rebuild assistant message blocks from canonical state.
+          // Uses result.blocks (pre-extracted) instead of re-calling extractRawBlocks (I3).
+          patched[patchedAssistantIdx] = patchAssistantForStreaming(result.assistant, {
+            canonicalText: result.nextText,
+            canonicalThinking: result.nextThinking,
+            existingBlocks: result.blocks,
           });
         }
 
@@ -375,8 +611,9 @@ export function registerMessageCallbacks(
         if (getRawUuid(message)) continue;
 
         const rawText = extractRawBlocks(message.raw)
-          .filter((block) => block?.type === 'text' && typeof block.text === 'string')
-          .map((block) => String(block.text))
+          .filter((block): block is ContentBlock & { type: 'text'; text: string } =>
+            block?.type === 'text' && 'text' in block && typeof (block as Record<string, unknown>).text === 'string')
+          .map((block) => block.text)
           .join('\n');
         if ((message.content || '') !== content && rawText !== content) continue;
 
@@ -445,7 +682,15 @@ export function registerMessageCallbacks(
       content: content || '',
       timestamp: new Date().toISOString(),
     };
-    setMessages((prev) => [...prev, userMessage]);
+    setMessages((prev) => {
+      const last = prev[prev.length - 1];
+      if (last?.type === 'assistant' && last?.isStreaming) {
+        const next = [...prev];
+        next.splice(prev.length - 1, 0, userMessage);
+        return next;
+      }
+      return [...prev, userMessage];
+    });
     userPausedRef.current = false;
     isUserAtBottomRef.current = true;
     requestAnimationFrame(() => {
@@ -456,3 +701,18 @@ export function registerMessageCallbacks(
   };
 
 }
+
+// ---------------------------------------------------------------------------
+// @internal — exported for direct unit testing only.
+// ---------------------------------------------------------------------------
+export {
+  chooseMoreCompleteStreamingValue as _chooseMoreCompleteStreamingValue,
+  selectMostCompleteStreamingText as _selectMostCompleteStreamingText,
+  computeCanonicalStreamingState as _computeCanonicalStreamingState,
+  getContentHash as _getContentHash,
+  getStructuralBlockSignature as _getStructuralBlockSignature,
+  hasStructuralBlockChange as _hasStructuralBlockChange,
+  collectAssistantBlocks as _collectAssistantBlocks,
+  extractCanonicalTextFromBlocks as _extractCanonicalTextFromBlocks,
+  extractCanonicalThinkingFromBlocks as _extractCanonicalThinkingFromBlocks,
+};

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -7,7 +7,7 @@
 
 import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
 import { sendBridgeEvent } from '../../../utils/bridge';
-import { THROTTLE_INTERVAL } from '../../useStreamingMessages';
+import { THROTTLE_INTERVAL, clearStreamingDataRefs } from '../../useStreamingMessages';
 
 /**
  * Timeout (ms) for detecting a stalled stream.  If no content/thinking delta
@@ -28,7 +28,6 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     setExpandedThinking,
     streamingContentRef,
     isStreamingRef,
-    useBackendStreamingRenderRef,
     autoExpandedThinkingKeysRef,
     streamingTextSegmentsRef,
     activeTextSegmentIndexRef,
@@ -42,7 +41,7 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     contentUpdateTimeoutRef,
     lastThinkingUpdateRef,
     thinkingUpdateTimeoutRef,
-    getOrCreateStreamingAssistantIndex,
+    findStreamingAssistantIndex,
     patchAssistantForStreaming,
   } = options;
 
@@ -92,20 +91,26 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
 
   window.onStreamStart = () => {
     if (window.__sessionTransitioning) return;
-    streamingContentRef.current = '';
-    isStreamingRef.current = true;
     startStallWatchdog();
-    useBackendStreamingRenderRef.current = false;
-    autoExpandedThinkingKeysRef.current.clear();
-    setStreamingActive(true);
-    streamingTextSegmentsRef.current = [];
-    activeTextSegmentIndexRef.current = -1;
-    streamingThinkingSegmentsRef.current = [];
-    activeThinkingSegmentIndexRef.current = -1;
-    seenToolUseCountRef.current = 0;
 
-    // FIX: Always reset streamingMessageIndexRef regardless of backend streaming mode
-    streamingMessageIndexRef.current = -1;
+    // Reset all streaming data refs via shared utility to stay in sync with
+    // onStreamEnd and resetStreamingState (avoids consistency drift if new
+    // refs are added to clearStreamingDataRefs in the future).
+    clearStreamingDataRefs({
+      streamingContentRef,
+      streamingTextSegmentsRef,
+      activeTextSegmentIndexRef,
+      streamingThinkingSegmentsRef,
+      activeThinkingSegmentIndexRef,
+      seenToolUseCountRef,
+      streamingMessageIndexRef,
+      streamingTurnIdRef,
+      autoExpandedThinkingKeysRef,
+    });
+
+    // Override values that differ from the "cleared" defaults for stream start.
+    isStreamingRef.current = true;
+    setStreamingActive(true);
     turnIdCounterRef.current += 1;
     streamingTurnIdRef.current = turnIdCounterRef.current;
     setMessages((prev) => {
@@ -116,57 +121,67 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
         updated[prev.length - 1] = { ...updated[prev.length - 1], __turnId: streamingTurnIdRef.current };
         return updated;
       }
+
+      const placeholder: typeof prev[number] = {
+        type: 'assistant',
+        content: '',
+        isStreaming: true,
+        timestamp: new Date().toISOString(),
+        __turnId: streamingTurnIdRef.current,
+      };
+
       streamingMessageIndexRef.current = prev.length;
-      return [
-        ...prev,
-        {
-          type: 'assistant',
-          content: '',
-          isStreaming: true,
-          timestamp: new Date().toISOString(),
-          __turnId: streamingTurnIdRef.current,
-        },
-      ];
+      return [...prev, placeholder];
     });
   };
 
   window.onContentDelta = (delta: string) => {
     if (window.__sessionTransitioning) return;
+    // SAFETY: Check if streaming ended (early-clear protection from onStreamEnd)
     if (!isStreamingRef.current) return;
     window.__lastStreamActivityAt = Date.now();
     streamingContentRef.current += delta;
-    activeThinkingSegmentIndexRef.current = -1;
+
+    // NOTE: No mutual-exclusion reset of activeThinkingSegmentIndexRef here.
+    // Under the single-thinking-block-per-turn design (Decision 3), thinking deltas
+    // always precede text deltas within a turn, so they cannot interleave. Both
+    // segment arrays accumulate independently and are merged by buildStreamingBlocks
+    // at render time. If the bridge later supports interleaved thinking/text, the
+    // segment arrays will still hold valid accumulated content without data loss.
 
     if (activeTextSegmentIndexRef.current < 0) {
-      activeTextSegmentIndexRef.current = streamingTextSegmentsRef.current.length;
-      streamingTextSegmentsRef.current.push('');
+      activeTextSegmentIndexRef.current = 0;
+      streamingTextSegmentsRef.current = [streamingContentRef.current];
+    } else {
+      streamingTextSegmentsRef.current[activeTextSegmentIndexRef.current] = streamingContentRef.current;
     }
-    streamingTextSegmentsRef.current[activeTextSegmentIndexRef.current] += delta;
 
     const now = Date.now();
     const timeSinceLastUpdate = now - lastContentUpdateRef.current;
 
     const updateMessages = () => {
       const currentContent = streamingContentRef.current;
+      const currentThinking = streamingThinkingSegmentsRef.current.join('');
       setMessages((prev) => {
-        const newMessages = [...prev];
-        let idx: number;
-        if (useBackendStreamingRenderRef.current) {
-          idx = streamingMessageIndexRef.current;
-          // Index is still -1: backend hasn't created the assistant via updateMessages yet
-          if (idx < 0) return prev;
-        } else {
-          idx = getOrCreateStreamingAssistantIndex(newMessages);
-        }
+        const idx = findStreamingAssistantIndex(prev);
 
-        if (idx >= 0 && newMessages[idx]?.type === 'assistant') {
-          newMessages[idx] = patchAssistantForStreaming({
-            ...newMessages[idx],
-            content: currentContent,
-            isStreaming: true,
-          });
+        if (idx >= 0 && idx < prev.length && prev[idx]?.type === 'assistant') {
+          const patched = patchAssistantForStreaming(
+            {
+              ...prev[idx],
+              content: currentContent,
+              isStreaming: true,
+            },
+            {
+              canonicalText: currentContent,
+              canonicalThinking: currentThinking,
+            },
+          );
+          const newMessages = [...prev];
+          newMessages[idx] = patched;
+          return newMessages;
         }
-        return newMessages;
+        return prev;
       });
     };
 
@@ -185,16 +200,30 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     }
   };
 
+  /**
+   * Handle thinking content delta during streaming.
+   *
+   * IMPORTANT: This implementation follows Decision 3 from design.md - single thinking block per turn.
+   * The segment management assumes only ONE active thinking segment at any time.
+   * This is safe because the bridge/frontend contract does not provide block-level lifecycle signals,
+   * so we cannot reliably detect multiple thinking blocks from delta-type switching alone.
+   *
+   * If the bridge later exposes explicit thinking-block-start events, this logic will need extension
+   * to support multiple thinking segments per turn.
+   */
   window.onThinkingDelta = (delta: string) => {
     if (window.__sessionTransitioning) return;
     if (!isStreamingRef.current) return;
     window.__lastStreamActivityAt = Date.now();
-    activeTextSegmentIndexRef.current = -1;
+
+    // NOTE: No mutual-exclusion reset of activeTextSegmentIndexRef here.
+    // See onContentDelta comment — thinking and text accumulate independently.
 
     let forceUpdate = false;
+    // Single-block mode: reset to single segment array when starting new thinking
     if (activeThinkingSegmentIndexRef.current < 0) {
-      activeThinkingSegmentIndexRef.current = streamingThinkingSegmentsRef.current.length;
-      streamingThinkingSegmentsRef.current.push('');
+      activeThinkingSegmentIndexRef.current = 0;
+      streamingThinkingSegmentsRef.current = [''];
       forceUpdate = true;
     }
     streamingThinkingSegmentsRef.current[activeThinkingSegmentIndexRef.current] += delta;
@@ -203,23 +232,28 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     const timeSinceLastUpdate = now - lastThinkingUpdateRef.current;
 
     const updateMessages = () => {
+      const currentThinking = streamingThinkingSegmentsRef.current.join('');
+      const currentContent = streamingContentRef.current;
       setMessages((prev) => {
-        const newMessages = [...prev];
-        let idx: number;
-        if (useBackendStreamingRenderRef.current) {
-          idx = streamingMessageIndexRef.current;
-          if (idx < 0) return prev;
-        } else {
-          idx = getOrCreateStreamingAssistantIndex(newMessages);
-        }
+        const idx = findStreamingAssistantIndex(prev);
 
-        if (idx >= 0 && newMessages[idx]?.type === 'assistant') {
-          newMessages[idx] = patchAssistantForStreaming({
-            ...newMessages[idx],
-            isStreaming: true,
-          });
+        if (idx >= 0 && idx < prev.length && prev[idx]?.type === 'assistant') {
+          const patched = patchAssistantForStreaming(
+            {
+              ...prev[idx],
+              content: currentContent,
+              isStreaming: true,
+            },
+            {
+              canonicalText: currentContent,
+              canonicalThinking: currentThinking,
+            },
+          );
+          const newMessages = [...prev];
+          newMessages[idx] = patched;
+          return newMessages;
         }
-        return newMessages;
+        return prev;
       });
     };
 
@@ -241,6 +275,11 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
   window.onStreamEnd = () => {
     if (window.__sessionTransitioning) return;
     clearStallWatchdog();
+
+    // SAFETY: Mark streaming as ending immediately to prevent late delta callbacks
+    // from interfering with the cleanup process. This flag is checked by delta handlers.
+    isStreamingRef.current = false; // Early clear to block new deltas
+
     // Notify backend about stream completion for tab status indicator
     sendBridgeEvent('tab_status_changed', JSON.stringify({ status: 'completed' }));
 
@@ -257,35 +296,64 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Snapshot keys that need collapsing BEFORE they are cleared inside the updater.
     const keysToCollapse = new Set(autoExpandedThinkingKeysRef.current);
 
+    // Snapshot final content and index BEFORE clearing refs for StrictMode safety.
+    // Under double-invocation, clearStreamingDataRefs resets streamingMessageIndexRef
+    // to -1 on the first call, so the second call would see an invalid index.
+    // By snapshotting here, both invocations use the same correct values.
+    const finalIdx = streamingMessageIndexRef.current;
+    const finalContentSnapshot = streamingContentRef.current;
+    const finalThinkingSnapshot = streamingThinkingSegmentsRef.current.join('');
+
     // Flush final content AND clear streaming refs inside the same updater.
     // This ensures any previously queued setMessages updater (e.g. from
     // updateMessages) still reads valid refs when it executes, because React
     // processes updaters in enqueue order.
     setMessages((prev) => {
       let newMessages = prev;
-      const idx = streamingMessageIndexRef.current;
+      const idx = finalIdx;
       if (prev.length > 0 && idx >= 0 && idx < prev.length && prev[idx]?.type === 'assistant') {
-        const finalContent = streamingContentRef.current;
         newMessages = [...prev];
-        newMessages[idx] = {
+        const flushedAssistant = patchAssistantForStreaming({
           ...newMessages[idx],
-          content: finalContent || newMessages[idx].content,
+          content: finalContentSnapshot || newMessages[idx].content,
+          isStreaming: true,
+        }, {
+          canonicalText: finalContentSnapshot || newMessages[idx].content || '',
+          canonicalThinking: finalThinkingSnapshot,
+        });
+        newMessages[idx] = {
+          ...flushedAssistant,
           isStreaming: false,
         };
       }
 
-      // Clear all streaming refs AFTER flushing content, inside the updater
-      isStreamingRef.current = false;
-      useBackendStreamingRenderRef.current = false;
-      streamingMessageIndexRef.current = -1;
-      streamingTurnIdRef.current = -1;
-      streamingContentRef.current = '';
-      streamingTextSegmentsRef.current = [];
-      activeTextSegmentIndexRef.current = -1;
-      streamingThinkingSegmentsRef.current = [];
-      activeThinkingSegmentIndexRef.current = -1;
-      seenToolUseCountRef.current = 0;
-      autoExpandedThinkingKeysRef.current.clear();
+      // Clear all streaming refs AFTER flushing content, inside the updater.
+      //
+      // INTENTIONAL SIDE EFFECT — this is an exception to the "updaters should be pure"
+      // rule. Refs are cleared here (not after setMessages) because:
+      // 1. React processes updaters in enqueue order, so a previously queued
+      //    updateMessages updater still reads valid refs when it executes.
+      // 2. Clearing refs after setMessages would create a window where delta callbacks
+      //    (blocked by isStreamingRef=false) could still see stale ref values if React
+      //    batches a second state update between setMessages and the cleanup code.
+      // 3. All mutations here are idempotent, so double-invocation (e.g., React StrictMode)
+      //    is safe.
+      //
+      // TODO(react-19): Verify this pattern remains safe under React 19 concurrent mode.
+      // React 19 may discard updater results in certain concurrent transitions, which
+      // could skip the ref-clearing side effect. Monitor React changelog for changes
+      // to updater purity guarantees.
+      clearStreamingDataRefs({
+        streamingContentRef,
+        streamingTextSegmentsRef,
+        activeTextSegmentIndexRef,
+        streamingThinkingSegmentsRef,
+        activeThinkingSegmentIndexRef,
+        seenToolUseCountRef,
+        streamingMessageIndexRef,
+        streamingTurnIdRef,
+        autoExpandedThinkingKeysRef,
+      });
 
       return newMessages;
     });
@@ -320,11 +388,10 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
       window.__deniedToolIds = new Set<string>();
     }
 
-    const idsToAdd: string[] = [];
-
     setMessages((currentMessages) => {
+      let changed = false;
       try {
-        for (let i = currentMessages.length - 1; i >= 0; i--) {
+        for (let i = currentMessages.length - 1; i >= 0; i -= 1) {
           const msg = currentMessages[i];
           if (msg.type === 'assistant' && msg.raw) {
             const rawObj = typeof msg.raw === 'string' ? JSON.parse(msg.raw) : msg.raw;
@@ -353,9 +420,13 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
                   }
                 }
 
-                for (const tu of toolUses) {
-                  if (!existingResultIds.has(tu.id)) {
-                    idsToAdd.push(tu.id);
+                // Add denied IDs inside the updater to ensure atomicity with
+                // message state — avoids the race where React 18 batching defers
+                // the updater execution past the old for-loop that ran after setMessages.
+                for (let j = 0; j < toolUses.length; j += 1) {
+                  if (!existingResultIds.has(toolUses[j].id)) {
+                    window.__deniedToolIds!.add(toolUses[j].id);
+                    changed = true;
                   }
                 }
 
@@ -368,11 +439,9 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
         console.error('[Frontend] Error in onPermissionDenied:', e);
       }
 
-      return [...currentMessages];
+      // Only create new array reference when denied IDs were added, to avoid
+      // unnecessary React re-renders (rerender-functional-setstate).
+      return changed ? [...currentMessages] : currentMessages;
     });
-
-    for (const id of idsToAdd) {
-      window.__deniedToolIds!.add(id);
-    }
   };
 }

--- a/webview/src/hooks/windowCallbacks/sessionTransition.ts
+++ b/webview/src/hooks/windowCallbacks/sessionTransition.ts
@@ -18,7 +18,6 @@ export interface ResetTransientUiStateOptions {
 
   // Streaming refs
   isStreamingRef: MutableRefObject<boolean>;
-  useBackendStreamingRenderRef: MutableRefObject<boolean>;
   streamingMessageIndexRef: MutableRefObject<number>;
   streamingContentRef: MutableRefObject<string>;
   streamingTextSegmentsRef: MutableRefObject<string[]>;
@@ -48,7 +47,6 @@ export const buildResetTransientUiState = (opts: ResetTransientUiStateOptions) =
     opts.setIsThinking(false);
     opts.setStreamingActive(false);
     opts.isStreamingRef.current = false;
-    opts.useBackendStreamingRenderRef.current = false;
     opts.streamingMessageIndexRef.current = -1;
     opts.streamingContentRef.current = '';
     opts.streamingTextSegmentsRef.current = [];

--- a/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
+++ b/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
@@ -11,24 +11,38 @@ import { sendBridgeEvent } from '../../utils/bridge';
 const MAX_RETRIES = 30;
 
 /**
+ * Retry a callback until `window.sendToJava` is available.
+ * Guards against timer firing after test environment teardown (jsdom removed).
+ * Extracted to deduplicate the identical retry-with-timeout pattern (N2).
+ */
+const retryUntilBridgeReady = (action: () => void): void => {
+  let retryCount = 0;
+  const attempt = () => {
+    if (typeof window === 'undefined') return;
+    if (window.sendToJava) {
+      action();
+    } else {
+      retryCount += 1;
+      if (retryCount < MAX_RETRIES) {
+        setTimeout(attempt, 100);
+      }
+    }
+  };
+  setTimeout(attempt, 200);
+};
+
+/**
  * Fire the three settings queries to the backend.  Retries up to MAX_RETRIES
  * times (at 100 ms intervals) if window.sendToJava is not yet available.
  */
 export const startInitialSettingsRequest = (): void => {
-  let settingsRetryCount = 0;
-  const requestInitialSettings = () => {
-    if (window.sendToJava) {
-      window.sendToJava('get_streaming_enabled:');
-      window.sendToJava('get_send_shortcut:');
-      window.sendToJava('get_auto_open_file_enabled:');
-    } else {
-      settingsRetryCount++;
-      if (settingsRetryCount < MAX_RETRIES) {
-        setTimeout(requestInitialSettings, 100);
-      }
-    }
-  };
-  setTimeout(requestInitialSettings, 200);
+  retryUntilBridgeReady(() => {
+    // Non-null assertion safe: retryUntilBridgeReady only calls action() after
+    // confirming window.sendToJava is truthy.
+    window.sendToJava!('get_streaming_enabled:');
+    window.sendToJava!('get_send_shortcut:');
+    window.sendToJava!('get_auto_open_file_enabled:');
+  });
 };
 
 /**
@@ -36,54 +50,21 @@ export const startInitialSettingsRequest = (): void => {
  * available.
  */
 export const startActiveProviderRequest = (): void => {
-  let retryCount = 0;
-  const requestActiveProvider = () => {
-    if (window.sendToJava) {
-      sendBridgeEvent('get_active_provider');
-    } else {
-      retryCount++;
-      if (retryCount < MAX_RETRIES) {
-        setTimeout(requestActiveProvider, 100);
-      }
-    }
-  };
-  setTimeout(requestActiveProvider, 200);
+  retryUntilBridgeReady(() => sendBridgeEvent('get_active_provider'));
 };
 
 /**
  * Request the current permission mode from the backend.
  */
 export const startModeRequest = (): void => {
-  let modeRetryCount = 0;
-  const requestMode = () => {
-    if (window.sendToJava) {
-      sendBridgeEvent('get_mode');
-    } else {
-      modeRetryCount++;
-      if (modeRetryCount < MAX_RETRIES) {
-        setTimeout(requestMode, 100);
-      }
-    }
-  };
-  setTimeout(requestMode, 200);
+  retryUntilBridgeReady(() => sendBridgeEvent('get_mode'));
 };
 
 /**
  * Request the thinking-enabled setting from the backend.
  */
 export const startThinkingEnabledRequest = (): void => {
-  let thinkingRetryCount = 0;
-  const requestThinkingEnabled = () => {
-    if (window.sendToJava) {
-      sendBridgeEvent('get_thinking_enabled');
-    } else {
-      thinkingRetryCount++;
-      if (thinkingRetryCount < MAX_RETRIES) {
-        setTimeout(requestThinkingEnabled, 100);
-      }
-    }
-  };
-  setTimeout(requestThinkingEnabled, 200);
+  retryUntilBridgeReady(() => sendBridgeEvent('get_thinking_enabled'));
 };
 
 /**

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -26,6 +26,11 @@ export interface ClaudeRawMessage {
   [key: string]: unknown;
 }
 
+export interface ClaudeMessageSourceRange {
+  start: number;
+  end: number;
+}
+
 /** Represents a single message in the chat conversation. */
 export interface ClaudeMessage {
   type: ClaudeRole;
@@ -36,6 +41,10 @@ export interface ClaudeMessage {
   isOptimistic?: boolean;
   /** Runtime-only: numeric turn identifier for streaming assistant isolation. */
   __turnId?: number;
+  /** Runtime-only: source raw message range merged into this rendered message. */
+  __sourceRange?: ClaudeMessageSourceRange;
+  /** Runtime-only: stable fallback render key for messages lacking persistent identity. */
+  __renderKey?: string;
   [key: string]: unknown;
 }
 

--- a/webview/src/utils/copyUtils.test.ts
+++ b/webview/src/utils/copyUtils.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { extractMarkdownContent, copyToClipboard } from './copyUtils';
+import type { ClaudeMessage } from '../types';
+
+describe('extractMarkdownContent', () => {
+  it('copies merged assistant text while skipping tool_use blocks', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'tool phase\nfinal answer',
+      raw: {
+        message: {
+          content: [
+            { type: 'text', text: 'tool phase' },
+            { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'a.ts' } },
+            { type: 'text', text: 'final answer' },
+          ],
+        },
+      } as any,
+    };
+
+    expect(extractMarkdownContent(message)).toBe('tool phase\n\nfinal answer');
+  });
+
+  it('optionally includes thinking blocks in copied markdown', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'final answer',
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'reasoning' },
+            { type: 'text', text: 'final answer' },
+          ],
+        },
+      } as any,
+    };
+
+    expect(extractMarkdownContent(message, true)).toBe('<thinking>\nreasoning\n</thinking>\n\nfinal answer');
+    expect(extractMarkdownContent(message, false)).toBe('final answer');
+  });
+});
+
+describe('copyToClipboard', () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    });
+    document.execCommand = originalExecCommand;
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.clipboard when available', async () => {
+    await expect(copyToClipboard('hello')).resolves.toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('falls back to execCommand when clipboard API fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error('denied')),
+      },
+    });
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    await expect(copyToClipboard('fallback')).resolves.toBe(true);
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+});

--- a/webview/src/utils/copyUtils.ts
+++ b/webview/src/utils/copyUtils.ts
@@ -1,41 +1,11 @@
 import type { ClaudeMessage, ClaudeContentBlock, ClaudeRawMessage } from '../types';
+import { normalizeBlocks as normalizeBlocksForMessages } from './messageUtils';
 
 /**
  * Normalize raw message blocks to ClaudeContentBlock array
  */
 function normalizeBlocks(raw: ClaudeRawMessage | string | undefined): ClaudeContentBlock[] | null {
-  if (!raw) return null;
-
-  if (typeof raw === 'string') {
-    return [{ type: 'text', text: raw }];
-  }
-
-  // Check raw.content
-  if (Array.isArray(raw.content)) {
-    return raw.content.filter(
-      (block): block is ClaudeContentBlock =>
-        block.type === 'text' || block.type === 'thinking' || block.type === 'tool_use' || block.type === 'image'
-    );
-  }
-
-  if (typeof raw.content === 'string') {
-    return [{ type: 'text', text: raw.content }];
-  }
-
-  // Check raw.message?.content
-  const msgContent = raw.message?.content;
-  if (Array.isArray(msgContent)) {
-    return msgContent.filter(
-      (block): block is ClaudeContentBlock =>
-        block.type === 'text' || block.type === 'thinking' || block.type === 'tool_use' || block.type === 'image'
-    );
-  }
-
-  if (typeof msgContent === 'string') {
-    return [{ type: 'text', text: msgContent }];
-  }
-
-  return null;
+  return normalizeBlocksForMessages(raw, (text) => text, ((key: string) => key) as any);
 }
 
 /**

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ClaudeMessage } from '../types';
-import { getMessageKey, mergeConsecutiveAssistantMessages } from './messageUtils';
+import { getMessageKey, getContentBlocks, mergeConsecutiveAssistantMessages, normalizeBlocks, findToolResultBlock } from './messageUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -14,6 +14,19 @@ const makeMsg = (
   type,
   content,
   timestamp: new Date().toISOString(),
+  ...extra,
+});
+
+const normalizeRenderableBlocks = (raw: unknown): any[] => {
+  if (!raw || typeof raw !== 'object') return [];
+  const r = raw as any;
+  const blocks = r.content ?? r.message?.content;
+  return Array.isArray(blocks) ? blocks : [];
+};
+
+const buildKeyFallbackMessage = (content: string, extra?: Partial<ClaudeMessage>): ClaudeMessage => ({
+  type: 'assistant',
+  content,
   ...extra,
 });
 
@@ -35,20 +48,55 @@ describe('getMessageKey', () => {
     expect(getMessageKey(msg, 0)).toBe('abc-123');
   });
 
-  it('returns __turnId-based key when uuid is absent', () => {
-    const msg = makeMsg('assistant', 'hello', { __turnId: 3 });
+  it('returns stable turn key when uuid is absent and message has merged raw blocks', () => {
+    const ts = '2024-01-01T00:00:00Z';
+    const msg = makeMsg('assistant', 'hello', {
+      __turnId: 3,
+      timestamp: ts,
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'plan' },
+            { type: 'tool_use', id: 'tool-1', name: 'Read' },
+          ],
+        },
+      } as any,
+    });
     expect(getMessageKey(msg, 0)).toBe('turn-3');
   });
 
-  it('falls back to type-timestamp when both uuid and __turnId are absent', () => {
+  it('returns same key for same __turnId even when timestamps differ', () => {
+    const a = makeMsg('assistant', 'hello', { __turnId: 3, timestamp: '2024-01-01T00:00:00Z' });
+    const b = makeMsg('assistant', 'hello again', { __turnId: 3, timestamp: '2024-01-01T00:00:01Z' });
+    expect(getMessageKey(a, 0)).toBe(getMessageKey(b, 1));
+  });
+
+  it('returns stable __turnId key when timestamp is absent', () => {
+    const msg: ClaudeMessage = { type: 'assistant', content: 'hi', __turnId: 7 };
+    expect(getMessageKey(msg, 2)).toBe('turn-7');
+  });
+
+  it('falls back to type-timestamp when uuid is not a string', () => {
     const ts = '2024-01-01T00:00:00Z';
-    const msg = makeMsg('user', 'hello', { timestamp: ts });
+    const msg = makeMsg('user', 'hello', { raw: { uuid: 123 } as any, timestamp: ts });
     expect(getMessageKey(msg, 0)).toBe(`user-${ts}`);
   });
 
-  it('falls back to type-index when no uuid, __turnId, or timestamp', () => {
-    const msg: ClaudeMessage = { type: 'assistant', content: 'hi' };
-    expect(getMessageKey(msg, 7)).toBe('assistant-7');
+  it('falls back to a content signature plus index when no uuid, __turnId, or timestamp', () => {
+    const msg = buildKeyFallbackMessage('hi');
+    expect(getMessageKey(msg, 7)).toBe('assistant-hi-7');
+  });
+
+  it('returns different fallback keys for equivalent content at different indexes without stable identity', () => {
+    const raw = { message: { content: [{ type: 'text', text: 'same text' }] } } as any;
+    const a = buildKeyFallbackMessage('', { raw });
+    const b = buildKeyFallbackMessage('', { raw });
+    expect(getMessageKey(a, 1)).not.toBe(getMessageKey(b, 99));
+  });
+
+  it('prefers __renderKey for messages lacking persistent identity', () => {
+    const msg = buildKeyFallbackMessage('hi', { __renderKey: 'merged-assistant-key' });
+    expect(getMessageKey(msg, 7)).toBe('merged-assistant-key');
   });
 });
 
@@ -57,17 +105,10 @@ describe('getMessageKey', () => {
 // ---------------------------------------------------------------------------
 
 describe('mergeConsecutiveAssistantMessages', () => {
-  const normalizeBlocks = (raw: unknown): any[] => {
-    if (!raw || typeof raw !== 'object') return [];
-    const r = raw as any;
-    const blocks = r.content ?? r.message?.content;
-    return Array.isArray(blocks) ? blocks : [];
-  };
-
-  it('preserves __turnId from first message in merged group', () => {
+  it('does not merge adjacent assistant messages when turn IDs differ', () => {
     const messages: ClaudeMessage[] = [
       makeMsg('assistant', 'part1', {
-        __turnId: 2,
+        __turnId: 1,
         raw: { content: [{ type: 'text', text: 'part1' }] } as any,
       }),
       makeMsg('assistant', 'part2', {
@@ -76,14 +117,16 @@ describe('mergeConsecutiveAssistantMessages', () => {
       }),
     ];
 
-    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
-    expect(result).toHaveLength(1);
-    expect(result[0].__turnId).toBe(2);
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(2);
+    expect(result[0].__turnId).toBe(1);
+    expect(result[1].__turnId).toBe(2);
   });
 
-  it('does not add __turnId when first message has none', () => {
+  it('does not merge adjacent assistant messages when turn ID is missing on one side and the other side has a turn ID', () => {
     const messages: ClaudeMessage[] = [
       makeMsg('assistant', 'part1', {
+        __turnId: 2,
         raw: { content: [{ type: 'text', text: 'part1' }] } as any,
       }),
       makeMsg('assistant', 'part2', {
@@ -91,21 +134,251 @@ describe('mergeConsecutiveAssistantMessages', () => {
       }),
     ];
 
-    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it('merges adjacent assistant messages with the same turn ID even when tool_use blocks are present', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'tool phase', {
+        __turnId: 7,
+        raw: {
+          content: [
+            { type: 'text', text: 'tool phase' },
+            { type: 'tool_use', id: 'tool-1', name: 'Skill' },
+          ],
+        } as any,
+      }),
+      makeMsg('assistant', 'final answer', {
+        __turnId: 7,
+        raw: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'tool-1', content: 'ok' },
+            { type: 'text', text: 'final answer' },
+          ],
+        } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(1);
+    expect(result[0].__turnId).toBe(7);
+    expect(result[0].content).toBe('tool phase\nfinal answer');
+    expect((result[0].raw as any)?.message?.content).toEqual([
+      { type: 'text', text: 'tool phase' },
+      { type: 'tool_use', id: 'tool-1', name: 'Skill' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'ok' },
+      { type: 'text', text: 'final answer' },
+    ]);
+  });
+
+  it('merges adjacent assistant messages without turn IDs when they are consecutive renderable assistant fragments', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'part1', {
+        raw: { content: [{ type: 'thinking', thinking: 'reasoning' }] } as any,
+      }),
+      makeMsg('assistant', 'part2', {
+        raw: { content: [{ type: 'text', text: 'final answer' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
     expect(result).toHaveLength(1);
     expect(result[0].__turnId).toBeUndefined();
+    expect((result[0].raw as any)?.message?.content).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'final answer' },
+    ]);
   });
 
-  it('does not merge across user messages', () => {
+  it('does not merge adjacent assistant messages without turn IDs when they only contain plain text', () => {
     const messages: ClaudeMessage[] = [
-      makeMsg('assistant', 'a1', { __turnId: 1 }),
-      makeMsg('user', 'q'),
-      makeMsg('assistant', 'a2', { __turnId: 2 }),
+      makeMsg('assistant', 'first answer', {
+        raw: { content: [{ type: 'text', text: 'first answer' }] } as any,
+      }),
+      makeMsg('assistant', 'second answer', {
+        raw: { content: [{ type: 'text', text: 'second answer' }] } as any,
+      }),
     ];
 
-    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
-    expect(result).toHaveLength(3);
-    expect(result[0].__turnId).toBe(1);
-    expect(result[2].__turnId).toBe(2);
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe('first answer');
+    expect(result[1].content).toBe('second answer');
+  });
+
+  it('records a lightweight source range for merged assistant messages', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'part1', {
+        raw: { content: [{ type: 'thinking', thinking: 'reasoning' }] } as any,
+      }),
+      makeMsg('assistant', 'part2', {
+        raw: { content: [{ type: 'text', text: 'final answer' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(1);
+    expect(result[0].__sourceRange).toEqual({ start: 0, end: 1 });
+    expect(result[0].__sourceRange).not.toHaveProperty('length');
+    expect(result[0].__renderKey).toContain('#2');
+  });
+
+  it('does not merge adjacent streaming assistant messages even when turn IDs match', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'thinking phase', {
+        __turnId: 9,
+        isStreaming: true,
+        raw: { content: [{ type: 'thinking', thinking: 'first thought' }] } as any,
+      }),
+      makeMsg('assistant', 'tool phase', {
+        __turnId: 9,
+        raw: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeRenderableBlocks as any);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe('thinking phase');
+    expect(result[1].content).toBe('tool phase');
+  });
+});
+
+describe('findToolResultBlock', () => {
+  it('prefers tool results from the same turn after the anchor message', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'previous tool', {
+        __turnId: 1,
+        raw: { message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] } } as any,
+      }),
+      makeMsg('user', 'previous result', {
+        __turnId: 1,
+        raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'old result' }] } } as any,
+      }),
+      makeMsg('assistant', 'current tool', {
+        __turnId: 2,
+        raw: { message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] } } as any,
+      }),
+      makeMsg('user', 'current result', {
+        __turnId: 2,
+        raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'new result' }] } } as any,
+      }),
+    ];
+
+    expect(findToolResultBlock(messages, 'tool-1', 2)?.content).toBe('new result');
+  });
+
+  it('falls back to the direct raw message index when anchor has no uuid or turn id but the raw object matches', () => {
+    const rawMessage = makeMsg('assistant', 'tool call', {
+      raw: { message: { content: [{ type: 'tool_use', id: 'tool-2', name: 'Read' }] } } as any,
+    });
+    const rawMessages: ClaudeMessage[] = [
+      rawMessage,
+      makeMsg('user', 'tool result holder', {
+        raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'matched' }] } } as any,
+      }),
+    ];
+    const renderedAssistant: ClaudeMessage = {
+      type: 'assistant',
+      content: 'tool call',
+      raw: rawMessage.raw,
+    };
+
+    expect(findToolResultBlock(rawMessages, 'tool-2', 0, renderedAssistant)?.content).toBe('matched');
+  });
+
+  it('uses source range over message index when resolving merged history tool results', () => {
+    const rawMessages: ClaudeMessage[] = [
+      makeMsg('user', 'earlier user'),
+      makeMsg('assistant', 'thinking fragment', {
+        raw: { message: { content: [{ type: 'thinking', thinking: 'plan' }] } } as any,
+      }),
+      makeMsg('assistant', 'tool fragment', {
+        raw: { message: { content: [{ type: 'tool_use', id: 'tool-10', name: 'Read' }] } } as any,
+      }),
+      makeMsg('user', 'tool result holder', {
+        raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-10', content: 'ok-10' }] } } as any,
+      }),
+    ];
+
+    const renderedAssistant: ClaudeMessage = {
+      type: 'assistant',
+      content: 'thinking fragment\ntool fragment',
+      __sourceRange: { start: 1, end: 2 },
+      raw: rawMessages[1].raw,
+    };
+
+    expect(findToolResultBlock(rawMessages, 'tool-10', 0, renderedAssistant)?.content).toBe('ok-10');
+  });
+
+
+  it('resolves tool results for merged history assistants via __sourceRange when turn id and uuid are absent', () => {
+    const assistantThinking = makeMsg('assistant', 'thinking fragment', {
+      raw: { message: { content: [{ type: 'thinking', thinking: 'plan' }] } } as any,
+    });
+    const assistantTool = makeMsg('assistant', 'tool fragment', {
+      raw: { message: { content: [{ type: 'tool_use', id: 'tool-9', name: 'Read' }] } } as any,
+    });
+    const rawMessages: ClaudeMessage[] = [
+      assistantThinking,
+      assistantTool,
+      makeMsg('user', 'tool result holder', {
+        raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-9', content: 'ok' }] } } as any,
+      }),
+    ];
+
+    const merged = mergeConsecutiveAssistantMessages(rawMessages, normalizeRenderableBlocks);
+
+    expect(merged).toHaveLength(2);
+    const renderedAssistant = merged[0];
+    expect(renderedAssistant.__sourceRange).toEqual({ start: 0, end: 1 });
+    expect(findToolResultBlock(rawMessages, 'tool-9', 0, renderedAssistant)?.content).toBe('ok');
+  });
+  const localizeMessage = (text: string) => text;
+
+  it('appends final assistant text after tool_use blocks when normalized raw has no text block', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'final answer',
+      raw: {
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tool-1', name: 'Skill' },
+            { type: 'tool_result', tool_use_id: 'tool-1', content: 'ok' },
+          ],
+        },
+      } as any,
+    };
+
+    const normalized = normalizeBlocks(message.raw as any, localizeMessage, ((key: string) => key) as any);
+    expect(normalized).toEqual([
+      { type: 'tool_use', id: 'tool-1', name: 'Skill', input: {} },
+    ]);
+
+    const blocks = getContentBlocks(message, (raw) => normalizeBlocks(raw as any, localizeMessage, ((key: string) => key) as any), localizeMessage);
+    expect(blocks).toEqual([
+      { type: 'tool_use', id: 'tool-1', name: 'Skill', input: {} },
+      { type: 'text', text: 'final answer' },
+    ]);
+  });
+
+  it('preserves raw text order when text already follows a tool block', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      raw: {
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tool-1', name: 'Skill' },
+            { type: 'text', text: 'final answer' },
+          ],
+        },
+      } as any,
+    };
+
+    const blocks = getContentBlocks(message, (raw) => normalizeBlocks(raw as any, localizeMessage, ((key: string) => key) as any), localizeMessage);
+    expect(blocks).toEqual([
+      { type: 'tool_use', id: 'tool-1', name: 'Skill', input: {} },
+      { type: 'text', text: 'final answer' },
+    ]);
   });
 });

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -1,16 +1,164 @@
 import type { TFunction } from 'i18next';
-import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage } from '../types';
+import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage, ToolResultBlock } from '../types';
 
 /**
  * Generate a stable key for a message, used for React list keys and anchor navigation.
- * Prefer raw.uuid > __turnId > type-timestamp > fallback to type-index.
+ * Prefer raw.uuid > __turnId > __renderKey > type-timestamp > content signature fallback.
  */
 export function getMessageKey(message: ClaudeMessage, index: number): string {
   const rawObj = typeof message.raw === 'object' ? message.raw as Record<string, unknown> : null;
-  if (rawObj?.uuid) return rawObj.uuid as string;
-  if (message.__turnId !== undefined) return `turn-${message.__turnId}`;
-  return message.timestamp ? `${message.type}-${message.timestamp}` : `${message.type}-${index}`;
+  if (typeof rawObj?.uuid === 'string') return rawObj.uuid;
+  if (message.__turnId !== undefined) {
+    return `turn-${message.__turnId}`;
+  }
+  if (typeof message.__renderKey === 'string' && message.__renderKey.trim().length > 0) {
+    return message.__renderKey;
+  }
+  if (message.timestamp) {
+    return `${message.type}-${message.timestamp}`;
+  }
+
+  const rawContent = typeof message.raw === 'object'
+    ? (message.raw.content ?? message.raw.message?.content)
+    : message.raw;
+  const signatureSource = typeof rawContent === 'string'
+    ? rawContent
+    : Array.isArray(rawContent)
+      ? JSON.stringify(rawContent)
+      : message.content ?? '';
+  const normalizedSignature = signatureSource
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || 'empty';
+
+  return `${message.type}-${normalizedSignature}-${index}`;
 }
+
+export function findToolResultBlock(
+  messages: ClaudeMessage[],
+  toolUseId: string | undefined,
+  messageIndex: number,
+  anchorMessage?: ClaudeMessage,
+): ToolResultBlock | null {
+  if (!toolUseId || messageIndex < 0) return null;
+
+  const collectToolResults = (message: ClaudeMessage): ToolResultBlock[] => {
+    const raw = message.raw;
+    if (!raw || typeof raw === 'string') return [];
+    const content = raw.content ?? raw.message?.content;
+    if (!Array.isArray(content)) return [];
+    return content.filter(
+      (block): block is ToolResultBlock =>
+        Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
+    );
+  };
+
+  const resolveAnchorIndex = (): number => {
+    if (!anchorMessage) {
+      return messageIndex < messages.length ? messageIndex : -1;
+    }
+
+    const sourceRange = anchorMessage.__sourceRange;
+    if (sourceRange) {
+      return sourceRange.start >= 0 && sourceRange.start < messages.length ? sourceRange.start : -1;
+    }
+
+    const rawObj = typeof anchorMessage.raw === 'object' ? anchorMessage.raw as Record<string, unknown> : null;
+    const anchorUuid = typeof rawObj?.uuid === 'string' ? rawObj.uuid : undefined;
+    if (anchorUuid) {
+      const byUuid = messages.findIndex((message) => {
+        const candidateRaw = typeof message.raw === 'object' ? message.raw as Record<string, unknown> : null;
+        return candidateRaw?.uuid === anchorUuid;
+      });
+      if (byUuid >= 0) return byUuid;
+      return -1;
+    }
+
+    if (anchorMessage.__turnId !== undefined) {
+      const byTurnId = messages.findIndex(
+        (message) => message.type === 'assistant' && message.__turnId === anchorMessage.__turnId,
+      );
+      if (byTurnId >= 0) return byTurnId;
+      return -1;
+    }
+
+    if (messageIndex < messages.length) {
+      const indexedMessage = messages[messageIndex];
+      if (indexedMessage === anchorMessage) {
+        return messageIndex;
+      }
+
+      const indexedRaw = typeof indexedMessage?.raw === 'object' ? indexedMessage.raw as Record<string, unknown> : null;
+      const anchorRaw = typeof anchorMessage.raw === 'object' ? anchorMessage.raw as Record<string, unknown> : null;
+      if (indexedRaw && anchorRaw && indexedRaw === anchorRaw) {
+        return messageIndex;
+      }
+    }
+
+    return -1;
+  };
+
+  const resolveSearchRange = (anchorIndex: number): { start: number; end: number } => {
+    const anchor = anchorMessage ?? messages[anchorIndex];
+    const anchorTurnId = anchor?.__turnId;
+
+    if (anchorTurnId !== undefined) {
+      let start = anchorIndex;
+      let end = anchorIndex;
+      while (start > 0 && messages[start - 1]?.__turnId === anchorTurnId) {
+        start -= 1;
+      }
+      while (end + 1 < messages.length && messages[end + 1]?.__turnId === anchorTurnId) {
+        end += 1;
+      }
+      return { start, end };
+    }
+
+    if (anchor?.__sourceRange) {
+      return {
+        start: Math.max(0, anchor.__sourceRange.start),
+        end: Math.min(messages.length - 1, anchor.__sourceRange.end),
+      };
+    }
+
+    return { start: anchorIndex, end: anchorIndex };
+  };
+
+  const scanToolResultInRange = (
+    start: number,
+    end: number,
+    stopAtAssistantBoundary: boolean,
+  ): ToolResultBlock | null => {
+    for (let i = start; i <= end; i += 1) {
+      const result = collectToolResults(messages[i])[0];
+      if (result) return result;
+    }
+
+    for (let i = end + 1; i < messages.length; i += 1) {
+      const candidate = messages[i];
+      if (stopAtAssistantBoundary && candidate?.type === 'assistant') break;
+      const result = collectToolResults(candidate)[0];
+      if (result) return result;
+    }
+
+    for (let i = start - 1; i >= 0; i -= 1) {
+      const candidate = messages[i];
+      if (stopAtAssistantBoundary && candidate?.type === 'assistant') break;
+      const result = collectToolResults(candidate)[0];
+      if (result) return result;
+    }
+
+    return null;
+  };
+
+  const anchorIndex = resolveAnchorIndex();
+  if (anchorIndex < 0 || anchorIndex >= messages.length) return null;
+
+  const searchRange = resolveSearchRange(anchorIndex);
+  const anchor = anchorMessage ?? messages[anchorIndex];
+  return scanToolResultInRange(searchRange.start, searchRange.end, anchor?.__turnId === undefined);
+}
+
 
 /**
  * Extract content from <command-message> and <command-args> tags if present.
@@ -356,7 +504,8 @@ export function getContentBlocks(
 ): ClaudeContentBlock[] {
   const rawBlocks = normalizeBlocksFn(message.raw);
   if (rawBlocks && rawBlocks.length > 0) {
-    // Streaming/tool scenario: if raw doesn't have text but message.content has text, still need to show text
+    // Streaming/tool scenario: if raw doesn't have text but message.content has text,
+    // append the final assistant text after existing blocks so tool anchoring stays intact.
     const hasTextBlock = rawBlocks.some(
       (block) => block.type === 'text' && typeof (block as any).text === 'string' && String((block as any).text).trim().length > 0,
     );
@@ -384,43 +533,66 @@ export function mergeConsecutiveAssistantMessages(
 ): ClaudeMessage[] {
   if (messages.length === 0) return [];
 
-  const getStableId = (message: ClaudeMessage, index: number): string => {
-    const rawObj = typeof message.raw === 'object' ? (message.raw as Record<string, unknown> | null) : null;
-    const uuid = rawObj?.uuid;
-    if (typeof uuid === 'string' && uuid) return uuid;
-    if (message.timestamp) return `${message.type}-${message.timestamp}`;
-    return `${message.type}-${index}`;
+  const getStableId = (message: ClaudeMessage, index: number): string => getMessageKey(message, index);
+
+  const getRenderableBlocks = (message: ClaudeMessage): ClaudeContentBlock[] =>
+    normalizeBlocksFn(message.raw) || [];
+
+  const hasToolResultBlock = (message: ClaudeMessage): boolean => {
+    const raw = message.raw;
+    if (!raw || typeof raw !== 'object') return false;
+    const content = raw.content ?? raw.message?.content;
+    return Array.isArray(content) && content.some((block) => block && typeof block === 'object' && (block as Record<string, unknown>).type === 'tool_result');
   };
 
-  const getAssistantBlockSummary = (message: ClaudeMessage): { hasToolUse: boolean; hasText: boolean } => {
-    const blocks = normalizeBlocksFn(message.raw) || [];
-    return {
-      hasToolUse: blocks.some((block) => block.type === 'tool_use'),
-      hasText: blocks.some((block) => block.type === 'text' && typeof block.text === 'string' && block.text.trim().length > 0)
-        || Boolean(message.content && message.content.trim()),
-    };
-  };
+  const hasMeaningfulRenderableBlocks = (message: ClaudeMessage): boolean =>
+    getRenderableBlocks(message).some((block) => {
+      if (block.type === 'text') {
+        return Boolean(block.text && block.text.trim().length > 0);
+      }
+      if (block.type === 'thinking') {
+        const thinkingText = block.thinking ?? block.text ?? '';
+        return thinkingText.trim().length > 0;
+      }
+      return true;
+    });
 
-  const shouldMergeAssistantMessage = (previous: ClaudeMessage, next: ClaudeMessage): boolean => {
-    const previousSummary = getAssistantBlockSummary(previous);
-    const nextSummary = getAssistantBlockSummary(next);
+  const hasFallbackMergeAnchor = (message: ClaudeMessage): boolean =>
+    getRenderableBlocks(message).some((block) => {
+      if (block.type === 'thinking') {
+        const thinkingText = block.thinking ?? block.text ?? '';
+        return thinkingText.trim().length > 0;
+      }
+      return block.type === 'tool_use';
+    });
 
-    // Keep tool-execution assistant messages separated from the final answer.
-    if (previousSummary.hasToolUse !== nextSummary.hasToolUse) {
+  const canMergeAssistantPair = (left: ClaudeMessage, right: ClaudeMessage): boolean => {
+    if (left.type !== 'assistant' || right.type !== 'assistant') return false;
+    if (left.isStreaming || right.isStreaming) return false;
+
+    if (left.__turnId !== undefined || right.__turnId !== undefined) {
+      return left.__turnId !== undefined && right.__turnId !== undefined && left.__turnId === right.__turnId;
+    }
+
+    if (hasToolResultBlock(left) || hasToolResultBlock(right)) {
       return false;
     }
 
-    return true;
+    if (!hasFallbackMergeAnchor(left) && !hasFallbackMergeAnchor(right)) {
+      return false;
+    }
+
+    return hasMeaningfulRenderableBlocks(left) || hasMeaningfulRenderableBlocks(right);
   };
 
-  const buildMergedAssistantMessage = (group: ClaudeMessage[]): ClaudeMessage => {
+  const buildMergedAssistantMessage = (group: ClaudeMessage[], startIndex: number, endIndex: number): ClaudeMessage => {
     const first = group[0];
 
     const combinedBlocks: ClaudeContentBlock[] = [];
     const contentParts: string[] = [];
 
     for (const msg of group) {
-      const blocks = normalizeBlocksFn(msg.raw) || [];
+      const blocks = getRenderableBlocks(msg);
       if (blocks.length > 0) {
         combinedBlocks.push(...blocks);
       }
@@ -435,19 +607,26 @@ export function mergeConsecutiveAssistantMessages(
     const rawBase: ClaudeRawMessage =
       (typeof first.raw === 'object' && first.raw ? { ...(first.raw as ClaudeRawMessage) } : ({} as ClaudeRawMessage));
 
+    const mergedContent = contentParts.join('\n');
+    const mergedBlocks: ClaudeRawMessage['message'] extends { content?: infer T } ? Exclude<T, string | undefined> : ClaudeContentBlock[] = combinedBlocks.length > 0
+      ? combinedBlocks
+      : mergedContent
+        ? [{ type: 'text' as const, text: mergedContent }]
+        : [];
+
     const nextRaw: ClaudeRawMessage = {
       ...rawBase,
-      content: combinedBlocks,
-      message: rawBase.message ? { ...rawBase.message, content: combinedBlocks } : rawBase.message,
+      content: mergedBlocks,
+      message: rawBase.message ? { ...rawBase.message, content: mergedBlocks } : { content: mergedBlocks },
     };
-
-    const mergedContent = contentParts.join('\n');
 
     return {
       ...first,
       content: mergedContent,
       raw: nextRaw,
       __turnId: first.__turnId,
+      __sourceRange: { start: startIndex, end: endIndex },
+      __renderKey: `${getStableId(group[0], startIndex)}..${getStableId(group[group.length - 1], endIndex)}#${group.length}`,
     };
   };
 
@@ -462,7 +641,10 @@ export function mergeConsecutiveAssistantMessages(
     }
 
     let j = i + 1;
-    while (j < messages.length && messages[j].type === 'assistant' && shouldMergeAssistantMessage(messages[j - 1], messages[j])) {
+    while (
+      j < messages.length &&
+      canMergeAssistantPair(messages[j - 1], messages[j])
+    ) {
       j += 1;
     }
 
@@ -489,7 +671,7 @@ export function mergeConsecutiveAssistantMessages(
       }
     }
 
-    const merged = buildMergedAssistantMessage(group);
+    const merged = buildMergedAssistantMessage(group, i, j - 1);
     if (cache) {
       cache.set(groupKey, { source: group, merged });
       if (cache.size > MESSAGE_MERGE_CACHE_LIMIT) {


### PR DESCRIPTION
Refactor the streaming assistant message pipeline to prevent content loss and block splitting when frontend delta callbacks and backend snapshots interleave during active streaming turns.

Problem:
The previous implementation inferred new logical thinking blocks from text/thinking delta type switches, causing an empty thinking block to appear when content deltas arrived between thinking deltas within the same turn. Backend snapshot reconciliation could also overwrite already-streamed characters with shorter stale snapshots, resulting in visible character loss.

Solution:
Introduce a canonical streaming state model where text and thinking content accumulate independently in ref-based buffers. Backend snapshots are accepted only when they carry structural block changes (new tool_use blocks, block count changes, or content hash differences detected via djb2 signatures). A three-source reconciliation
(delta buffer / assistant.content / backend blocks) always selects the most complete value using monotonic length comparison with same-length meaningful-difference detection.

Key changes:

Streaming state (useStreamingMessages.ts):
- Extract StreamingDataRefs interface and clearStreamingDataRefs() shared utility, used by onStreamStart, onStreamEnd, and resetStreamingState
- Extract pure block-type guards (isStreamingBlock, isStableBackendBlock) and findLastAssistantIndex/extractRawBlocks to module scope
- Add @sideEffect annotation to findStreamingAssistantIndex documenting its streamingMessageIndexRef cache-update side effect
- Gate console.debug in buildStreamingBlocks behind import.meta.env.DEV

Reconciliation (messageCallbacks.ts):
- Add computeCanonicalStreamingState() pure function that accepts snapshotted ref values (not refs) for StrictMode double-invocation safety
- Add selectMostCompleteStreamingText() with pairwise reduction via chooseMoreCompleteStreamingValue(), giving backend implicit priority
- Add djb2Hash + getContentHash for O(1)-allocation structural block signatures on the hot reconciliation path
- Hoist WHITESPACE_COLLAPSE_RE to module level (js-hoist-regexp)
- Snapshot streamingContent, thinkingContent, and messageIndex refs BEFORE state updaters to guarantee idempotent results under StrictMode

Streaming callbacks (streamingCallbacks.ts):
- onStreamStart: use clearStreamingDataRefs() instead of inline resets
- onStreamEnd: snapshot streamingMessageIndexRef into finalIdx before the updater to prevent StrictMode double-invocation from reading cleared -1
- Remove mutual-exclusion segment index resets from delta handlers with explanatory comments documenting why they were intentionally removed

Identity preservation (messageSync.ts):
- Add turn-ID guards to preserveLastAssistantIdentity and preserveStreamingAssistantContent to prevent cross-turn merging
- Add ensureStreamingAssistantInList with primary (ref-valid) and fallback (ref-cleared race condition) recovery paths

Testing:
- Add 52 direct unit tests for pure functions (messageCallbacksPure.test) covering boundary cases, StrictMode idempotency, and legacy formats
- Extend useWindowCallbacks integration tests to 37 scenarios including interleaved delta/snapshot timing and stream-end finalization
- Extend messageSync tests to 50 scenarios for identity preservation
- Update messageUtils tests for improved getMessageKey stability
- Total: 232 tests passing, 0 TypeScript errors

Fixes #798