### PR TITLE
feat(ui): add long context toggle for Claude models

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -24,11 +24,17 @@ public class ModelProviderHandler {
 
     static final Map<String, Integer> MODEL_CONTEXT_LIMITS = new HashMap<>();
     static {
-        MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 1_000_000);
-        MODEL_CONTEXT_LIMITS.put("claude-opus-4-7", 1_000_000);
-        MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 1_000_000);
+        // Claude models with 1M context (base IDs)
+        MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-7", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 200_000);
+        // Claude models with [1m] suffix - 1M context
+        MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6[1m]", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-7[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6[1m]", 1_000_000);
+        // Haiku - no 1M context available
         MODEL_CONTEXT_LIMITS.put("claude-haiku-4-5", 200_000);
+        // Codex/GPT models
         MODEL_CONTEXT_LIMITS.put("gpt-5.4", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("gpt-5.3-codex", 258_000);
         MODEL_CONTEXT_LIMITS.put("gpt-5.2-codex", 258_000);

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
@@ -60,8 +60,23 @@ public class ModelProviderHandlerTest {
     }
 
     @Test
-    public void shouldTreatBothOpus46IdsAsOneMillionContext() {
-        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6"));
+    public void shouldReturnCorrectContextLimitsForClaudeModels() {
+        // Base IDs without [1m] suffix - 200k context by default
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6"));
+        // IDs with [1m] suffix - 1M context
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6[1m]"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6[1m]"));
+        // Haiku - no 1M context available
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-haiku-4-5"));
+    }
+
+    @Test
+    public void shouldParseCapacitySuffixForCustomContextLimits() {
+        assertEquals(500_000, ModelProviderHandler.getModelContextLimit("custom-model[500k]"));
+        assertEquals(2_000_000, ModelProviderHandler.getModelContextLimit("custom-model[2m]"));
+        assertEquals(100_000, ModelProviderHandler.getModelContextLimit("custom-model[100K]"));
     }
 }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -170,6 +170,7 @@ const App = () => {
     currentProviderRef,
     activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
     reasoningEffort, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+    longContextEnabled,
     usagePercentage, usageUsedTokens, usageMaxTokens,
     setPermissionMode,
     setClaudePermissionMode, setCodexPermissionMode,
@@ -183,7 +184,7 @@ const App = () => {
     handleModeSelect, handleModelSelect, handleProviderSelect,
     handleReasoningChange, handleAgentSelect, handleToggleThinking,
     handleStreamingEnabledChange, handleSendShortcutChange,
-    handleAutoOpenFileEnabledChange,
+    handleAutoOpenFileEnabledChange, handleLongContextChange,
   } = useModelProviderState({ addToast, t });
 
   // ── Global drag event interception ──
@@ -641,6 +642,8 @@ const App = () => {
               onRemoveFromQueue={dequeueMessage}
               autoOpenFileEnabled={autoOpenFileEnabled}
               onAutoOpenFileEnabledChange={handleAutoOpenFileEnabledChange}
+              longContextEnabled={longContextEnabled}
+              onLongContextChange={handleLongContextChange}
             />
           </div>
         </>

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -90,6 +90,8 @@ export const ButtonArea = ({
   onAgentSelect,
   onOpenAgentSettings,
   onAddModel,
+  longContextEnabled = true,
+  onLongContextChange,
 }: ButtonAreaProps) => {
   const { t } = useTranslation();
   // const fileInputRef = useRef<HTMLInputElement>(null);
@@ -258,7 +260,7 @@ export const ButtonArea = ({
           compact
         />
         <ModeSelect value={permissionMode} onChange={handleModeSelect} provider={currentProvider} />
-        <ModelSelect value={selectedModel} onChange={handleModelSelect} models={availableModels} currentProvider={currentProvider} onAddModel={onAddModel} />
+        <ModelSelect value={selectedModel} onChange={handleModelSelect} models={availableModels} currentProvider={currentProvider} onAddModel={onAddModel} longContextEnabled={longContextEnabled} onLongContextChange={onLongContextChange} />
         {currentProvider === 'codex' && (
           <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} />
         )}

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -103,6 +103,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       onRemoveFromQueue,
       autoOpenFileEnabled,
       onAutoOpenFileEnabledChange,
+      longContextEnabled = true,
+      onLongContextChange,
     }: ChatInputBoxProps,
     ref: React.ForwardedRef<ChatInputBoxHandle>
   ) => {
@@ -697,6 +699,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
           onOpenAgentSettings={onOpenAgentSettings}
           onAddModel={onOpenModelSettings}
           onClearAgent={() => onAgentSelect?.(null)}
+          longContextEnabled={longContextEnabled}
+          onLongContextChange={onLongContextChange}
           fileCompletion={fileCompletion}
           commandCompletion={commandCompletion}
           agentCompletion={agentCompletion}

--- a/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
@@ -41,6 +41,8 @@ export function ChatInputBoxFooter({
   onOpenAgentSettings,
   onAddModel,
   onClearAgent,
+  longContextEnabled = true,
+  onLongContextChange,
   fileCompletion,
   commandCompletion,
   agentCompletion,
@@ -74,6 +76,8 @@ export function ChatInputBoxFooter({
   onOpenAgentSettings?: () => void;
   onAddModel?: () => void;
   onClearAgent: () => void;
+  longContextEnabled?: boolean;
+  onLongContextChange?: (enabled: boolean) => void;
   fileCompletion: CompletionController;
   commandCompletion: CompletionController;
   agentCompletion: CompletionController;
@@ -119,6 +123,8 @@ export function ChatInputBoxFooter({
         onOpenAgentSettings={onOpenAgentSettings}
         onAddModel={onAddModel}
         onClearAgent={onClearAgent}
+        longContextEnabled={longContextEnabled}
+        onLongContextChange={onLongContextChange}
       />
 
       {/* @ file reference dropdown menu */}

--- a/webview/src/components/ChatInputBox/selectors/LongContextToggle.tsx
+++ b/webview/src/components/ChatInputBox/selectors/LongContextToggle.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from 'react-i18next';
+import { Switch } from 'antd';
+import { modelSupports1MContext } from '../types';
+
+interface LongContextToggleProps {
+  /** Current model ID (to determine if toggle should be enabled) */
+  modelId: string;
+  /** Whether long context is enabled */
+  enabled: boolean;
+  /** Toggle callback */
+  onChange: (enabled: boolean) => void;
+}
+
+/**
+ * LongContextToggle - Toggle switch for 1M context window.
+ * Positioned next to model selector. Only enabled for non-Haiku models.
+ */
+export const LongContextToggle = ({
+  modelId,
+  enabled,
+  onChange,
+}: LongContextToggleProps) => {
+  const { t } = useTranslation();
+  const supports1M = modelSupports1MContext(modelId);
+
+  const displayEnabled = supports1M ? enabled : false;
+
+  return (
+    <div
+      className="long-context-toggle"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '4px',
+        marginLeft: '4px',
+        opacity: supports1M ? 1 : 0.5,
+      }}
+      title={supports1M
+        ? t('models.longContext.tooltipEnabled')
+        : t('models.longContext.tooltipDisabled')
+      }
+    >
+      <span
+        style={{
+          fontSize: '11px',
+          fontWeight: 500,
+          color: displayEnabled ? 'var(--text-link-active)' : 'var(--text-secondary)',
+        }}
+      >
+        {t('models.longContext.label')}
+      </span>
+      <Switch
+        size="small"
+        checked={displayEnabled}
+        disabled={!supports1M}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+export default LongContextToggle;

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -1,16 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AVAILABLE_MODELS, normalizeClaudeModelId } from '../types';
+import { AVAILABLE_MODELS, normalizeClaudeModelId, modelSupports1MContext, strip1MContextSuffix } from '../types';
 import type { ModelInfo } from '../types';
 import { readClaudeModelMapping } from '../../../utils/claudeModelMapping';
 import { ProviderModelIcon } from '../../shared/ProviderModelIcon';
+import { Switch } from 'antd';
 
 interface ModelSelectProps {
   value: string;
   onChange: (modelId: string) => void;
-  models?: ModelInfo[];  // Optional dynamic model list
-  currentProvider?: string;  // Current provider type
-  onAddModel?: () => void;  // Navigate to model management
+  models?: ModelInfo[];
+  currentProvider?: string;
+  onAddModel?: () => void;
+  longContextEnabled?: boolean;
+  onLongContextChange?: (enabled: boolean) => void;
 }
 
 const DEFAULT_MODEL_MAP: Record<string, ModelInfo> = AVAILABLE_MODELS.reduce(
@@ -105,47 +108,54 @@ const resolveModelIdForIcon = (
  * ModelSelect - Model selector component
  * Supports switching between Sonnet 4.5, Opus 4.5, and other models, including Codex models
  */
-export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, currentProvider = 'claude', onAddModel }: ModelSelectProps) => {
+export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, currentProvider = 'claude', onAddModel, longContextEnabled = true, onLongContextChange }: ModelSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const normalizedValue = currentProvider === 'claude' ? normalizeClaudeModelId(value) : value;
-  const currentModel = models.find(m => m.id === normalizedValue) || models.find(m => m.id === value) || models[0];
+  // Strip [1m] suffix for finding the model in the list
+  const strippedValue = strip1MContextSuffix(value);
+  const normalizedValue = currentProvider === 'claude' ? normalizeClaudeModelId(strippedValue) : strippedValue;
+  const currentModel = models.find(m => m.id === normalizedValue) || models.find(m => m.id === strippedValue) || models[0];
   const modelMapping = readClaudeModelMapping();
 
   const isSelectedModel = (modelId: string): boolean => {
     if (currentProvider !== 'claude') {
-      return modelId === value;
+      return modelId === strippedValue;
     }
     return normalizeClaudeModelId(modelId) === normalizedValue;
   };
 
-  const getModelLabel = (model: ModelInfo): string => {
-    // Only apply Claude model mapping to Claude models (not Codex)
+  const getModelLabel = (model: ModelInfo, show1MContext = false): string => {
     const mappingKey = MODEL_ID_TO_MAPPING_KEY[model.id];
     if (mappingKey) {
       const mappedName = resolveMappedModelName(mappingKey, modelMapping);
       if (mappedName) {
-        return mappedName;
+        return append1MContextSuffix(mappedName, model.id, show1MContext);
       }
     }
 
-    // Fall back to default logic when no mapping is found
     const defaultModel = DEFAULT_MODEL_MAP[model.id];
     const labelKey = MODEL_LABEL_KEYS[model.id];
     const hasCustomLabel = defaultModel && model.label && model.label !== defaultModel.label;
 
     if (hasCustomLabel) {
-      return model.label;
+      return append1MContextSuffix(model.label ?? '', model.id, show1MContext);
     }
 
     if (labelKey) {
-      return t(labelKey);
+      return append1MContextSuffix(t(labelKey), model.id, show1MContext);
     }
 
-    return model.label;
+    return append1MContextSuffix(model.label ?? '', model.id, show1MContext);
+  };
+
+  const append1MContextSuffix = (label: string, modelId: string, show1MContext: boolean): string => {
+    if (show1MContext && modelSupports1MContext(modelId) && longContextEnabled) {
+      return `${label} (${t('models.longContext.shortLabel')})`;
+    }
+    return label;
   };
 
   const getModelDescription = (model: ModelInfo): string | undefined => {
@@ -206,7 +216,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         ref={buttonRef}
         className="selector-button"
         onClick={handleToggle}
-        title={t('chat.currentModel', { model: getModelLabel(currentModel) })}
+        title={t('chat.currentModel', { model: getModelLabel(currentModel, true) })}
       >
         <ProviderModelIcon
           providerId={currentProvider}
@@ -214,7 +224,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
           size={12}
           colored
         />
-        <span className="selector-button-text">{getModelLabel(currentModel)}</span>
+        <span className="selector-button-text">{getModelLabel(currentModel, true)}</span>
         <span className={`codicon codicon-chevron-${isOpen ? 'up' : 'down'}`} style={{ fontSize: '10px', marginLeft: '2px' }} />
       </button>
 
@@ -243,7 +253,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
                 colored
               />
               <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-                <span>{getModelLabel(model)}</span>
+                <span>{getModelLabel(model, false)}</span>
                 {getModelDescription(model) && (
                   <span className="model-description">{getModelDescription(model)}</span>
                 )}
@@ -253,6 +263,24 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
               )}
             </div>
           ))}
+          {currentProvider === 'claude' && onLongContextChange && (
+            <>
+              <div className="selector-divider" />
+              <div
+                className="selector-option"
+                style={{ justifyContent: 'space-between', cursor: 'default' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span style={{ fontSize: '12px' }}>{t('models.longContext.shortLabel')}</span>
+                <Switch
+                  size="small"
+                  checked={modelSupports1MContext(value) ? longContextEnabled : false}
+                  disabled={!modelSupports1MContext(value)}
+                  onChange={onLongContextChange}
+                />
+              </div>
+            </>
+          )}
           {onAddModel && (
             <>
               <div className="selector-divider" />

--- a/webview/src/components/ChatInputBox/selectors/index.ts
+++ b/webview/src/components/ChatInputBox/selectors/index.ts
@@ -3,3 +3,4 @@ export { ModelSelect } from './ModelSelect';
 export { ProviderSelect } from './ProviderSelect';
 export { ConfigSelect } from './ConfigSelect';
 export { ReasoningSelect } from './ReasoningSelect';
+export { LongContextToggle } from './LongContextToggle';

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -250,6 +250,51 @@ export interface ModelInfo {
   description?: string;
 }
 
+/**
+ * Check if a model supports 1M context window.
+ * All models support 1M except Haiku (matched by name substring).
+ */
+export function modelSupports1MContext(modelId: string | undefined | null): boolean {
+  if (!modelId) {
+    return false;
+  }
+  return !modelId.replace(/\[1m\]$/i, '').toLowerCase().includes('haiku');
+}
+
+/**
+ * Check if a model ID already has [1m] suffix.
+ */
+export function has1MContextSuffix(modelId: string | undefined | null): boolean {
+  if (!modelId) {
+    return false;
+  }
+  return /\[1m\]$/i.test(modelId);
+}
+
+/**
+ * Apply [1m] suffix to model ID if supported and enabled.
+ * Returns the original model ID if the model doesn't support 1M context.
+ */
+export function apply1MContextSuffix(modelId: string, enabled: boolean): string {
+  if (!enabled || !modelSupports1MContext(modelId)) {
+    // Remove any existing [1m] suffix if disabled
+    return modelId.replace(/\[1m\]$/i, '');
+  }
+  // Remove existing suffix first, then add new one
+  const baseId = modelId.replace(/\[1m\]$/i, '');
+  return `${baseId}[1m]`;
+}
+
+/**
+ * Remove [1m] suffix from model ID for display/storage purposes.
+ */
+export function strip1MContextSuffix(modelId: string | undefined | null): string {
+  if (!modelId) {
+    return '';
+  }
+  return modelId.replace(/\[1m\]$/i, '');
+}
+
 const LEGACY_CLAUDE_MODEL_ID_ALIASES: Record<string, string> = {
   'claude-opus-4-6[1m]': 'claude-opus-4-6',
 };
@@ -258,26 +303,29 @@ export function normalizeClaudeModelId(modelId: string | undefined | null): stri
   if (!modelId) {
     return 'claude-sonnet-4-6';
   }
-  return LEGACY_CLAUDE_MODEL_ID_ALIASES[modelId] ?? modelId;
+  // First strip any [1m] suffix
+  const stripped = strip1MContextSuffix(modelId);
+  return LEGACY_CLAUDE_MODEL_ID_ALIASES[stripped] ?? stripped;
 }
 
 /**
- * Claude model list
+ * Claude model list (base IDs without [1m] suffix).
+ * The 1M context suffix is applied dynamically via toggle.
  */
 export const CLAUDE_MODELS: ModelInfo[] = [
   {
     id: 'claude-sonnet-4-6',
-    label: 'Sonnet 4.6 (1M context)',
+    label: 'Sonnet 4.6',
     description: 'Sonnet 4.6 · Use the default model',
   },
   {
     id: 'claude-opus-4-7',
-    label: 'Opus 4.7 (1M context)',
+    label: 'Opus 4.7',
     description: 'Opus 4.7 · Latest and most capable',
   },
   {
     id: 'claude-opus-4-6',
-    label: 'Opus 4.6 (1M context)',
+    label: 'Opus 4.6',
     description: 'Opus 4.6 for long sessions',
   },
   {
@@ -561,6 +609,10 @@ export interface ChatInputBoxProps {
   autoOpenFileEnabled?: boolean;
   /** Toggle auto open file enabled */
   onAutoOpenFileEnabledChange?: (enabled: boolean) => void;
+  /** Whether long context (1M) is enabled */
+  longContextEnabled?: boolean;
+  /** Toggle long context callback */
+  onLongContextChange?: (enabled: boolean) => void;
 }
 
 /**
@@ -612,6 +664,10 @@ export interface ButtonAreaProps {
   onOpenAgentSettings?: () => void;
   /** Navigate to model management to add models */
   onAddModel?: () => void;
+  /** Whether long context (1M) is enabled */
+  longContextEnabled?: boolean;
+  /** Toggle long context callback */
+  onLongContextChange?: (enabled: boolean) => void;
 }
 
 /**

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../utils/bridge';
-import { CLAUDE_MODELS, CODEX_MODELS, isValidPermissionMode, normalizeClaudeModelId } from '../components/ChatInputBox/types';
+import { CLAUDE_MODELS, CODEX_MODELS, isValidPermissionMode, normalizeClaudeModelId, apply1MContextSuffix, strip1MContextSuffix } from '../components/ChatInputBox/types';
 import type { PermissionMode, ReasoningEffort, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ProviderConfig } from '../types/provider';
 import { isSpecialProviderId } from '../types/provider';
@@ -48,6 +48,8 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   const [sendShortcut, setSendShortcut] = useState<'enter' | 'cmdEnter'>('enter');
   // Auto-open file setting
   const [autoOpenFileEnabled, setAutoOpenFileEnabled] = useState(false);
+  // Long context (1M) toggle state - default enabled, persisted with model selection
+  const [longContextEnabled, setLongContextEnabled] = useState(true);
 
   // SDK installation status
   const [sdkStatus, setSdkStatus] = useState<Record<string, { installed?: boolean; status?: string }>>({});
@@ -56,8 +58,12 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   // Refs for stale closure prevention
   const currentProviderRef = useRef(currentProvider);
   const activeProviderConfigRef = useRef(activeProviderConfig);
+  const selectedClaudeModelRef = useRef(selectedClaudeModel);
+  const longContextEnabledRef = useRef(longContextEnabled);
   useEffect(() => { currentProviderRef.current = currentProvider; }, [currentProvider]);
   useEffect(() => { activeProviderConfigRef.current = activeProviderConfig; }, [activeProviderConfig]);
+  useEffect(() => { selectedClaudeModelRef.current = selectedClaudeModel; }, [selectedClaudeModel]);
+  useEffect(() => { longContextEnabledRef.current = longContextEnabled; }, [longContextEnabled]);
 
   // Select the displayed model based on the current provider
   const selectedModel = currentProvider === 'codex' ? selectedCodexModel : selectedClaudeModel;
@@ -102,6 +108,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
       let restoredClaudePermissionMode: PermissionMode = 'bypassPermissions';
       let restoredCodexPermissionMode: PermissionMode = 'default';
       let initialPermissionMode: PermissionMode = 'bypassPermissions';
+      let restoredLongContextEnabled = true;  // Default enabled
 
       if (saved) {
         const state = JSON.parse(saved);
@@ -120,8 +127,16 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
             : state.codexPermissionMode;
         }
 
+        // Load long context setting (default true if not present)
+        if (typeof state.longContextEnabled === 'boolean') {
+          restoredLongContextEnabled = state.longContextEnabled;
+          setLongContextEnabled(state.longContextEnabled);
+        }
+
         const savedClaudeCustomModels = getCustomModels('claude-custom-models');
-        const normalizedClaudeModel = normalizeClaudeModelId(state.claudeModel);
+        // Strip [1m] suffix for internal state
+        const strippedClaudeModel = strip1MContextSuffix(state.claudeModel);
+        const normalizedClaudeModel = normalizeClaudeModelId(strippedClaudeModel);
         if (
           CLAUDE_MODELS.find(m => m.id === normalizedClaudeModel) ||
           savedClaudeCustomModels.find((m: { id: string }) => m.id === normalizedClaudeModel)
@@ -153,7 +168,10 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
       const syncToBackend = () => {
         if (window.sendToJava) {
           sendBridgeEvent('set_provider', restoredProvider);
-          const modelToSync = restoredProvider === 'codex' ? restoredCodexModel : restoredClaudeModel;
+          // For Claude, apply [1m] suffix if long context is enabled and model supports it
+          const modelToSync = restoredProvider === 'codex'
+            ? restoredCodexModel
+            : apply1MContextSuffix(restoredClaudeModel, restoredLongContextEnabled);
           sendBridgeEvent('set_model', modelToSync);
           sendBridgeEvent('set_mode', initialPermissionMode);
         } else {
@@ -178,11 +196,12 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
         codexModel: selectedCodexModel,
         claudePermissionMode,
         codexPermissionMode,
+        longContextEnabled,
       }));
     } catch {
       // Failed to save model selection state
     }
-  }, [currentProvider, selectedClaudeModel, selectedCodexModel, claudePermissionMode, codexPermissionMode]);
+  }, [currentProvider, selectedClaudeModel, selectedCodexModel, claudePermissionMode, codexPermissionMode, longContextEnabled]);
 
   // Load selected agent
   useEffect(() => {
@@ -226,9 +245,11 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
 
   const handleModelSelect = useCallback((modelId: string) => {
     if (currentProviderRef.current === 'claude') {
-      const normalizedModelId = normalizeClaudeModelId(modelId);
+      const strippedModelId = strip1MContextSuffix(modelId);
+      const normalizedModelId = normalizeClaudeModelId(strippedModelId);
       setSelectedClaudeModel(normalizedModelId);
-      sendBridgeEvent('set_model', normalizedModelId);
+      const modelToSync = apply1MContextSuffix(normalizedModelId, longContextEnabledRef.current);
+      sendBridgeEvent('set_model', modelToSync);
     } else if (currentProviderRef.current === 'codex') {
       setSelectedCodexModel(modelId);
       sendBridgeEvent('set_model', modelId);
@@ -244,7 +265,9 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     setPermissionMode(modeToSet);
     sendBridgeEvent('set_mode', modeToSet);
 
-    const newModel = providerId === 'codex' ? selectedCodexModel : selectedClaudeModel;
+    const newModel = providerId === 'codex'
+      ? selectedCodexModel
+      : apply1MContextSuffix(selectedClaudeModel, longContextEnabledRef.current);
     sendBridgeEvent('set_model', newModel);
   }, [claudePermissionMode, codexPermissionMode, selectedCodexModel, selectedClaudeModel]);
 
@@ -326,6 +349,14 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     addToast(enabled ? t('settings.basic.autoOpenFile.enabled') : t('settings.basic.autoOpenFile.disabled'), 'success');
   }, [t, addToast]);
 
+  const handleLongContextChange = useCallback((enabled: boolean) => {
+    setLongContextEnabled(enabled);
+    if (currentProviderRef.current === 'claude') {
+      const modelToSync = apply1MContextSuffix(selectedClaudeModelRef.current, enabled);
+      sendBridgeEvent('set_model', modelToSync);
+    }
+  }, []);
+
   return {
     // States
     currentProvider, setCurrentProvider,
@@ -345,6 +376,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     streamingEnabledSetting, setStreamingEnabledSetting,
     sendShortcut, setSendShortcut,
     autoOpenFileEnabled, setAutoOpenFileEnabled,
+    longContextEnabled, setLongContextEnabled,
     sdkStatus, setSdkStatus,
     sdkStatusLoaded, setSdkStatusLoaded,
     // Computed
@@ -365,5 +397,6 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     handleStreamingEnabledChange,
     handleSendShortcutChange,
     handleAutoOpenFileEnabledChange,
+    handleLongContextChange,
   };
 }

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1300,17 +1300,23 @@
   },
   "models": {
     "addModel": "Add Model",
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M context",
+      "tooltipEnabled": "Toggle 1M context window on/off",
+      "tooltipDisabled": "1M context not available for Haiku"
+    },
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M context)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Use the default model"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M context)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · Latest and most capable"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M context)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 for long sessions"
       },
       "haiku45": {

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1124,21 +1124,27 @@
     "addModel": "Agregar modelo",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M contexto)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Modelo recomendado por defecto"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M contexto)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · El más reciente y capaz"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M contexto)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 para sesiones largas"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · El más rápido para respuestas rápidas"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M contexto",
+      "tooltipEnabled": "Activar/desactivar contexto 1M",
+      "tooltipDisabled": "1M contexto no disponible para Haiku"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1124,21 +1124,27 @@
     "addModel": "Ajouter un modèle",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M contexte)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Modèle recommandé par défaut"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M contexte)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · Le plus récent et le plus performant"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M contexte)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 pour les longues sessions"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Le plus rapide pour des réponses rapides"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M contexte",
+      "tooltipEnabled": "Activer/désactiver le contexte 1M",
+      "tooltipDisabled": "1M contexte non disponible pour Haiku"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1123,21 +1123,27 @@
     "addModel": "मॉडल जोड़ें",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M संदर्भ)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · डिफ़ॉल्ट अनुशंसित मॉडल"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M संदर्भ)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · नवीनतम और सबसे सक्षम"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M संदर्भ)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 लंबे सत्रों के लिए"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · सबसे तेज़, त्वरित उत्तरों के लिए उपयुक्त"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M संदर्भ",
+      "tooltipEnabled": "1M संदर्भ चालू/बंद करें",
+      "tooltipDisabled": "Haiku के लिए 1M संदर्भ उपलब्ध नहीं है"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1127,17 +1127,23 @@
   },
   "models": {
     "addModel": "モデル追加",
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1Mコンテキスト",
+      "tooltipEnabled": "1Mコンテキストウィンドウをオン/オフ",
+      "tooltipDisabled": "Haikuでは1Mコンテキストは利用できません"
+    },
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M コンテキスト)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · デフォルトモデルを使用"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M コンテキスト)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · 最新かつ最も優れたモデル"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M コンテキスト)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 長時間セッション向け"
       },
       "haiku45": {

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1246,21 +1246,27 @@
     "addModel": "모델 추가",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M 컨텍스트)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 기본 모델 사용"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M 컨텍스트)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · 최신 및 가장 강력한 모델"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M 컨텍스트)",
+        "label": "Opus 4.6",
         "description": "긴 세션을 위한 Opus 4.6"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · 빠른 응답에 최적"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M 컨텍스트",
+      "tooltipEnabled": "1M 컨텍스트 켜기/끄기",
+      "tooltipDisabled": "Haiku에서는 1M 컨텍스트를 사용할 수 없습니다"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1301,21 +1301,27 @@
     "addModel": "Adicionar Modelo",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (contexto 1M)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Usar o modelo padrão"
       },
       "opus46": {
-        "label": "Opus 4.7 (contexto 1M)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · O mais recente e capaz"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (contexto 1M)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 para sessões longas"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Mais rápido para respostas rápidas"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M contexto",
+      "tooltipEnabled": "Ativar/desativar contexto 1M",
+      "tooltipDisabled": "1M contexto não disponível para Haiku"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1150,21 +1150,27 @@
     "addModel": "Добавить модель",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6 (1M контекст)",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Модель по умолчанию"
       },
       "opus46": {
-        "label": "Opus 4.7 (1M контекст)",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · Новейшая и самая мощная"
       },
       "opus46_1m": {
-        "label": "Opus 4.6 (1M контекст)",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 для длинных чатов"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Самая быстрая для быстрых ответов"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M контекст",
+      "tooltipEnabled": "Включить/выключить 1M контекст",
+      "tooltipDisabled": "1M контекст недоступен для Haiku"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1129,21 +1129,27 @@
     "addModel": "新增模型",
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6（1M 上下文）",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 預設推薦模型"
       },
       "opus46": {
-        "label": "Opus 4.7（1M 上下文）",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · 最新最強大的模型"
       },
       "opus46_1m": {
-        "label": "Opus 4.6（1M 上下文）",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 長對話模式"
       },
       "haiku45": {
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · 速度最快，適合快速回覆"
       }
+    },
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M上下文",
+      "tooltipEnabled": "開啟/關閉1M上下文",
+      "tooltipDisabled": "Haiku不支援1M上下文"
     },
     "codex": {
       "gpt53codex": {

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1305,17 +1305,23 @@
   },
   "models": {
     "addModel": "添加模型",
+    "longContext": {
+      "label": "1M",
+      "shortLabel": "1M上下文",
+      "tooltipEnabled": "开启/关闭1M上下文窗口",
+      "tooltipDisabled": "Haiku不支持1M上下文"
+    },
     "claude": {
       "sonnet46": {
-        "label": "Sonnet 4.6（1M 上下文）",
+        "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 默认推荐模型"
       },
       "opus46": {
-        "label": "Opus 4.7（1M 上下文）",
+        "label": "Opus 4.7",
         "description": "Opus 4.7 · 最新最强大的模型"
       },
       "opus46_1m": {
-        "label": "Opus 4.6（1M 上下文）",
+        "label": "Opus 4.6",
         "description": "Opus 4.6 长会话模式"
       },
       "haiku45": {


### PR DESCRIPTION
Add a toggle switch next to the model selector to enable/disable 1M context window for Claude models. The toggle only appears for Claude provider and is disabled when Haiku model is selected (Haiku does not support 1M context).

Changes:
- Add LongContextToggle component with "1M" label and tooltip
- Add helper functions for [1m] suffix handling in types.ts
- Integrate toggle state with model selection in useModelProviderState
- Persist long context setting in localStorage with model selection
- Update ModelProviderHandler context limits (base: 200k, [1m]: 1M)
- Add i18n translations for all 10 locales
- Update test cases for new context limit behavior

The SDK receives model ID with [1m] suffix when toggle is enabled, matching CLI behavior for controlling context window size.