### PR TITLE
fix(backend): prevent streaming content duplication by skipping frontend notification on dedup

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -51,6 +51,12 @@ public class ClaudeMessageHandler implements MessageCallback {
     private volatile boolean textSegmentActive = false;
     private volatile boolean thinkingSegmentActive = false;
 
+    // Offset tracking for deduplication after conservative sync.
+    // Volatile: same threading pattern as textSegmentActive/thinkingSegmentActive
+    // (read/written across SDK callback threads and EDT).
+    private volatile int syncedContentOffset = 0;
+    private volatile int syncedThinkingOffset = 0;
+
     /**
      * Constructor.
      */
@@ -150,6 +156,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         lastReportedError = error;
         textSegmentActive = false;
         thinkingSegmentActive = false;
+        syncedContentOffset = 0;
+        syncedThinkingOffset = 0;
 
         // Reset thinking state if still active — same as onComplete() and handleStreamEnd()
         if (isThinking) {
@@ -203,6 +211,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         isStreaming = false;
         textSegmentActive = false;
         thinkingSegmentActive = false;
+        syncedContentOffset = 0;
+        syncedThinkingOffset = 0;
 
         // Reset thinking state if still active
         if (isThinking) {
@@ -263,6 +273,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                 assistantContent.setLength(0);
                 assistantContent.append(aggregatedText);
                 currentAssistantMessage.content = assistantContent.toString();
+                syncedContentOffset = assistantContent.length();
             }
             currentAssistantMessage.raw = mergedRaw;
 
@@ -389,12 +400,30 @@ public class ClaudeMessageHandler implements MessageCallback {
         // Content output means the current thinking segment has ended
         thinkingSegmentActive = false;
 
+        // Dedup: skip if delta was already included via conservative sync.
+        // Heuristic: checks if assistantContent ends with the delta. This may produce
+        // false positives for very short deltas (1-2 chars) that coincidentally match
+        // the suffix, but the SDK sends deltas in token-level chunks (typically whole
+        // words) making this extremely rare in practice.
+        // CRITICAL: Do NOT notify frontend when dedup triggers - frontend has no dedup
+        // and will accumulate the delta, causing content duplication.
+        if (syncedContentOffset > 0
+                && assistantContent.length() >= content.length()
+                && assistantContent.substring(assistantContent.length() - content.length()).equals(content)) {
+            LOG.debug("Skipping duplicate content delta (len=" + content.length() + ")");
+            if (!isStreaming) {
+                callbackHandler.notifyMessageUpdate(state.getMessages());
+            }
+            return;
+        }
+
         // Accumulate content for the final message
         assistantContent.append(content);
 
         ensureCurrentAssistantMessageExists();
         currentAssistantMessage.content = assistantContent.toString();
         applyTextDeltaToRaw(content);
+        syncedContentOffset = assistantContent.length();
         textSegmentActive = true;
 
         callbackHandler.notifyContentDelta(content);
@@ -623,6 +652,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         lastReportedError = null;
         textSegmentActive = false;
         thinkingSegmentActive = false;
+        syncedContentOffset = 0;
+        syncedThinkingOffset = 0;
         callbackHandler.notifyStreamStart();
     }
 
@@ -635,6 +666,8 @@ public class ClaudeMessageHandler implements MessageCallback {
         streamEndedThisTurn = true;
         textSegmentActive = false;
         thinkingSegmentActive = false;
+        syncedContentOffset = 0;
+        syncedThinkingOffset = 0;
 
         // Reset thinking state — stream end is the definitive boundary for a turn.
         // If thinking was active when the stream ended (e.g., extended thinking without
@@ -668,11 +701,20 @@ public class ClaudeMessageHandler implements MessageCallback {
         }
         // Write thinking delta to raw to prevent data loss after stream ends
         ensureCurrentAssistantMessageExists();
-        applyThinkingDeltaToRaw(content);
-        thinkingSegmentActive = true;
-        callbackHandler.notifyThinkingDelta(content);
-        if (!isStreaming) {
-            callbackHandler.notifyMessageUpdate(state.getMessages());
+        boolean applied = applyThinkingDeltaToRaw(content);
+        if (applied) {
+            // Note: uses += (not absolute assignment like syncedContentOffset)
+            // because there is no thinkingContent StringBuilder to take length from
+            syncedThinkingOffset += content.length();
+            thinkingSegmentActive = true;
+            // CRITICAL: Only notify frontend when delta was actually applied.
+            // Frontend has no dedup and will accumulate, causing duplication.
+            callbackHandler.notifyThinkingDelta(content);
+            if (!isStreaming) {
+                callbackHandler.notifyMessageUpdate(state.getMessages());
+            }
+        } else {
+            LOG.debug("Skipping duplicate thinking delta (len=" + content.length() + ")");
         }
     }
 
@@ -711,9 +753,9 @@ public class ClaudeMessageHandler implements MessageCallback {
         return content;
     }
 
-    private void applyTextDeltaToRaw(String delta) {
+    private boolean applyTextDeltaToRaw(String delta) {
         if (delta == null || delta.isEmpty()) {
-            return;
+            return false;
         }
         JsonArray contentArray = ensureAssistantContentArray();
         JsonObject target = null;
@@ -741,7 +783,14 @@ public class ClaudeMessageHandler implements MessageCallback {
         String existing = target.has("text") && !target.get("text").isJsonNull()
                 ? target.get("text").getAsString()
                 : "";
+
+        // Dedup: skip if delta was already included after the last conservative sync
+        if (syncedContentOffset > 0 && existing.endsWith(delta)) {
+            return false;
+        }
+
         target.addProperty("text", existing + delta);
+        return true;
     }
 
     /**
@@ -787,9 +836,9 @@ public class ClaudeMessageHandler implements MessageCallback {
         LOG.debug("Updated assistant message usage from [USAGE] tag");
     }
 
-    private void applyThinkingDeltaToRaw(String delta) {
+    private boolean applyThinkingDeltaToRaw(String delta) {
         if (delta == null || delta.isEmpty()) {
-            return;
+            return false;
         }
         JsonArray contentArray = ensureAssistantContentArray();
         JsonObject target = null;
@@ -817,6 +866,13 @@ public class ClaudeMessageHandler implements MessageCallback {
         String existing = target.has("thinking") && !target.get("thinking").isJsonNull()
                 ? target.get("thinking").getAsString()
                 : "";
+
+        // Dedup: skip if delta was already included after the last conservative sync
+        if (syncedThinkingOffset > 0 && existing.endsWith(delta)) {
+            return false;
+        }
+
         target.addProperty("thinking", existing + delta);
+        return true;
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/MessageMerger.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageMerger.java
@@ -104,6 +104,14 @@ public class MessageMerger {
                         consumedUnkeyedIndexes.add(idx);
                         continue;
                     }
+
+                    // Fallback: merge with last same-type block instead of adding duplicate
+                    int lastSameTypeIdx = findLastSameTypeBlockIndex(baseContent, block);
+                    if (lastSameTypeIdx >= 0) {
+                        baseContent.set(lastSameTypeIdx,
+                                mergeUnkeyedBlock(baseContent.get(lastSameTypeIdx).getAsJsonObject(), block));
+                        continue;
+                    }
                 }
             }
 
@@ -225,6 +233,31 @@ public class MessageMerger {
         }
 
         return existingBlock.equals(incomingBlock);
+    }
+
+    private int findLastSameTypeBlockIndex(JsonArray baseContent, JsonObject incomingBlock) {
+        String incomingType = getContentBlockType(incomingBlock);
+        if (incomingType == null) {
+            return -1;
+        }
+        // Only consider the tail of baseContent — do not cross keyed blocks
+        // (tool_use, tool_result) to avoid merging content from different segments.
+        // E.g., [text_1, tool_use, text_2] should NOT merge text_2 into text_1.
+        for (int i = baseContent.size() - 1; i >= 0; i--) {
+            JsonElement element = baseContent.get(i);
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject existingBlock = element.getAsJsonObject();
+            // Stop scanning if we hit a keyed block (tool_use, tool_result)
+            if (getContentBlockKey(existingBlock) != null) {
+                break;
+            }
+            if (incomingType.equals(getContentBlockType(existingBlock))) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private String getContentBlockType(JsonObject block) {

--- a/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerDedupTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerDedupTest.java
@@ -1,0 +1,233 @@
+package com.github.claudecodegui.session;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for ClaudeMessageHandler dedup logic.
+ * Uses a recording CallbackHandler to verify notifications.
+ */
+public class ClaudeMessageHandlerDedupTest {
+
+    private RecordingCallbackHandler callbackHandler;
+    private ClaudeMessageHandler handler;
+
+    @Before
+    public void setUp() {
+        callbackHandler = new RecordingCallbackHandler();
+        SessionState state = new SessionState();
+        MessageParser messageParser = new MessageParser();
+        MessageMerger messageMerger = new MessageMerger();
+        Gson gson = new GsonBuilder().create();
+
+        handler = new ClaudeMessageHandler(
+                null, // project not needed for these tests
+                state,
+                callbackHandler,
+                messageParser,
+                messageMerger,
+                gson
+        );
+    }
+
+    /**
+     * Test that content delta is skipped when it duplicates existing content after conservative sync.
+     */
+    @Test
+    public void handleContentDelta_skipsDuplicateAfterConservativeSync() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Simulate conservative sync with full content "ABC"
+        String fullMessage = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ABC\"}]}}";
+        handler.onMessage("assistant", fullMessage);
+        callbackHandler.clear();
+
+        // Now try to send a duplicate delta "C" which is already in "ABC"
+        handler.onMessage("content_delta", "C");
+
+        // Should NOT notify frontend about the duplicate delta
+        assertTrue("Duplicate delta should not be notified",
+                callbackHandler.contentDeltas.isEmpty());
+    }
+
+    /**
+     * Test that non-duplicate delta is processed normally.
+     */
+    @Test
+    public void handleContentDelta_processesNonDuplicateNormally() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Send a normal delta "ABC"
+        handler.onMessage("content_delta", "ABC");
+
+        // Should notify frontend
+        assertEquals("Non-duplicate delta should be notified",
+                List.of("ABC"), callbackHandler.contentDeltas);
+
+        callbackHandler.clear();
+
+        // Send another non-duplicate delta "DEF"
+        handler.onMessage("content_delta", "DEF");
+
+        // Should notify frontend
+        assertEquals("Second non-duplicate delta should be notified",
+                List.of("DEF"), callbackHandler.contentDeltas);
+    }
+
+    /**
+     * Test that thinking delta is processed when not duplicate.
+     */
+    @Test
+    public void handleThinkingDelta_processesNonDuplicateNormally() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Send a thinking delta directly - handleThinkingDelta sets isThinking internally
+        handler.onMessage("thinking_delta", "Let me think");
+
+        // Should notify frontend
+        assertEquals("Non-duplicate thinking delta should be notified",
+                List.of("Let me think"), callbackHandler.thinkingDeltas);
+    }
+
+    /**
+     * Test that syncedContentOffset is reset on stream end.
+     */
+    @Test
+    public void streamEnd_resetsSyncedContentOffset() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+
+        // Send some content
+        handler.onMessage("content_delta", "ABC");
+
+        // End stream
+        handler.onMessage("stream_end", "");
+
+        // Start a new stream
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Send a new delta (should not be dedup'd because offset was reset)
+        handler.onMessage("content_delta", "ABC");
+
+        // Should notify frontend (not dedup'd)
+        assertEquals("Delta after stream end reset should be notified",
+                List.of("ABC"), callbackHandler.contentDeltas);
+    }
+
+    /**
+     * Test that syncedThinkingOffset is reset on stream end.
+     */
+    @Test
+    public void streamEnd_resetsSyncedThinkingOffset() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+
+        // Send thinking delta directly - handleThinkingDelta sets isThinking internally
+        handler.onMessage("thinking_delta", "Analysis");
+
+        // End stream
+        handler.onMessage("stream_end", "");
+
+        // Start a new stream
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Send the same delta (should not be dedup'd because offset was reset)
+        handler.onMessage("thinking_delta", "Analysis");
+
+        // Should notify frontend (not dedup'd because offset was reset)
+        assertEquals("Thinking delta after stream end reset should be notified",
+                List.of("Analysis"), callbackHandler.thinkingDeltas);
+    }
+
+    /**
+     * Test that very short delta (single char) matching suffix is dedup'd.
+     * This is a known trade-off documented in the code.
+     */
+    @Test
+    public void handleContentDelta_shortDeltaSuffixMatchIsDedupd() {
+        // Simulate stream start
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Simulate conservative sync with content "A"
+        String fullMessage = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"A\"}]}}";
+        handler.onMessage("assistant", fullMessage);
+        callbackHandler.clear();
+
+        // Send delta "A" - matches the suffix of existing content "A"
+        handler.onMessage("content_delta", "A");
+
+        // Should be dedup'd (this is the documented trade-off)
+        assertTrue("Short delta suffix match should be dedup'd",
+                callbackHandler.contentDeltas.isEmpty());
+    }
+
+    /**
+     * Test that dedup does not trigger when syncedContentOffset is zero.
+     */
+    @Test
+    public void handleContentDelta_noDedupWhenOffsetIsZero() {
+        // Simulate stream start (syncedContentOffset is 0)
+        handler.onMessage("stream_start", "");
+        callbackHandler.clear();
+
+        // Send delta "A" - offset is 0, no dedup
+        handler.onMessage("content_delta", "A");
+
+        // Should be processed (offset is 0, no dedup)
+        assertEquals("First delta should be processed when offset is zero",
+                List.of("A"), callbackHandler.contentDeltas);
+    }
+
+    /**
+     * Recording callback handler that captures all notifications for testing.
+     * Extends CallbackHandler and overrides relevant methods.
+     */
+    private static class RecordingCallbackHandler extends CallbackHandler {
+        final List<String> contentDeltas = new ArrayList<>();
+        final List<String> thinkingDeltas = new ArrayList<>();
+        int streamStartCount = 0;
+        int streamEndCount = 0;
+
+        void clear() {
+            contentDeltas.clear();
+            thinkingDeltas.clear();
+        }
+
+        @Override
+        public void notifyContentDelta(String delta) {
+            contentDeltas.add(delta);
+        }
+
+        @Override
+        public void notifyThinkingDelta(String delta) {
+            thinkingDeltas.add(delta);
+        }
+
+        @Override
+        public void notifyStreamStart() {
+            streamStartCount++;
+        }
+
+        @Override
+        public void notifyStreamEnd() {
+            streamEndCount++;
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/MessageMergerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/MessageMergerTest.java
@@ -229,7 +229,7 @@ public class MessageMergerTest {
     }
 
     @Test
-    public void mergeAssistantMessageKeepsMoreCompleteThinkingBlock() {
+    public void mergeAssistantMessageKeepsMoreCompleteThinkingBlockFromSnapshot() {
         MessageMerger merger = new MessageMerger();
 
         JsonObject existingRaw = assistantMessage(

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -565,6 +565,22 @@ interface Window {
   __lastStreamActivityAt?: number;
 
   /**
+   * The __turnId of the most recently ended streaming turn.
+   * Used by mergeConsecutiveAssistantMessages to distinguish recently-ended
+   * streaming messages from true history messages and prevent incorrect merging.
+   * Cleared after 5 seconds or when a new turn starts.
+   * @default undefined (no recently ended turn)
+   */
+  __lastStreamEndedTurnId?: number;
+
+  /**
+   * Timestamp when the last streaming turn ended (via onStreamEnd).
+   * Used with __lastStreamEndedTurnId to implement a time-based cleanup.
+   * @default undefined (no stream end recorded)
+   */
+  __lastStreamEndedAt?: number;
+
+  /**
    * Timestamp when the current streaming turn started.
    * Used to calculate durationMs on the assistant message when the stream ends.
    */

--- a/webview/src/hooks/useStreamingMessages.test.ts
+++ b/webview/src/hooks/useStreamingMessages.test.ts
@@ -276,4 +276,110 @@ describe('useStreamingMessages', () => {
       thinking: 'Deep analysis of the problem.',
     });
   });
+
+  it('consolidates multiple backend thinking blocks into one to prevent duplication', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current = 'Response text.';
+    result.current.streamingTextSegmentsRef.current = ['Response text.'];
+    result.current.streamingThinkingSegmentsRef.current = [
+      'Thinking part 1. Thinking part 2.',
+    ];
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: result.current.streamingContentRef.current,
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Thinking part 1.',
+              text: 'Thinking part 1.',
+            },
+            {
+              type: 'thinking',
+              thinking: 'Thinking part 1. Thinking part 2.',
+              text: 'Thinking part 1. Thinking part 2.',
+            },
+            {
+              type: 'text',
+              text: 'Response text.',
+            },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const content = ((patched.raw as any).message?.content ?? []) as Array<Record<string, unknown>>;
+
+    const thinkingBlocks = content.filter((b) => b.type === 'thinking');
+    expect(thinkingBlocks).toHaveLength(1);
+    expect(thinkingBlocks[0]).toMatchObject({
+      type: 'thinking',
+      thinking: 'Thinking part 1. Thinking part 2.',
+    });
+    expect(content.filter((b) => b.type === 'text')).toHaveLength(1);
+  });
+
+  it('keeps separate thinking blocks when content is distinct', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current = 'Text 1. Text 2.';
+    result.current.streamingTextSegmentsRef.current = ['Text 1.', 'Text 2.'];
+    result.current.streamingThinkingSegmentsRef.current = [
+      'Phase 1 thinking.',
+      'Phase 2 thinking.',
+    ];
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: result.current.streamingContentRef.current,
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Phase 1 thinking.',
+              text: 'Phase 1 thinking.',
+            },
+            {
+              type: 'text',
+              text: 'Text 1.',
+            },
+            {
+              type: 'tool_use',
+              id: 'tool-1',
+              name: 'search',
+              input: { query: 'test' },
+            },
+            {
+              type: 'thinking',
+              thinking: 'Phase 2 thinking.',
+              text: 'Phase 2 thinking.',
+            },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const content = ((patched.raw as any).message?.content ?? []) as Array<Record<string, unknown>>;
+
+    // Smart merge preserves distinct thinking phases when content doesn't overlap
+    const thinkingBlocks = content.filter((b) => b.type === 'thinking');
+    expect(thinkingBlocks).toHaveLength(2); // Two distinct phases, not merged
+    expect(thinkingBlocks[0]).toMatchObject({ thinking: 'Phase 1 thinking.' });
+    expect(thinkingBlocks[1]).toMatchObject({ thinking: 'Phase 2 thinking.' });
+    // Verify positions: first thinking before text, second thinking after tool_use
+    const thinking1Idx = content.findIndex((b) => b.type === 'thinking');
+    const textIdx = content.findIndex((b) => b.type === 'text');
+    const toolIdx = content.findIndex((b) => b.type === 'tool_use');
+    const thinking2Idx = content.findIndex((b, i) => b.type === 'thinking' && i !== thinking1Idx);
+    expect(thinking1Idx).toBeLessThan(textIdx);
+    expect(toolIdx).toBeLessThan(thinking2Idx);
+  });
 });

--- a/webview/src/hooks/useStreamingMessages.ts
+++ b/webview/src/hooks/useStreamingMessages.ts
@@ -112,12 +112,20 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
       .replace(/\n+$/, '');
   };
 
+  const isDoubledContent = (candidate: string, base: string): boolean => {
+    if (!base || !candidate || base.length >= candidate.length) return false;
+    // Check if candidate is base repeated 2+ times (e.g., "ABCABC" from "ABC")
+    const repeated = base + base;
+    return candidate.startsWith(repeated);
+  };
+
   const preferMoreCompleteText = (segmentText: unknown, existingText: unknown): string => {
     const streamed = typeof segmentText === 'string' ? segmentText : '';
     const existing = typeof existingText === 'string' ? existingText : '';
 
     if (!streamed) return existing;
     if (!existing) return streamed;
+    if (isDoubledContent(existing, streamed)) return streamed;
     return existing.length > streamed.length ? existing : streamed;
   };
 
@@ -127,6 +135,7 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
 
     if (!streamed) return existing;
     if (!existing) return streamed;
+    if (isDoubledContent(existing, streamed)) return streamed;
     return existing.length > streamed.length ? existing : streamed;
   };
 
@@ -231,7 +240,10 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
     output.push({ type: 'text', text: novel });
   };
 
-  // Helper: Build streaming blocks from segments
+  // Helper: Build streaming blocks from segments.
+  // Thinking blocks use index-based matching to preserve positions (multi-phase thinking).
+  // After building, adjacent thinking blocks with overlapping content are merged
+  // to prevent duplication while preserving distinct thinking phases.
   const buildStreamingBlocks = (existingBlocks: ContentBlock[]): ContentBlock[] => {
     const textSegments = streamingTextSegmentsRef.current;
     const thinkingSegments = streamingThinkingSegmentsRef.current;
@@ -240,23 +252,25 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
     let thinkingIdx = 0;
     let textIdx = 0;
 
+    // Process existing blocks in order, matching segments by position
     for (const block of existingBlocks) {
-      if (!block || typeof block !== 'object') {
-        continue;
-      }
+      if (!block || typeof block !== 'object') continue;
+
       if (block.type === 'thinking') {
-        const thinking = preferMoreCompleteThinking(
-          thinkingSegments[thinkingIdx],
-          block.thinking ?? block.text,
-        );
+        const segmentContent = thinkingSegments[thinkingIdx];
+        const backendContent = block.thinking ?? block.text ?? '';
+        const thinking = preferMoreCompleteThinking(segmentContent, backendContent);
         thinkingIdx += 1;
         if (thinking.length > 0) {
           appendNovelTextLikeBlock(output, 'thinking', thinking);
         }
         continue;
       }
+
       if (block.type === 'text') {
-        const text = preferMoreCompleteText(textSegments[textIdx], block.text);
+        const segmentContent = textSegments[textIdx];
+        const backendContent = block.text ?? '';
+        const text = preferMoreCompleteText(segmentContent, backendContent);
         textIdx += 1;
         if (text.length > 0) {
           appendNovelTextLikeBlock(output, 'text', text);
@@ -264,9 +278,11 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
         continue;
       }
 
+      // Non-text/thinking blocks (tool_use, image, etc.) - keep as-is
       output.push(block);
     }
 
+    // Append remaining segments that weren't matched to existing blocks
     const phasesCount = Math.max(textSegments.length, thinkingSegments.length);
     const appendFromPhase = Math.max(textIdx, thinkingIdx);
     for (let phase = appendFromPhase; phase < phasesCount; phase += 1) {
@@ -280,7 +296,74 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
       }
     }
 
-    return output;
+    return mergeOverlappingThinkingBlocks(output);
+  };
+
+  /**
+   * Merge thinking blocks with overlapping content to prevent duplication.
+   * Preserves distinct thinking phases that have no content overlap.
+   * Uses mark-and-filter approach to avoid splice index corruption.
+   */
+  const mergeOverlappingThinkingBlocks = (blocks: ContentBlock[]): ContentBlock[] => {
+    const thinkingIndices: number[] = [];
+    for (let i = 0; i < blocks.length; i++) {
+      if (blocks[i]?.type === 'thinking') thinkingIndices.push(i);
+    }
+
+    if (thinkingIndices.length <= 1) return blocks;
+
+    const thinkingContents = thinkingIndices.map((i) =>
+      normalizeThinking(blocks[i]?.thinking ?? blocks[i]?.text ?? ''),
+    );
+
+    // Group thinking blocks that have overlapping content
+    const mergeGroups: number[][] = [];
+    const assigned = new Set<number>();
+
+    for (let i = 0; i < thinkingContents.length; i++) {
+      if (assigned.has(i)) continue;
+      const group = [i];
+      assigned.add(i);
+
+      for (let j = i + 1; j < thinkingContents.length; j++) {
+        if (assigned.has(j)) continue;
+        const a = thinkingContents[i];
+        const b = thinkingContents[j];
+        // Overlap: one contains the other (covers prefix/suffix cases too)
+        if (a.includes(b) || b.includes(a)) {
+          group.push(j);
+          assigned.add(j);
+        }
+      }
+      mergeGroups.push(group);
+    }
+
+    // Mark indices to remove, update first block with merged content
+    const toRemove = new Set<number>();
+    for (const group of mergeGroups) {
+      if (group.length === 1) continue;
+
+      let merged = '';
+      for (const idx of group) {
+        const content = thinkingContents[idx];
+        if (content.includes(merged)) {
+          merged = content;
+        } else if (!merged.includes(content)) {
+          merged = mergeStreamingTextLikeContent(merged, content);
+        }
+      }
+
+      const firstIdx = thinkingIndices[group[0]];
+      blocks[firstIdx] = { type: 'thinking', thinking: merged, text: merged };
+
+      // Mark other blocks in group for removal
+      for (let k = 1; k < group.length; k++) {
+        toRemove.add(thinkingIndices[group[k]]);
+      }
+    }
+
+    // Filter out marked blocks (single pass, no index corruption)
+    return toRemove.size === 0 ? blocks : blocks.filter((_, idx) => !toRemove.has(idx));
   };
 
   /**

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -121,6 +121,53 @@ describe('useWindowCallbacks integration', () => {
     expect((window as any).__sessionTransitionToken).toBeNull();
   });
 
+  // ===== historyLoadComplete triggers full message re-render =====
+
+  it('historyLoadComplete creates new object references for all messages', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    const originalMessages: ClaudeMessage[] = [
+      { type: 'user', content: 'question', timestamp: '2024-01-01T00:00:00Z' },
+      { type: 'assistant', content: 'answer', timestamp: '2024-01-01T00:01:00Z' },
+    ];
+
+    act(() => {
+      (window as any).historyLoadComplete();
+    });
+
+    expect(opts.setMessages).toHaveBeenCalledTimes(1);
+    const updater = (opts.setMessages as any).mock.calls[0][0] as (prev: ClaudeMessage[]) => ClaudeMessage[];
+    const result = updater(originalMessages);
+
+    // Verify full shallow copy: array is new, each message object is new
+    expect(result).not.toBe(originalMessages);
+    expect(result.length).toBe(originalMessages.length);
+    for (let i = 0; i < result.length; i++) {
+      expect(result[i]).not.toBe(originalMessages[i]);
+      expect(result[i].content).toBe(originalMessages[i].content);
+      expect(result[i].type).toBe(originalMessages[i].type);
+    }
+  });
+
+  it('historyLoadComplete returns unchanged array when messages are empty', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      (window as any).historyLoadComplete();
+    });
+
+    expect(opts.setMessages).toHaveBeenCalledTimes(1);
+    const updater = (opts.setMessages as any).mock.calls[0][0] as (prev: ClaudeMessage[]) => ClaudeMessage[];
+    const emptyArray: ClaudeMessage[] = [];
+    const result = updater(emptyArray);
+
+    // Returns the same empty array reference (no unnecessary copy)
+    expect(result).toBe(emptyArray);
+    expect(result.length).toBe(0);
+  });
+
   // ===== setSessionId releases transition guard =====
 
   it('setSessionId releases __sessionTransitioning guard', () => {

--- a/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
@@ -423,6 +423,31 @@ describe('preserveStreamingAssistantContent', () => {
     );
     expect(result[0].content).toBe(longContent);
   });
+
+  it('blocks merge when only prev has turn ID (streaming vs history)', () => {
+    const longContent = 'long streaming content';
+    const prev = [makeAssistantMsg(longContent, { __turnId: 1 })];
+    const next = [makeAssistantMsg('history snapshot')];
+
+    const result = preserveStreamingAssistantContent(
+      prev, next, ref(true), ref(longContent),
+      findLastAssistantIndex, patchAssistantForStreaming,
+    );
+    expect(result).toBe(next);
+    expect(result[0].content).toBe('history snapshot');
+  });
+
+  it('blocks merge when only next has turn ID (history vs streaming)', () => {
+    const prev = [makeAssistantMsg('old history content')];
+    const next = [makeAssistantMsg('new streaming', { __turnId: 2 })];
+
+    const result = preserveStreamingAssistantContent(
+      prev, next, ref(true), ref('buffer'),
+      findLastAssistantIndex, patchAssistantForStreaming,
+    );
+    expect(result).toBe(next);
+    expect(result[0].content).toBe('new streaming');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -458,13 +483,24 @@ describe('preserveLastAssistantIdentity — turn ID guards', () => {
     expect(result[0].timestamp).toBe(prevTs);
   });
 
-  it('allows merge when only one has turn ID (Java message without turnId)', () => {
+  it('blocks merge when only prev has turn ID (streaming vs history)', () => {
     const prevTs = '2024-01-01T10:00:00.000Z';
-    const prev = [makeAssistantMsg('a1', { timestamp: prevTs, __turnId: 1 })];
-    const next = [makeAssistantMsg('a1', { timestamp: '2024-01-01T10:00:01.000Z' })];
+    const prev = [makeAssistantMsg('streaming', { timestamp: prevTs, __turnId: 1 })];
+    const next = [makeAssistantMsg('history snapshot', { timestamp: '2024-01-01T10:00:01.000Z' })];
 
     const result = preserveLastAssistantIdentity(prev, next, findLastAssistantIndex);
-    expect(result[0].timestamp).toBe(prevTs);
+    expect(result).toBe(next);
+    expect(result[0].timestamp).not.toBe(prevTs);
+  });
+
+  it('blocks merge when only next has turn ID (history vs streaming)', () => {
+    const prevTs = '2024-01-01T10:00:00.000Z';
+    const prev = [makeAssistantMsg('history', { timestamp: prevTs })];
+    const next = [makeAssistantMsg('streaming', { timestamp: '2024-01-01T10:00:01.000Z', __turnId: 2 })];
+
+    const result = preserveLastAssistantIdentity(prev, next, findLastAssistantIndex);
+    expect(result).toBe(next);
+    expect(result[0].timestamp).not.toBe(prevTs);
   });
 });
 

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -141,8 +141,8 @@ export const preserveLastAssistantIdentity = (
   const prevAssistant = prevList[prevAssistantIdx];
   const nextAssistant = nextList[nextAssistantIdx];
   // Guard: do not merge identity across different streaming turns
-  // Only block when BOTH have __turnId and they differ; allow merge when either lacks __turnId (backward compat)
-  if (prevAssistant.__turnId !== undefined && nextAssistant.__turnId !== undefined &&
+  // Block when either side has __turnId and they differ
+  if ((prevAssistant.__turnId !== undefined || nextAssistant.__turnId !== undefined) &&
       prevAssistant.__turnId !== nextAssistant.__turnId) {
     return nextList;
   }
@@ -179,8 +179,8 @@ export const preserveStreamingAssistantContent = (
   }
 
   // Guard: do not merge content across different streaming turns
-  // Only block when BOTH have __turnId and they differ
-  if (prevAssistant.__turnId !== undefined && nextAssistant.__turnId !== undefined &&
+  // Block when either side has __turnId and they differ
+  if ((prevAssistant.__turnId !== undefined || nextAssistant.__turnId !== undefined) &&
       prevAssistant.__turnId !== nextAssistant.__turnId) {
     return nextList;
   }
@@ -294,25 +294,31 @@ export const stripDuplicateTrailingToolMessages = (
 };
 
 /**
- * When Codex compacts or summarizes a long conversation, backend snapshots can
- * briefly shrink and omit the newest in-memory turn. Preserve that trailing
- * turn locally until the backend catches up, instead of wiping it from the UI.
+ * When backend snapshots briefly shrink (e.g., Codex compaction or Claude
+ * conversation summarization), preserve the newest in-memory turn locally
+ * until the backend catches up, instead of wiping it from the UI.
+ * FIX: Apply to all providers, not just Codex, to prevent message loss
+ * during streaming end race conditions.
  */
 export const preserveLatestMessagesOnShrink = (
   prevList: ClaudeMessage[],
   nextList: ClaudeMessage[],
   provider: string,
 ): ClaudeMessage[] => {
-  if (provider !== 'codex') return nextList;
+  // Always check for shrink regardless of provider
   if (nextList.length >= prevList.length) return nextList;
   if (prevList.length === 0 || nextList.length === 0) return nextList;
 
   const preservedTail = prevList.slice(nextList.length);
   if (preservedTail.length === 0) return nextList;
 
+  // Check if the preserved tail contains streaming/recent assistant messages
   const hasStreamingTail = preservedTail.some((msg) => msg.type === 'assistant' && (msg.isStreaming || !!msg.__turnId));
   const hasRecentUserTail = preservedTail.some((msg) => msg.type === 'user');
-  if (!hasStreamingTail && !hasRecentUserTail) {
+
+  // Codex: always preserve shrink tail (handles compaction/summarization)
+  // Other providers: only preserve if tail contains streaming/recent messages
+  if (provider !== 'codex' && !hasStreamingTail && !hasRecentUserTail) {
     return nextList;
   }
 

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -334,12 +334,34 @@ export function registerMessageCallbacks(
         // changed. This keeps pure content_delta traffic cheap, while still
         // re-rendering when the backend injects tool_use/tool_result blocks into
         // an existing assistant message during streaming.
+        // FIX: Also check thinking block content changes, as thinking blocks are
+        // rendered in collapsible UI and need updates even when tool_use count is stable.
         const hasStructuralChange = patched.length !== prev.length ||
           patched.some((msg, i) => {
             if (i >= prev.length) return true;
             const prevMsg = prev[i];
             if (msg.type !== prevMsg.type || msg.timestamp !== prevMsg.timestamp) {
               return true;
+            }
+            // For assistant messages during streaming, also check thinking block changes
+            if (msg.type === 'assistant' && prevMsg.type === 'assistant') {
+              const prevBlocks = extractRawBlocks(prevMsg.raw);
+              const newBlocks = extractRawBlocks(msg.raw);
+              // Check if thinking block content changed
+              const prevThinkingBlocks = prevBlocks.filter(
+                (b): b is { type: 'thinking'; thinking?: string } => b?.type === 'thinking'
+              );
+              const newThinkingBlocks = newBlocks.filter(
+                (b): b is { type: 'thinking'; thinking?: string } => b?.type === 'thinking'
+              );
+              if (prevThinkingBlocks.length !== newThinkingBlocks.length) return true;
+              for (let j = 0; j < prevThinkingBlocks.length; j++) {
+                const prevThinking = prevThinkingBlocks[j]?.thinking ?? '';
+                const newThinking = newThinkingBlocks[j]?.thinking ?? '';
+                if (prevThinking !== newThinking) return true;
+              }
+              // Check total block count change (new tool_use added)
+              if (prevBlocks.length !== newBlocks.length) return true;
             }
             return getStructuralRawBlockSignature(msg, extractRawBlocks) !==
               getStructuralRawBlockSignature(prevMsg, extractRawBlocks);
@@ -567,13 +589,15 @@ export function registerMessageCallbacks(
   };
 
   // History load complete callback — triggers Markdown re-rendering
+  // Use full shallow copy to ensure all messages trigger re-render regardless of batching timing
+  // Also clear stream-ended markers since history messages don't have __turnId
   window.historyLoadComplete = () => {
     releaseSessionTransition();
+    window.__lastStreamEndedTurnId = undefined;
+    window.__lastStreamEndedAt = undefined;
     setMessages((prev) => {
       if (prev.length === 0) return prev;
-      const updated = [...prev];
-      updated[updated.length - 1] = { ...updated[updated.length - 1] };
-      return updated;
+      return prev.map(m => ({ ...m }));
     });
   };
 

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -99,6 +99,9 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
 
   window.onStreamStart = () => {
     if (window.__sessionTransitioning) return;
+    // Clear the previous stream-ended marker when a new turn starts
+    window.__lastStreamEndedTurnId = undefined;
+    window.__lastStreamEndedAt = undefined;
     // Record turn start time for duration calculation in onStreamEnd
     window.__turnStartedAt = Date.now();
     streamingContentRef.current = '';
@@ -282,45 +285,72 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     const turnStartedAt = window.__turnStartedAt;
     window.__turnStartedAt = undefined;
 
-    // Flush final content AND clear streaming refs inside the same updater.
-    // This ensures any previously queued setMessages updater (e.g. from
-    // updateMessages) still reads valid refs when it executes, because React
-    // processes updaters in enqueue order.
+    // Snapshot streaming state BEFORE clearing refs - used for post-stream merge guard
+    const endedStreamingTurnId = streamingTurnIdRef.current;
+    const endedStreamingMessageIndex = streamingMessageIndexRef.current;
+    const endedStreamingContent = streamingContentRef.current;
+
+    // FIX: Clear streaming refs BEFORE setMessages updater to prevent race conditions.
+    //
+    // Trade-off analysis:
+    // - Original approach: refs cleared inside updater, leverages React batching to ensure
+    //   clearing and state update happen together. But this caused timing issues when
+    //   deferred operations (rAF, timeout) executed after the updater but before refs were
+    //   actually cleared, allowing them to modify the streaming message incorrectly.
+    // - New approach: refs cleared outside updater, uses snapshot values inside updater.
+    //   This prevents race conditions where deferred updateMessages sees isStreamingRef=false
+    //   but streamingMessageIndexRef still points to the old message.
+    // - Benefit: More robust handling of async callback ordering, especially important
+    //   when JCEF async chains can reorder callbacks unpredictably.
+    // - Risk: Minimal, since snapshot values are used inside updater and refs are cleared
+    //   synchronously before the updater is scheduled.
+    //
+    // Streaming state refs (isStreaming flag)
+    isStreamingRef.current = false;
+    useBackendStreamingRenderRef.current = false;
+
+    // Index refs (message position tracking)
+    streamingMessageIndexRef.current = -1;
+    streamingTurnIdRef.current = -1;
+
+    // Content buffer refs (text/thinking segments)
+    streamingContentRef.current = '';
+    streamingTextSegmentsRef.current = [];
+    streamingThinkingSegmentsRef.current = [];
+    activeTextSegmentIndexRef.current = -1;
+    activeThinkingSegmentIndexRef.current = -1;
+
+    // Counter and tracking refs
+    seenToolUseCountRef.current = 0;
+    autoExpandedThinkingKeysRef.current.clear();
+
+    // Mark that streaming just ended - used by mergeConsecutiveAssistantMessages to
+    // distinguish recently-ended streaming messages from true history messages.
+    window.__lastStreamEndedTurnId = endedStreamingTurnId;
+    window.__lastStreamEndedAt = Date.now();
+
+    // Flush final content and finalize the streaming message.
     setMessages((prev) => {
       let newMessages = prev;
-      const idx = streamingMessageIndexRef.current;
+      const idx = endedStreamingMessageIndex;
       if (prev.length > 0 && idx >= 0 && idx < prev.length && prev[idx]?.type === 'assistant') {
-        const finalContent = streamingContentRef.current;
         newMessages = [...prev];
-        // FIX: Clear __turnId from the streaming message. After streaming ends,
-        // the backend's updateMessages snapshots contain the correct message
-        // structure.  Stale __turnId can interfere with mergeConsecutiveAssistantMessages
-        // when subsequent backend snapshots carry different message splits.
-        const { __turnId: _removedTurnId, ...restWithoutTurnId } = newMessages[idx];
+        // FIX: Keep __turnId on the message for a short period to prevent
+        // incorrect merging with history messages. The __turnId will be
+        // removed later when history is loaded or a new turn starts.
+        const finalContent = endedStreamingContent || newMessages[idx].content || '';
         // Calculate durationMs and stamp it on the assistant message
         const durationMs = (typeof turnStartedAt === 'number' && turnStartedAt > 0)
           ? Date.now() - turnStartedAt
           : undefined;
         newMessages[idx] = {
-          ...restWithoutTurnId,
-          content: finalContent || newMessages[idx].content,
+          ...newMessages[idx],
+          content: finalContent,
           isStreaming: false,
+          __turnId: endedStreamingTurnId, // Keep __turnId for merge guard
           ...(durationMs != null ? { durationMs } : {}),
         };
       }
-
-      // Clear all streaming refs AFTER flushing content, inside the updater
-      isStreamingRef.current = false;
-      useBackendStreamingRenderRef.current = false;
-      streamingMessageIndexRef.current = -1;
-      streamingTurnIdRef.current = -1;
-      streamingContentRef.current = '';
-      streamingTextSegmentsRef.current = [];
-      activeTextSegmentIndexRef.current = -1;
-      streamingThinkingSegmentsRef.current = [];
-      activeThinkingSegmentIndexRef.current = -1;
-      seenToolUseCountRef.current = 0;
-      autoExpandedThinkingKeysRef.current.clear();
 
       return newMessages;
     });

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -34,7 +34,12 @@ export interface ClaudeMessage {
   timestamp?: string;
   isStreaming?: boolean;
   isOptimistic?: boolean;
-  /** Runtime-only: numeric turn identifier for streaming assistant isolation. */
+  /**
+   * Runtime-only: numeric turn identifier for streaming assistant isolation.
+   * Set by frontend during streaming to distinguish messages from different
+   * conversation turns. Messages with different __turnId values should never
+   * be merged. Undefined for history messages loaded from JSONL files.
+   */
   __turnId?: number;
   [key: string]: unknown;
 }

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -126,6 +126,55 @@ describe('mergeConsecutiveAssistantMessages', () => {
     expect(result.map((message) => message.__turnId)).toEqual([10, 11]);
   });
 
+  it('does not merge streaming message (has __turnId) with history message (no __turnId)', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'streaming turn', {
+        __turnId: 5,
+        raw: { content: [{ type: 'text', text: 'streaming turn' }] } as any,
+      }),
+      makeMsg('assistant', 'history message', {
+        raw: { content: [{ type: 'text', text: 'history message' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    expect(result).toHaveLength(2);
+    expect(result[0].__turnId).toBe(5);
+    expect(result[1].__turnId).toBeUndefined();
+  });
+
+  it('does not merge history message (no __turnId) with streaming message (has __turnId)', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'history message', {
+        raw: { content: [{ type: 'text', text: 'history message' }] } as any,
+      }),
+      makeMsg('assistant', 'streaming turn', {
+        __turnId: 5,
+        raw: { content: [{ type: 'text', text: 'streaming turn' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    expect(result).toHaveLength(2);
+    expect(result[0].__turnId).toBeUndefined();
+    expect(result[1].__turnId).toBe(5);
+  });
+
+  it('merges history messages without __turnId together', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', 'part1', {
+        raw: { content: [{ type: 'text', text: 'part1' }] } as any,
+      }),
+      makeMsg('assistant', 'part2', {
+        raw: { content: [{ type: 'text', text: 'part2' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('part1\npart2');
+  });
+
   it('merges tool-only assistant messages across user tool_result boundaries', () => {
     const messages: ClaudeMessage[] = [
       makeMsg('assistant', '', {
@@ -144,5 +193,50 @@ describe('mergeConsecutiveAssistantMessages', () => {
     expect(result).toHaveLength(1);
     const mergedRaw = result[0].raw as { content?: Array<{ type?: string; id?: string }> };
     expect(mergedRaw.content?.filter((block) => block.type === 'tool_use').map((block) => block.id)).toEqual(['tool-1', 'tool-2']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // hasToolUse + __turnId absence — tool_use merging behavior
+  // ---------------------------------------------------------------------------
+
+  it('merges tool_use with final answer for history messages (no __turnId)', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', '', {
+        raw: { content: [{ type: 'tool_use', id: 'tool-1', name: 'read_file' }] } as any,
+      }),
+      makeMsg('user', '[tool_result]', {
+        raw: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'file content' }] } as any,
+      }),
+      makeMsg('assistant', 'final answer', {
+        raw: { content: [{ type: 'text', text: 'final answer' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    expect(result).toHaveLength(1);
+    const mergedRaw = result[0].raw as { content?: Array<{ type?: string }> };
+    expect(mergedRaw.content?.some((b) => b.type === 'tool_use')).toBe(true);
+    expect(mergedRaw.content?.some((b) => b.type === 'text')).toBe(true);
+  });
+
+  it('keeps tool_use separated from final answer for streaming messages (has __turnId)', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', '', {
+        __turnId: 1,
+        raw: { content: [{ type: 'tool_use', id: 'tool-1', name: 'read_file' }] } as any,
+      }),
+      makeMsg('user', '[tool_result]', {
+        raw: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'file content' }] } as any,
+      }),
+      makeMsg('assistant', 'final answer', {
+        __turnId: 1,
+        raw: { content: [{ type: 'text', text: 'final answer' }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+    // Should have 2 assistant messages: tool_use block and final answer block
+    // (user tool_result is skipped, but assistant blocks stay separated)
+    expect(result.filter((m) => m.type === 'assistant')).toHaveLength(2);
   });
 });

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -373,9 +373,38 @@ export function getContentBlocks(
   return [];
 }
 
+// ---------------------------------------------------------------------------
+// Helper functions for mergeConsecutiveAssistantMessages
+// These functions handle the stream-ended marker cleanup and checking.
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear stale stream-ended markers from window global state.
+ * Called once at the entry of mergeConsecutiveAssistantMessages to avoid
+ * modifying global state inside a pure judgment function.
+ * The marker expires after 5 seconds to allow normal history merging.
+ */
+const clearStaleStreamEndedMarker = (): void => {
+  const lastEndedTime = (window as any).__lastStreamEndedAt;
+  if (lastEndedTime && Date.now() - lastEndedTime > 5000) {
+    (window as any).__lastStreamEndedTurnId = undefined;
+    (window as any).__lastStreamEndedAt = undefined;
+  }
+};
+
+/**
+ * Check if a message has the recently-ended streaming turn ID.
+ * Used to block merging of recently-ended streaming messages with history messages.
+ * Returns true if the message's turnId matches the last ended streaming turn.
+ */
+const hasRecentlyEndedTurnId = (turnId: number | undefined): boolean => {
+  const lastEndedTurnId = (window as any).__lastStreamEndedTurnId;
+  return lastEndedTurnId !== undefined && lastEndedTurnId > 0 && turnId === lastEndedTurnId;
+};
+
 /**
  * Merge consecutive assistant messages to fix style inconsistencies in history
- * where Thinking and ToolUse are separated
+ * where Thinking and ToolUse are separated.
  */
 export function mergeConsecutiveAssistantMessages(
   messages: ClaudeMessage[],
@@ -383,6 +412,9 @@ export function mergeConsecutiveAssistantMessages(
   cache?: Map<string, { source: ClaudeMessage[]; merged: ClaudeMessage }>
 ): ClaudeMessage[] {
   if (messages.length === 0) return [];
+
+  // Clear stale stream-ended markers once at entry (5 second timeout)
+  clearStaleStreamEndedMarker();
 
   const getStableId = (message: ClaudeMessage, index: number): string => {
     const rawObj = typeof message.raw === 'object' ? (message.raw as Record<string, unknown> | null) : null;
@@ -404,19 +436,32 @@ export function mergeConsecutiveAssistantMessages(
   const shouldMergeAssistantMessage = (previous: ClaudeMessage, next: ClaudeMessage): boolean => {
     // Distinct streaming turns must stay visually separated even when the
     // backend emits adjacent assistant fragments during synchronization.
-    if (
-      previous.__turnId !== undefined &&
-      next.__turnId !== undefined &&
-      previous.__turnId !== next.__turnId
-    ) {
+    // Block merge when either side has a __turnId and they differ.
+    // This prevents streaming messages from merging with history messages.
+    // FIX: Also check __lastStreamEndedTurnId to distinguish recently-ended
+    // streaming messages from true history messages.
+    const prevTurnId = previous.__turnId;
+    const nextTurnId = next.__turnId;
+
+    // If either message has the recently-ended turn ID, block merging
+    if (hasRecentlyEndedTurnId(prevTurnId) || hasRecentlyEndedTurnId(nextTurnId)) {
+      return false;
+    }
+
+    // Block merge when either side has a __turnId and they differ
+    if ((prevTurnId !== undefined || nextTurnId !== undefined) &&
+        prevTurnId !== nextTurnId) {
       return false;
     }
 
     const previousSummary = getAssistantBlockSummary(previous);
     const nextSummary = getAssistantBlockSummary(next);
 
-    // Keep tool-execution assistant messages separated from the final answer.
-    if (previousSummary.hasToolUse !== nextSummary.hasToolUse) {
+    // For messages without __turnId (loaded from history), allow merging across
+    // tool_use boundary so that tool-execution and final answer appear as one block.
+    // For streaming messages (with __turnId), keep tool_use separated from answer.
+    const bothLackTurnId = prevTurnId === undefined && nextTurnId === undefined;
+    if (!bothLackTurnId && previousSummary.hasToolUse !== nextSummary.hasToolUse) {
       return false;
     }
 


### PR DESCRIPTION
Six critical fixes for streaming message rendering:

1. Backend dedup skips frontend notification (root cause fix)
   - Problem: When dedup triggered in handleContentDelta/handleThinkingDelta,
     the backend still notified frontend via notifyContentDelta/notifyThinkingDelta.
     Frontend has no dedup and accumulated the duplicate delta, causing content
     like "AB" to render as "ABABABAB".
   - Fix: Remove notifyContentDelta call in handleContentDelta dedup branch.
     Only call notifyThinkingDelta when applyThinkingDeltaToRaw returns true.
   - Added syncedContentOffset/syncedThinkingOffset (volatile) for offset tracking.

2. Backend MessageMerger fallback merge without crossing keyed blocks
   - Problem: When textLooksRelated failed to match, new blocks were added
     causing duplicate text/thinking blocks.
   - Fix: Added findLastSameTypeBlockIndex to merge with last same-type block
     in tail region, stopping at keyed blocks (tool_use/tool_result).

3. Frontend isDoubledContent defensive check
   - Added isDoubledContent function to detect when backend content is
     segment content repeated 2+ times (e.g., "ABCABC" from "ABC").
   - Used in preferMoreCompleteText/preferMoreCompleteThinking.

4. Thinking blocks consolidated via mergeOverlappingThinkingBlocks
   - Added post-processing in buildStreamingBlocks to merge thinking blocks
     with overlapping content while preserving distinct thinking phases.

5. Stream-ended merge guard with 5-second TTL
   - Added __lastStreamEndedTurnId/__lastStreamEndedAt window markers.
   - mergeConsecutiveAssistantMessages blocks merging when message has
     recently-ended turn ID, preventing incorrect history/stream merge.
   - Updated preserveLastAssistantIdentity/preserveStreamingAssistantContent
     to block merge when either side has __turnId and they differ.

6. Enhanced structural change detection
   - hasStructuralChange now checks thinking block content changes and
     total block count changes, not just tool_use/tool_result signatures.

Additional changes:
- onStreamEnd clears refs BEFORE setMessages updater (using snapshots)
- historyLoadComplete clears stream-ended markers and does full shallow copy
- preserveLatestMessagesOnShrink applied to all providers (not just Codex)
- Added ClaudeMessageHandlerDedupTest with 8 test cases
- Added regression tests in frontend test files