### PR TITLE
feat: simulate CLI client identity in API requests

### DIFF
--- a/ai-bridge/channel-manager.js
+++ b/ai-bridge/channel-manager.js
@@ -27,13 +27,16 @@ import { readStdinData } from './utils/stdin-utils.js';
 import { handleClaudeCommand } from './channels/claude-channel.js';
 import { handleCodexCommand } from './channels/codex-channel.js';
 import { getSdkStatus, isClaudeSdkAvailable, isCodexSdkAvailable } from './utils/sdk-loader.js';
-import { injectNetworkEnvVars } from './config/api-config.js';
+import { injectNetworkEnvVars, configureCliIdentity } from './config/api-config.js';
 
 // Sync proxy/TLS settings from ~/.claude/settings.json BEFORE any network
 // activity, but only for explicitly authorized Local settings.json / CLI Login
 // modes. Without this, users behind corporate SSL-inspection proxies in those
 // modes will get certificate verification errors.
 injectNetworkEnvVars();
+
+// Configure CLI client identity before any SDK loading
+configureCliIdentity();
 
 // Diagnostic logging: startup info
 console.log('[DIAG-ENTRY] ========== CHANNEL-MANAGER STARTUP ==========');

--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -15,6 +15,122 @@ function debugLog(...args) {
   }
 }
 
+// ============================================================================
+// CLI Client Identity
+// ============================================================================
+// Simulates CLI client identity so the API treats our SDK calls as CLI traffic.
+// The CLI version is resolved dynamically from the installed SDK's manifest.json,
+// which embeds the CLI version that was bundled with the SDK.
+
+const FALLBACK_CLI_VERSION = '2.1.88';
+
+let _cachedCliVersion = null;
+
+/**
+ * Resolve CLI version from the installed SDK's manifest.json.
+ * The SDK bundles a manifest.json with ` "version": "<cli-version>" }`.
+ * Falls back to converting the SDK package version (0.x.y -> x.1.y),
+ * then to the hardcoded fallback.
+ */
+function resolveCliVersionFromSdk() {
+  if (_cachedCliVersion) return _cachedCliVersion;
+
+  try {
+    const depsBase = join(getCodemossDir(), 'dependencies');
+    const sdkDir = join(depsBase, 'claude-sdk', 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+
+    // Try manifest.json first (contains the bundled CLI version)
+    const manifestPath = join(sdkDir, 'manifest.json');
+    if (existsSync(manifestPath)) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      if (manifest?.version) {
+        _cachedCliVersion = manifest.version;
+        return _cachedCliVersion;
+      }
+    }
+
+    // Fallback: derive from SDK package.json version (0.x.y -> x.1.y)
+    // e.g., SDK 0.2.88 -> CLI 2.1.88
+    const pkgPath = join(sdkDir, 'package.json');
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+      if (pkg?.version) {
+        const parts = pkg.version.split('.');
+        if (parts.length >= 3) {
+          _cachedCliVersion = `${parts[1]}.1.${parts[2]}`;
+          return _cachedCliVersion;
+        }
+      }
+    }
+  } catch {
+    // Ignore errors, use fallback
+  }
+
+  _cachedCliVersion = FALLBACK_CLI_VERSION;
+  return _cachedCliVersion;
+}
+
+/**
+ * Get the CLI version for User-Agent header.
+ * Priority: CLAUDE_CLI_VERSION env var > SDK manifest > SDK version conversion > fallback
+ * @returns {string} CLI version string (e.g., "2.1.88")
+ */
+export function getCliVersion() {
+  return process.env.CLAUDE_CLI_VERSION || resolveCliVersionFromSdk();
+}
+
+/**
+ * Build CLI-style User-Agent header value.
+ * Format: claude-cli/{VERSION} ({USER_TYPE}, {ENTRYPOINT})
+ *
+ * Does NOT include agent-sdk version suffix — we simulate a pure CLI client.
+ * @returns {string} User-Agent header value
+ */
+export function getCliUserAgent() {
+  const version = getCliVersion();
+  const userType = process.env.USER_TYPE || 'external';
+  const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT || 'cli';
+  return `claude-cli/${version} (${userType}, ${entrypoint})`;
+}
+
+/**
+ * Build a clean env object for SDK child processes that identifies as CLI.
+ *
+ * The SDK's query() checks `options.env` — if absent, it copies process.env
+ * (which includes CLAUDE_AGENT_SDK_VERSION set by the SDK itself).
+ * By passing our own env, we control exactly what the child process sees.
+ *
+ * @returns {Object} Environment variables object for options.env
+ */
+export function buildCliEnv() {
+  const env = {
+    ...process.env,
+    CLAUDE_CODE_ENTRYPOINT: 'cli',
+    USER_TYPE: 'external',
+  };
+  delete env.CLAUDE_AGENT_SDK_VERSION;
+  return env;
+}
+
+/**
+ * Configure process.env for CLI client identity at startup.
+ * Sets CLAUDE_CODE_ENTRYPOINT and USER_TYPE, deletes CLAUDE_AGENT_SDK_VERSION.
+ * Call once at process startup before any SDK loading.
+ */
+export function configureCliIdentity() {
+  if (!process.env.CLAUDE_CODE_ENTRYPOINT) {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+  }
+  if (!process.env.USER_TYPE) {
+    process.env.USER_TYPE = 'external';
+  }
+  delete process.env.CLAUDE_AGENT_SDK_VERSION;
+}
+
+// ============================================================================
+// Network Environment Variables
+// ============================================================================
+
 /**
  * Network-related environment variable names that should be injected from
  * settings.json into process.env early at startup.

--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -6,7 +6,7 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { setupApiKey } from '../../config/api-config.js';
+import { setupApiKey, buildCliEnv } from '../../config/api-config.js';
 import { getClaudeDir, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
 import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessionFile, isNoConversationFoundError } from './message-utils.js';
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
@@ -29,8 +29,6 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
       console.log('[REWIND] Session not in memory, attempting to resume...');
 
       try {
-        process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
-
         setupApiKey();
 
         if (!process.env.HOME) {
@@ -55,6 +53,7 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
           permissionMode: 'default',
           enableFileCheckpointing: true,
           maxTurns: 1,
+          env: buildCliEnv(),
           tools: { type: 'preset', preset: 'claude_code' },
           settingSources: ['user', 'project', 'local'],
           additionalDirectories: Array.from(

--- a/ai-bridge/services/claude/message-sender-anthropic.js
+++ b/ai-bridge/services/claude/message-sender-anthropic.js
@@ -4,7 +4,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { loadClaudeSettings } from '../../config/api-config.js';
+import { loadClaudeSettings, getCliUserAgent } from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
 import { resolveModelFromSettings } from '../../utils/model-utils.js';
 import { loadSessionHistory, persistJsonlMessage } from './session-service.js';
@@ -32,6 +32,12 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
     const modelId = resolveModelFromSettings(rawModelId, sdkSettings?.env);
     console.log('[DEBUG] (AnthropicSDK) Model resolved for API:', rawModelId, '->', modelId);
 
+    // Build CLI-style headers for API identification
+    const cliHeaders = {
+      'x-app': 'cli',
+      'User-Agent': getCliUserAgent()
+    };
+
     // Use the correct SDK parameters based on auth type
     // authType = 'auth_token': use authToken parameter (Bearer authentication)
     // authType = 'api_key': use apiKey parameter (x-api-key authentication)
@@ -42,7 +48,8 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
       client = new Anthropic({
         authToken: apiKey,
         apiKey: null,  // Explicitly set to null to avoid sending the x-api-key header
-        baseURL: baseUrl || undefined
+        baseURL: baseUrl || undefined,
+        defaultHeaders: cliHeaders
       });
       // Prefer Bearer (ANTHROPIC_AUTH_TOKEN) and prevent sending x-api-key
       delete process.env.ANTHROPIC_API_KEY;
@@ -52,13 +59,16 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
       // Dynamically load Bedrock SDK
       const bedrockModule = await ensureBedrockSdk();
       const AnthropicBedrock = bedrockModule.AnthropicBedrock || bedrockModule.default || bedrockModule;
-      client = new AnthropicBedrock();
+      client = new AnthropicBedrock({
+        defaultHeaders: cliHeaders
+      });
     } else {
       console.log('[DEBUG] Using API Key authentication (ANTHROPIC_API_KEY)');
       // Use apiKey parameter (x-api-key authentication)
       client = new Anthropic({
         apiKey,
-        baseURL: baseUrl || undefined
+        baseURL: baseUrl || undefined,
+        defaultHeaders: cliHeaders
       });
     }
 

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -3,7 +3,7 @@
  * Handles plain text messages and multimodal messages with attachments.
  */
 
-import { isCustomBaseUrl, loadClaudeSettings, setupApiKey } from '../../config/api-config.js';
+import { isCustomBaseUrl, loadClaudeSettings, setupApiKey, buildCliEnv } from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
 import { mapModelIdToSdkName, resolveModelFromSettings, setModelEnvironmentVariables } from '../../utils/model-utils.js';
 import { AsyncStream } from '../../utils/async-stream.js';
@@ -58,6 +58,7 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
     model: sdkModelName,
     maxTurns: 100,
     enableFileCheckpointing: true,
+    env: buildCliEnv(),
     ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
     ...(streamingEnabled && { includePartialMessages: true }),
     additionalDirectories: Array.from(
@@ -395,8 +396,6 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
   let streamingEnabled = false;
   const outerStreamState = { streamStarted: false, streamEnded: false, accumulatedUsage: null };
   try {
-    process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
-
     const { baseUrl, apiKeySource, baseUrlSource } = setupApiKey();
     if (isCustomBaseUrl(baseUrl)) {
       console.log('[DEBUG] Custom Base URL detected:', baseUrl);
@@ -456,8 +455,6 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
   let streamingEnabled = false;
   const outerStreamState = { streamStarted: false, streamEnded: false, accumulatedUsage: null };
   try {
-    process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
-
     setupApiKey();
     console.log('[MESSAGE_START]');
 

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -3,7 +3,7 @@
  * Keeps Claude Query processes alive across turns to reduce per-request latency.
  */
 
-import { isCustomBaseUrl, loadClaudeSettings, setupApiKey } from '../../config/api-config.js';
+import { isCustomBaseUrl, loadClaudeSettings, setupApiKey, buildCliEnv } from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
 import {
   mapModelIdToSdkName,
@@ -83,6 +83,7 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
     model: sdkModelName,
     maxTurns: 100,
     enableFileCheckpointing: true,
+    env: buildCliEnv(),
     ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
     ...(streamingEnabled && { includePartialMessages: true }),
     additionalDirectories: Array.from(
@@ -123,7 +124,6 @@ async function buildUserMessage(params, withAttachments, requestedSessionId) {
 }
 
 async function buildRequestContext(params, withAttachments) {
-  process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
   setupApiKey();
 
   const baseUrl = process.env.ANTHROPIC_BASE_URL || process.env.ANTHROPIC_API_URL || '';

--- a/ai-bridge/services/prompt-enhancer.js
+++ b/ai-bridge/services/prompt-enhancer.js
@@ -11,7 +11,7 @@
  */
 
 import { loadClaudeSdk, isClaudeSdkAvailable } from '../utils/sdk-loader.js';
-import { setupApiKey, loadClaudeSettings } from '../config/api-config.js';
+import { setupApiKey, loadClaudeSettings, buildCliEnv } from '../config/api-config.js';
 import { mapModelIdToSdkName } from '../utils/model-utils.js';
 import { getRealHomeDir } from '../utils/path-utils.js';
 
@@ -245,9 +245,6 @@ async function enhancePrompt(originalPrompt, systemPrompt, model, context) {
     const sdk = await ensureClaudeSdk();
     const { query } = sdk;
 
-    // Set environment variables (same as normal conversation)
-    process.env.CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT || 'sdk-ts';
-
     // Set up API Key (this sets the correct environment variables)
     const config = setupApiKey();
 
@@ -265,13 +262,12 @@ async function enhancePrompt(originalPrompt, systemPrompt, model, context) {
     const fullPrompt = buildFullPrompt(originalPrompt, context);
     console.log(`[PromptEnhancer] Full prompt length: ${fullPrompt.length}`);
 
-    // Prepare options
-    // Note: Prompt enhancement is a simple task that doesn't require tool calls
     const options = {
       cwd: workingDirectory,
       permissionMode: 'bypassPermissions',  // Prompt enhancement doesn't need tool permissions
       model: sdkModelName,
       maxTurns: 1,  // Prompt enhancement only needs a single turn, no tool calls
+      env: buildCliEnv(),
       // Use custom system prompt (passed as a string directly, not as an object)
       systemPrompt: systemPrompt,
       settingSources: ['user', 'project', 'local'],


### PR DESCRIPTION
Pass custom env objects via options.env to all SDK query() calls to prevent the SDK from injecting CLAUDE_AGENT_SDK_VERSION into the child process environment. This makes the API treat our requests as CLI traffic (User-Agent: claude-cli/{version} (external, cli)) instead of SDK traffic.

- Add buildCliEnv() to centralize env construction for SDK child processes
- Resolve CLI version dynamically from SDK manifest.json with fallback to SDK package version conversion (0.x.y -> x.1.y)
- Add configureCliIdentity() called at process startup
- Add CLI-style defaultHeaders (x-app, User-Agent) to direct Anthropic SDK calls including Bedrock
- Remove all legacy process.env.CLAUDE_CODE_ENTRYPOINT = 'sdk-ts' assignments

听说官方订阅正式禁止sdk了，本PR修改了header，根据我对cli的理解，应该就足够绕过检测了（我自己并没有官方订阅）。