### PR TITLE
fix: prevent WebView freeze on Ctrl+C by async clipboard access

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/ClipboardHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/ClipboardHandler.java
@@ -3,6 +3,8 @@ package com.github.claudecodegui.handler;
 import com.github.claudecodegui.handler.core.BaseMessageHandler;
 import com.github.claudecodegui.handler.core.HandlerContext;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.awt.*;
@@ -22,7 +24,7 @@ public class ClipboardHandler extends BaseMessageHandler {
     private static final long MIN_READ_INTERVAL_MS = 200;
     private static final int MAX_CLIPBOARD_WRITE_SIZE = 10 * 1024 * 1024; // 10 MB
 
-    private long lastReadTime = 0;
+    private volatile long lastReadTime = 0;
 
     public ClipboardHandler(HandlerContext context) {
         super(context);
@@ -43,7 +45,7 @@ public class ClipboardHandler extends BaseMessageHandler {
     }
 
     private void handleReadClipboard() {
-        // Rate limiting to prevent clipboard-monitoring abuse
+        // Rate limiting to prevent clipboard-monitoring abuse (checked synchronously before dispatch)
         long now = System.currentTimeMillis();
         if (now - lastReadTime < MIN_READ_INTERVAL_MS) {
             LOG.debug("Clipboard read rate-limited");
@@ -52,18 +54,22 @@ public class ClipboardHandler extends BaseMessageHandler {
         }
         lastReadTime = now;
 
-        try {
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            if (clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
-                String text = (String) clipboard.getData(DataFlavor.stringFlavor);
-                callJavaScript("window.onClipboardRead", escapeJs(text != null ? text : ""));
-            } else {
+        // Dispatch clipboard access to EDT to avoid blocking the CEF browser thread.
+        // Use ModalityState.any() so copy works even when a modal dialog (e.g. PermissionDialog) is open.
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                if (clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+                    String text = (String) clipboard.getData(DataFlavor.stringFlavor);
+                    callJavaScript("window.onClipboardRead", escapeJs(text != null ? text : ""));
+                } else {
+                    callJavaScript("window.onClipboardRead", "");
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to read clipboard", e);
                 callJavaScript("window.onClipboardRead", "");
             }
-        } catch (Exception e) {
-            LOG.warn("Failed to read clipboard", e);
-            callJavaScript("window.onClipboardRead", "");
-        }
+        }, ModalityState.any());
     }
 
     private void handleWriteClipboard(String content) {
@@ -71,11 +77,15 @@ public class ClipboardHandler extends BaseMessageHandler {
             LOG.warn("Clipboard write rejected: content too large (" + content.length() + " chars)");
             return;
         }
-        try {
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(new StringSelection(content), null);
-        } catch (Exception e) {
-            LOG.warn("Failed to write clipboard", e);
-        }
+        // Dispatch clipboard access to EDT to avoid blocking the CEF browser thread.
+        // Use ModalityState.any() so copy works even when a modal dialog (e.g. PermissionDialog) is open.
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                clipboard.setContents(new StringSelection(content), null);
+            } catch (Exception e) {
+                LOG.warn("Failed to write clipboard", e);
+            }
+        }, ModalityState.any());
     }
 }


### PR DESCRIPTION
Clipboard read/write in ClipboardHandler was executed synchronously on the CEF browser thread via JBCefJSQuery onQuery callback. On Windows, AWT clipboard operations involve OLE calls that block when the clipboard lock is contended (e.g. by Chromium's native copy), freezing the entire WebView for several seconds.

- Dispatch clipboard.setContents/getData to EDT via invokeLater
- Use ModalityState.any() so clipboard works during modal dialogs
- Add volatile to lastReadTime for cross-thread visibility