### PR TITLE
feat: add CLI bundled skills to slash command registry

### DIFF
--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -46,10 +46,22 @@ public final class SlashCommandRegistry {
     }
 
     // Claude built-in commands (GUI-relevant only; CLI-only and frontend-local ones are excluded)
+    // Includes commands that work via SDK or are handled by frontend locally
+    // 'local-jsx' commands (TUI UI) that have GUI equivalents are included
+    // Bundled skills from CLI that are userInvocable and work in GUI environment
     public static final List<SlashCommand> CLAUDE_BUILTIN = List.of(
-            new SlashCommand("/compact", "Toggle compact mode", "builtin"),
-            new SlashCommand("/init", "Initialize a new project", "builtin"),
-            new SlashCommand("/review", "Review changes before applying", "builtin")
+            new SlashCommand("/compact", "Summarize conversation to free context", "builtin"),
+            new SlashCommand("/init", "Initialize a new CLAUDE.md file with codebase documentation", "builtin"),
+            new SlashCommand("/plan", "Switch to plan mode", "builtin"),
+            new SlashCommand("/resume", "Resume a previous conversation", "builtin"),
+            new SlashCommand("/review", "Review a pull request", "builtin"),
+            // Bundled skills (userInvocable, no ANT-only restriction)
+            new SlashCommand("/batch", "Execute large-scale changes in parallel across isolated worktrees", "bundled"),
+            new SlashCommand("/claude-api", "Build apps with the Claude API or Anthropic SDK", "bundled"),
+            new SlashCommand("/debug", "Enable debug logging and diagnose session issues", "bundled"),
+            new SlashCommand("/loop", "Run a prompt or command on a recurring interval", "bundled"),
+            new SlashCommand("/simplify", "Review changed code for reuse, quality, and efficiency", "bundled"),
+            new SlashCommand("/update-config", "Configure settings.json (hooks, permissions, env vars)", "bundled")
     );
 
     // Codex built-in commands (GUI-relevant only; CLI-only ones like /status, /model, /quit are excluded)

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -24,6 +24,11 @@ import {
   useFileChangesManagement,
   useModelProviderState,
 } from './hooks';
+import {
+  NEW_SESSION_COMMANDS,
+  RESUME_COMMANDS,
+  PLAN_COMMANDS,
+} from './hooks/useMessageSender';
 import type { ContextInfo, ViewMode } from './hooks';
 import { formatTime } from './utils/helpers';
 import { extractMarkdownContent } from './utils/copyUtils';
@@ -300,6 +305,7 @@ const App = () => {
     setMessages, setLoading, setLoadingStartTime, setStreamingActive,
     setSettingsInitialTab, setCurrentView,
     forceCreateNewSession,
+    handleModeSelect,
   });
 
   // ── Message queue ──
@@ -309,16 +315,32 @@ const App = () => {
     dequeue: dequeueMessage,
   } = useMessageQueue({ isLoading: loading, onExecute: executeMessage });
 
-  // handleSubmit with queue support (new session commands bypass loading check)
+  // handleSubmit with queue support (new session and local commands bypass loading check)
   const handleSubmit = useCallback((content: string, attachments?: Attachment[]) => {
     const text = content.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
     const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
     if (!text && !hasAttachments) return;
-    // New session commands work even while loading
+    // Local commands work even while loading
     if (text.startsWith('/')) {
       const command = text.split(/\s+/)[0].toLowerCase();
-      if (['/new', '/clear', '/reset'].includes(command)) {
+      // New session commands
+      if (NEW_SESSION_COMMANDS.has(command)) {
         forceCreateNewSession();
+        return;
+      }
+      // /resume - open history view
+      if (RESUME_COMMANDS.has(command)) {
+        setCurrentView('history');
+        return;
+      }
+      // /plan - switch to plan mode
+      if (PLAN_COMMANDS.has(command)) {
+        if (currentProvider === 'codex') {
+          addToast(t('chat.planModeNotAvailableForCodex', { defaultValue: 'Plan mode is not available for Codex provider' }), 'warning');
+        } else {
+          handleModeSelect('plan');
+          addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
+        }
         return;
       }
     }
@@ -328,7 +350,7 @@ const App = () => {
       return;
     }
     hookHandleSubmit(content, attachments);
-  }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession]);
+  }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession, currentProvider, handleModeSelect, setCurrentView, addToast, t]);
 
   // ── File changes management ──
   const {

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -5,6 +5,13 @@ import type { ClaudeContentBlock, ClaudeMessage } from '../types';
 import type { Attachment, ChatInputBoxHandle, PermissionMode, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ViewMode } from './useModelProviderState';
 
+/**
+ * Command sets for local handling (shared with App.tsx to avoid duplication)
+ */
+export const NEW_SESSION_COMMANDS = new Set(['/new', '/clear', '/reset']);
+export const RESUME_COMMANDS = new Set(['/resume', '/continue']);
+export const PLAN_COMMANDS = new Set(['/plan']);
+
 export interface UseMessageSenderOptions {
   t: TFunction;
   addToast: (message: string, type?: 'info' | 'success' | 'warning' | 'error') => void;
@@ -26,6 +33,7 @@ export interface UseMessageSenderOptions {
   setSettingsInitialTab: React.Dispatch<React.SetStateAction<any>>;
   setCurrentView: React.Dispatch<React.SetStateAction<ViewMode>>;
   forceCreateNewSession: () => void;
+  handleModeSelect?: (mode: PermissionMode) => void;
 }
 
 /**
@@ -52,12 +60,8 @@ export function useMessageSender({
   setSettingsInitialTab,
   setCurrentView,
   forceCreateNewSession,
+  handleModeSelect,
 }: UseMessageSenderOptions) {
-  /**
-   * Set of commands that trigger new session creation (/new, /clear, /reset)
-   */
-  const NEW_SESSION_COMMANDS = new Set(['/new', '/clear', '/reset']);
-
   /**
    * Check if the input is a new session command
    */
@@ -70,6 +74,35 @@ export function useMessageSender({
     }
     return false;
   }, [forceCreateNewSession]);
+
+  /**
+   * Check for local-handled slash commands (/resume, /plan)
+   * Returns true if the command was handled locally
+   * Note: This is also checked in App.tsx handleSubmit to bypass loading queue
+   */
+  const checkLocalCommand = useCallback((text: string): boolean => {
+    if (!text.startsWith('/')) return false;
+    const command = text.split(/\s+/)[0].toLowerCase();
+
+    // /resume - open history view
+    if (RESUME_COMMANDS.has(command)) {
+      setCurrentView('history');
+      return true;
+    }
+
+    // /plan - switch to plan mode (Claude only)
+    if (PLAN_COMMANDS.has(command)) {
+      if (currentProvider === 'codex') {
+        addToast(t('chat.planModeNotAvailableForCodex', { defaultValue: 'Plan mode is not available for Codex provider' }), 'warning');
+      } else if (handleModeSelect) {
+        handleModeSelect('plan');
+        addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
+      }
+      return true;
+    }
+
+    return false;
+  }, [setCurrentView, handleModeSelect, currentProvider, addToast, t]);
 
   /**
    * Check for unimplemented slash commands
@@ -304,12 +337,15 @@ export function useMessageSender({
     // Check new session commands
     if (checkNewSessionCommand(text)) return;
 
+    // Check local-handled commands (/resume, /plan)
+    if (checkLocalCommand(text)) return;
+
     // Check for unimplemented commands
     if (checkUnimplementedCommand(text)) return;
 
     // Execute message
     executeMessage(content, attachments);
-  }, [checkNewSessionCommand, checkUnimplementedCommand, executeMessage]);
+  }, [checkNewSessionCommand, checkLocalCommand, checkUnimplementedCommand, executeMessage]);
 
   /**
    * Interrupt the current session


### PR DESCRIPTION
- Add 6 bundled skills to CLAUDE_BUILTIN: /batch, /claude-api, /debug, /loop, /simplify, /update-config
- Export command sets (NEW_SESSION_COMMANDS, RESUME_COMMANDS, PLAN_COMMANDS) from useMessageSender.ts to avoid code duplication
- Update App.tsx to use shared command sets for local command handling