### PR TITLE
feat(history): add session ID copy button for CLI resume

### DIFF
--- a/webview/src/components/history/HistoryView.tsx
+++ b/webview/src/components/history/HistoryView.tsx
@@ -5,6 +5,7 @@ import VirtualList from './VirtualList';
 import { extractCommandMessageContent } from '../../utils/messageUtils';
 import { sendBridgeEvent } from '../../utils/bridge';
 import { ProviderModelIcon } from '../shared/ProviderModelIcon';
+import { copyToClipboard } from '../../utils/copyUtils';
 
 // Deep search timeout (milliseconds)
 const DEEP_SEARCH_TIMEOUT_MS = 30000;
@@ -91,13 +92,19 @@ const HistoryView = ({ historyData, currentProvider, onLoadSession, onDeleteSess
   const [editingTitle, setEditingTitle] = useState(''); // Title content being edited
   const [isDeepSearching, setIsDeepSearching] = useState(false); // Deep search in-progress state
   const deepSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null); // Deep search timeout timer
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null); // Copy status timeout timer
+  const [copiedSessionId, setCopiedSessionId] = useState<string | null>(null); // Track which session ID was copied
 
-  // Clean up deep search timeout timer
+  // Clean up all timeout timers on unmount
   useEffect(() => {
     return () => {
       if (deepSearchTimeoutRef.current) {
         clearTimeout(deepSearchTimeoutRef.current);
         deepSearchTimeoutRef.current = null;
+      }
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
       }
     };
   }, []);
@@ -289,6 +296,25 @@ const HistoryView = ({ historyData, currentProvider, onLoadSession, onDeleteSess
     setEditingTitle('');
   };
 
+  // Handle copy session ID
+  const handleCopySessionId = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation(); // Prevent click event from bubbling to parent
+    const success = await copyToClipboard(sessionId);
+    if (success) {
+      // Clear previous timeout if exists (handles rapid clicking)
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
+      }
+      setCopiedSessionId(sessionId);
+      // Clear the copied status after 2 seconds
+      copyTimeoutRef.current = setTimeout(() => {
+        setCopiedSessionId(null);
+        copyTimeoutRef.current = null;
+      }, 2000);
+    }
+  };
+
   // Deep search: clear cache and reload history
   const handleDeepSearch = () => {
     if (isDeepSearching) return;
@@ -441,7 +467,22 @@ const HistoryView = ({ historyData, currentProvider, onLoadSession, onDeleteSess
         </div>
         <div className="history-item-meta">
           <span>{t('history.messageCount', { count: session.messageCount })}</span>
-          <span style={{ fontFamily: 'var(--idea-editor-font-family, monospace)', color: '#666' }}>{session.sessionId.slice(0, 8)}</span>
+          <div className="history-session-id-container">
+            <span
+              className="history-session-id"
+              title={session.sessionId}
+            >
+              {session.sessionId.slice(0, 8)}
+            </span>
+            <button
+              className={`history-copy-id-btn ${copiedSessionId === session.sessionId ? 'copied' : ''}`}
+              onClick={(e) => handleCopySessionId(e, session.sessionId)}
+              title={t('history.copySessionId')}
+              aria-label={t('history.copySessionId')}
+            >
+              <span className={`codicon ${copiedSessionId === session.sessionId ? 'codicon-check' : 'codicon-copy'}`}></span>
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -792,6 +792,8 @@
     "cancelEditButton": "Cancel",
     "titleTooLong": "Title too long (max 50 characters)",
     "titleUpdated": "Title updated",
+    "copySessionId": "Copy session ID for CLI resume",
+    "sessionIdCopied": "Session ID copied",
     "timeAgo": {
       "yearsAgo": "years ago",
       "monthsAgo": "months ago",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -618,6 +618,8 @@
     "cancelEditButton": "Cancelar",
     "titleTooLong": "Título demasiado largo (máximo 50 caracteres)",
     "titleUpdated": "Título actualizado",
+    "copySessionId": "Copiar ID de sesión para CLI resume",
+    "sessionIdCopied": "ID de sesión copiado",
     "timeAgo": {
       "yearsAgo": "hace años",
       "monthsAgo": "hace meses",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -618,6 +618,8 @@
     "cancelEditButton": "Annuler",
     "titleTooLong": "Titre trop long (maximum 50 caractères)",
     "titleUpdated": "Titre mis à jour",
+    "copySessionId": "Copier l'ID de session pour CLI resume",
+    "sessionIdCopied": "ID de session copié",
     "timeAgo": {
       "yearsAgo": "il y a des années",
       "monthsAgo": "il y a des mois",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -618,6 +618,8 @@
     "cancelEditButton": "रद्द करें",
     "titleTooLong": "शीर्षक बहुत लंबा (अधिकतम 50 वर्ण)",
     "titleUpdated": "शीर्षक अपडेट किया गया",
+    "copySessionId": "CLI resume के लिए सेशन ID कॉपी करें",
+    "sessionIdCopied": "सेशन ID कॉपी किया गया",
     "timeAgo": {
       "yearsAgo": "साल पहले",
       "monthsAgo": "महीने पहले",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -623,6 +623,8 @@
     "cancelEditButton": "キャンセル",
     "titleTooLong": "タイトルが長すぎます(最大50文字)",
     "titleUpdated": "タイトルが更新されました",
+    "copySessionId": "CLI resume用にセッションIDをコピー",
+    "sessionIdCopied": "セッションIDをコピーしました",
     "timeAgo": {
       "yearsAgo": "年前",
       "monthsAgo": "ヶ月前",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -739,6 +739,8 @@
     "cancelEditButton": "취소",
     "titleTooLong": "제목이 너무 깁니다 (최대 50자)",
     "titleUpdated": "제목 업데이트됨",
+    "copySessionId": "CLI resume용 세션 ID 복사",
+    "sessionIdCopied": "세션 ID 복사됨",
     "timeAgo": {
       "yearsAgo": "년 전",
       "monthsAgo": "개월 전",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -792,6 +792,8 @@
     "cancelEditButton": "Cancelar",
     "titleTooLong": "Título muito longo (máx. 50 caracteres)",
     "titleUpdated": "Título atualizado",
+    "copySessionId": "Copiar ID da sessão para CLI resume",
+    "sessionIdCopied": "ID da sessão copiado",
     "timeAgo": {
       "yearsAgo": "anos atrás",
       "monthsAgo": "meses atrás",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -630,6 +630,8 @@
     "cancelEditButton": "Отмена",
     "titleTooLong": "Название слишком длинное (максимум 50 символов)",
     "titleUpdated": "Название обновлено",
+    "copySessionId": "Копировать ID сессии для CLI resume",
+    "sessionIdCopied": "ID сессии скопирован",
     "timeAgo": {
       "yearsAgo_one": "{{count}} год назад",
       "yearsAgo_other": "{{count}} лет назад",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -623,6 +623,8 @@
     "cancelEditButton": "取消",
     "titleTooLong": "標題過長（最多50個字元）",
     "titleUpdated": "標題已更新",
+    "copySessionId": "複製會話ID用於CLI恢復",
+    "sessionIdCopied": "會話ID已複製",
     "timeAgo": {
       "yearsAgo": "年前",
       "monthsAgo": "個月前",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -797,6 +797,8 @@
     "cancelEditButton": "取消",
     "titleTooLong": "标题过长（最多50个字符）",
     "titleUpdated": "标题已更新",
+    "copySessionId": "复制会话ID用于CLI恢复",
+    "sessionIdCopied": "会话ID已复制",
     "timeAgo": {
       "yearsAgo": "年前",
       "monthsAgo": "个月前",

--- a/webview/src/styles/less/components/history.less
+++ b/webview/src/styles/less/components/history.less
@@ -154,6 +154,7 @@
 
     .codicon {
         font-size: 14px;
+        pointer-events: none;
     }
 }
 
@@ -175,6 +176,7 @@
 
     .codicon {
         font-size: 14px;
+        pointer-events: none;
     }
 
     /* 已收藏状态：始终显示金色星标 */
@@ -202,12 +204,15 @@
 
     .codicon {
         font-size: 14px;
+        pointer-events: none;
     }
 }
 
 .history-item:hover .history-delete-btn,
 .history-item:hover .history-export-btn,
-.history-item:hover .history-favorite-btn {
+.history-item:hover .history-favorite-btn,
+.history-item:hover .history-edit-btn,
+.history-item:hover .history-copy-id-btn {
     opacity: 1; /* 鼠标悬停时显示 */
 }
 
@@ -259,6 +264,7 @@
 
     .codicon {
         font-size: 14px;
+        pointer-events: none;
     }
 }
 
@@ -360,4 +366,64 @@
 .history-title-cancel-btn:active {
     transform: scale(0.92);
     background-color: rgba(255, 59, 48, 0.25);
+}
+
+/* Session ID container styles */
+.history-session-id-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* Session ID text styles */
+.history-session-id {
+    font-family: var(--idea-editor-font-family, monospace);
+    color: var(--text-tertiary);
+    font-size: 12px;
+}
+
+/* Copy session ID button styles */
+.history-copy-id-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0; /* Hidden by default */
+    line-height: 1;
+
+    .codicon {
+        font-size: 12px;
+        pointer-events: none;
+    }
+}
+
+.history-item:hover .history-copy-id-btn {
+    opacity: 1; /* Show on hover */
+}
+
+.history-copy-id-btn:hover {
+    background-color: rgba(10, 132, 255, 0.15);
+    color: #0a84ff;
+}
+
+.history-copy-id-btn:active {
+    transform: scale(0.92);
+    background-color: rgba(10, 132, 255, 0.25);
+}
+
+/* Copied state styles */
+.history-copy-id-btn.copied {
+    opacity: 1;
+    color: #30d158; /* Green color for success */
+}
+
+.history-copy-id-btn.copied:hover {
+    background-color: rgba(48, 209, 88, 0.15);
 }


### PR DESCRIPTION
- Add copy button next to session ID in history view
- Users can now copy full session ID to resume via CLI
- Add i18n translations for all 10 languages
- Fix cursor pointer issue on icon buttons (pointer-events: none)
- Use CSS variable for session ID color instead of hardcoded value
- Properly cleanup timeout on unmount and handle rapid clicking