### PR TITLE
fix: handle structured MCP output in convertFunctionCallOutputToToolResult

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -465,7 +465,15 @@ public class CodexMessageConverter {
         toolResult.addProperty("type", "tool_result");
         toolResult.addProperty("tool_use_id", payload.has("call_id") ? payload.get("call_id").getAsString() : "unknown");
 
-        String output = payload.has("output") ? payload.get("output").getAsString() : "";
+        JsonElement outputElem = payload.get("output");
+        String output;
+        if (outputElem == null || outputElem.isJsonNull()) {
+            output = "";
+        } else if (outputElem.isJsonPrimitive()) {
+            output = outputElem.getAsString();
+        } else {
+            output = outputElem.toString();
+        }
         toolResult.addProperty("content", output);
 
         JsonArray content = new JsonArray();


### PR DESCRIPTION
## Bug Description
Loading a Codex session fails with `UnsupportedOperationException: JsonObject` when the session contains MCP tool results with structured (non-string) output.

## Stack Trace
```
java.lang.UnsupportedOperationException: JsonObject
	at com.google.gson.JsonElement.getAsString(JsonElement.java:187)
	at com.google.gson.JsonArray.getAsString(JsonArray.java:262)
	at com.github.claudecodegui.handler.CodexMessageConverter.convertFunctionCallOutputToToolResult(CodexMessageConverter.java:468)
```

## Root Cause
`convertFunctionCallOutputToToolResult` blindly calls `getAsString()` on the `output` field of a `function_call_output` payload. When MCP tools return JSON arrays or objects, this throws `UnsupportedOperationException` and breaks the entire history load.

## Fix
Add type-safe extraction: use `getAsString()` for primitives, and fall back to `toString()` for `JsonArray` / `JsonObject`.

## Related
- Front-end side of the same class of issue was fixed in v0.2.5 (#567).