### PR TITLE
fix(streaming): resolve message duplication and stream-end content loss

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -678,6 +678,11 @@ public class ClaudeMessageHandler implements MessageCallback {
             callbackHandler.notifyThinkingStatusChanged(false);
         }
 
+        // Ensure raw blocks are consistent with the accumulated content before sending the final update.
+        // Conservative sync may leave raw text/thinking blocks shorter than assistantContent
+        // if deltas arrived after the sync but before stream end.
+        ensureRawBlocksConsistency();
+
         // After streaming ends, send a final message update to ensure the message list is in sync
         callbackHandler.notifyMessageUpdate(state.getMessages());
         callbackHandler.notifyStreamEnd();
@@ -791,6 +796,76 @@ public class ClaudeMessageHandler implements MessageCallback {
 
         target.addProperty("text", existing + delta);
         return true;
+    }
+
+    /**
+     * Ensure raw text blocks are consistent with the accumulated assistantContent.
+     * Conservative sync may leave the last raw text block shorter than the actual
+     * streamed content when deltas arrive after the sync. This safety net runs
+     * before the final notifyMessageUpdate to guarantee the frontend receives complete data.
+     *
+     * <p>Since assistantContent accumulates ALL text deltas (concatenation of all text blocks),
+     * we calculate the total length of preceding text blocks and use only the tail portion
+     * of assistantContent to fix the last block. This prevents incorrectly overwriting
+     * the last block with the full concatenated content when multiple text blocks exist.</p>
+     *
+     * <p>Note: Only text blocks are fixed here because assistantContent is the
+     * authoritative accumulator for text. Thinking content has no separate
+     * accumulator — it is written directly to raw blocks — so there is no
+     * external source of truth to compare against.</p>
+     */
+    private void ensureRawBlocksConsistency() {
+        if (this.currentAssistantMessage == null || this.currentAssistantMessage.raw == null) {
+            return;
+        }
+        JsonObject raw = this.currentAssistantMessage.raw;
+        JsonObject message = raw.has("message") && raw.get("message").isJsonObject()
+                ? raw.getAsJsonObject("message") : null;
+        if (message == null || !message.has("content") || !message.get("content").isJsonArray()) {
+            return;
+        }
+        JsonArray contentArray = message.getAsJsonArray("content");
+
+        String accumulatedText = this.assistantContent.toString();
+        if (accumulatedText.isEmpty()) {
+            return;
+        }
+
+        // Find the last text block and calculate total text length from all preceding text blocks.
+        // We need this because assistantContent is the concatenation of ALL text deltas,
+        // but each text block should only contain its respective portion.
+        JsonObject lastTextBlock = null;
+        int precedingTextLength = 0;
+        for (int i = 0; i < contentArray.size(); i++) {
+            if (!contentArray.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject block = contentArray.get(i).getAsJsonObject();
+            String blockType = block.has("type") && !block.get("type").isJsonNull()
+                    ? block.get("type").getAsString() : "";
+            if ("text".equals(blockType)) {
+                lastTextBlock = block;
+                precedingTextLength += block.has("text") && !block.get("text").isJsonNull()
+                        ? block.get("text").getAsString().length() : 0;
+            }
+        }
+
+        // The last iteration added the last block's length to precedingTextLength,
+        // so subtract it to get the actual preceding length.
+        if (lastTextBlock != null) {
+            String lastBlockText = lastTextBlock.has("text") && !lastTextBlock.get("text").isJsonNull()
+                    ? lastTextBlock.get("text").getAsString() : "";
+            precedingTextLength -= lastBlockText.length();
+
+            // The expected content for the last block is the tail of assistantContent
+            // starting from the end of all preceding text blocks.
+            String expectedLastBlockText = accumulatedText.length() > precedingTextLength
+                    ? accumulatedText.substring(precedingTextLength)
+                    : "";
+            if (lastBlockText.length() < expectedLastBlockText.length()) {
+                lastTextBlock.addProperty("text", expectedLastBlockText);
+            }
+        }
     }
 
     /**

--- a/webview/src/hooks/useStreamingMessages.test.ts
+++ b/webview/src/hooks/useStreamingMessages.test.ts
@@ -382,4 +382,83 @@ describe('useStreamingMessages', () => {
     expect(thinking1Idx).toBeLessThan(textIdx);
     expect(toolIdx).toBeLessThan(thinking2Idx);
   });
+
+  it('trims suffix-prefix overlap when markdown code block fence is duplicated', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current =
+      "Here's code:\n```python\nprint('hello')\n```\n\nMore text";
+    result.current.streamingTextSegmentsRef.current = [
+      "Here's code:\n```python\nprint('hello')\n```",
+      "\n\nMore text",
+    ];
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: result.current.streamingContentRef.current,
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: "Here's code:\n```python\nprint('hello')\n```",
+            },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const content = ((patched.raw as any).message?.content ?? []) as Array<Record<string, unknown>>;
+
+    const textBlocks = content.filter((b) => b.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0]).toMatchObject({
+      type: 'text',
+      text: "Here's code:\n```python\nprint('hello')\n```\n\nMore text",
+    });
+  });
+
+  it('trims suffix-prefix overlap when code block body overlaps between blocks', () => {
+    const { result } = renderHook(() => useStreamingMessages());
+
+    // Scenario: Conservative sync pushed a backend snapshot, then subsequent
+    // deltas arrived that partially duplicated the backend content due to
+    // timing issues. The streamingTextSegments show the raw delta accumulation,
+    // while the backend raw contains the synced portion.
+    // This tests that trimDuplicateTextLikeContent correctly removes the overlap.
+    result.current.streamingTextSegmentsRef.current = [
+      "Here's code:\n```python\nprint('hello')\n```",
+      "print('hello')\n```\n\nMore text", // Overlaps with tail of segment 0
+    ];
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      // Backend snapshot content (the synced portion before overlap)
+      content: "Here's code:\n```python\nprint('hello')\n```",
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: "Here's code:\n```python\nprint('hello')\n```",
+            },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const content = ((patched.raw as any).message?.content ?? []) as Array<Record<string, unknown>>;
+
+    const textBlocks = content.filter((b) => b.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    const merged = textBlocks[0].text as string;
+    // Should not have duplicated "print('hello')\n```"
+    expect(merged).not.toMatch(/print\('hello'\)\n```\n.*print\('hello'\)\n```/);
+    // After trimming overlap, the novel content "\n\nMore text" is appended
+    expect(merged).toBe("Here's code:\n```python\nprint('hello')\n```\n\nMore text");
+  });
 });

--- a/webview/src/hooks/useStreamingMessages.ts
+++ b/webview/src/hooks/useStreamingMessages.ts
@@ -195,6 +195,19 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
         if (!remaining) {
           return '';
         }
+      } else {
+        const MIN_OVERLAP = 10;
+        const MAX_OVERLAP = 200;
+        const maxLen = Math.min(existing.length, remaining.length, MAX_OVERLAP);
+        for (let n = maxLen; n >= MIN_OVERLAP; n -= 1) {
+          if (existing.slice(-n) === remaining.slice(0, n)) {
+            remaining = remaining.slice(n);
+            break;
+          }
+        }
+        if (!remaining) {
+          return '';
+        }
       }
     }
 

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
+import type { ClaudeRawMessage } from '../../../types';
 import { sendBridgeEvent } from '../../../utils/bridge';
 import { THROTTLE_INTERVAL } from '../../useStreamingMessages';
 import { parseSequence } from '../parseSequence';
@@ -99,6 +100,14 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
 
   window.onStreamStart = () => {
     if (window.__sessionTransitioning) return;
+    // Clear any stale pending updateMessages from previous turn.
+    // This prevents onStreamEnd from using outdated snapshot data.
+    if (typeof window.__cancelPendingUpdateMessages === 'function') {
+      window.__cancelPendingUpdateMessages();
+    }
+    // Explicit null in case the rAF already executed (clearing pendingUpdateRaf)
+    // but __pendingUpdateJson was not yet cleared by the rAF callback.
+    window.__pendingUpdateJson = null;
     // Clear the previous stream-ended marker when a new turn starts
     window.__lastStreamEndedTurnId = undefined;
     window.__lastStreamEndedAt = undefined;
@@ -260,10 +269,32 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Notify backend about stream completion for tab status indicator
     sendBridgeEvent('tab_status_changed', JSON.stringify({ status: 'completed' }));
 
-    // FIX: Cancel any pending coalesced updateMessages rAF.  If onStreamEnd
-    // fires between the rAF scheduling and execution, the stale snapshot
-    // would be processed in the non-streaming path after refs are cleared,
-    // overwriting the final state with an outdated message structure.
+    // FIX: Extract backend final snapshot from pending updateMessages BEFORE cancelling rAF.
+    // The backend's final flush contains the authoritative message state (complete raw blocks).
+    // If onStreamEnd cancels the rAF without processing this snapshot, the final message may
+    // show incomplete content (e.g., last delta missing) or duplicated content in raw blocks.
+    let backendSnapshotContent: string | undefined;
+    let backendSnapshotRaw: ClaudeRawMessage | string | undefined = undefined;
+    if (typeof window.__pendingUpdateJson === 'string' && window.__pendingUpdateJson.length > 0) {
+      try {
+        const parsed = JSON.parse(window.__pendingUpdateJson) as Array<Record<string, unknown>>;
+        for (let i = parsed.length - 1; i >= 0; i--) {
+          if (parsed[i]?.type === 'assistant') {
+            const rawContent = parsed[i].content;
+            const content = typeof rawContent === 'string' ? rawContent : '';
+            if (content) {
+              backendSnapshotContent = content;
+              const rawVal = parsed[i].raw;
+              if (rawVal != null && (typeof rawVal === 'object' || typeof rawVal === 'string')) {
+                backendSnapshotRaw = rawVal as ClaudeRawMessage | string;
+              }
+            }
+            break;
+          }
+        }
+      } catch { /* ignore parse errors */ }
+    }
+
     if (typeof window.__cancelPendingUpdateMessages === 'function') {
       window.__cancelPendingUpdateMessages();
     }
@@ -288,7 +319,28 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Snapshot streaming state BEFORE clearing refs - used for post-stream merge guard
     const endedStreamingTurnId = streamingTurnIdRef.current;
     const endedStreamingMessageIndex = streamingMessageIndexRef.current;
-    const endedStreamingContent = streamingContentRef.current;
+    // Use the more complete content between streaming ref and backend snapshot
+    const endedStreamingContent = (backendSnapshotContent && backendSnapshotContent.length > streamingContentRef.current.length)
+      ? backendSnapshotContent
+      : streamingContentRef.current;
+    const endedBackendRaw = backendSnapshotRaw;
+
+    // Helper to measure total text length from raw blocks (for comparing completeness).
+    // Handles both object and JSON string formats of raw.
+    const getTextLenFromRaw = (raw: unknown): number => {
+      try {
+        let parsedRaw: unknown = raw;
+        if (typeof raw === 'string') {
+          parsedRaw = JSON.parse(raw);
+        }
+        const msg = (parsedRaw as Record<string, unknown>)?.message as Record<string, unknown> | undefined;
+        const content = msg?.content as Array<Record<string, unknown>> | undefined;
+        if (!Array.isArray(content)) return 0;
+        return content
+          .filter((b) => b?.type === 'text' && typeof b.text === 'string')
+          .reduce((sum, b) => sum + (b.text as string).length, 0);
+      } catch { return 0; }
+    };
 
     // FIX: Clear streaming refs BEFORE setMessages updater to prevent race conditions.
     //
@@ -343,9 +395,19 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
         const durationMs = (typeof turnStartedAt === 'number' && turnStartedAt > 0)
           ? Date.now() - turnStartedAt
           : undefined;
+        // Use backend raw blocks only if they are more complete than the existing raw.
+        // The backend snapshot may be from an earlier coalescer flush, so the existing
+        // raw (updated by subsequent deltas) could actually be more up-to-date.
+        let finalRaw = newMessages[idx].raw;
+        if (endedBackendRaw != null) {
+          if (getTextLenFromRaw(endedBackendRaw) >= getTextLenFromRaw(finalRaw)) {
+            finalRaw = endedBackendRaw;
+          }
+        }
         newMessages[idx] = {
           ...newMessages[idx],
           content: finalContent,
+          raw: finalRaw,
           isStreaming: false,
           __turnId: endedStreamingTurnId, // Keep __turnId for merge guard
           ...(durationMs != null ? { durationMs } : {}),


### PR DESCRIPTION
Three root causes addressed:

1. Backend (ClaudeMessageHandler): ensureRawBlocksConsistency() now correctly computes the expected tail content for the last text block by subtracting preceding text block lengths from assistantContent, preventing full-content overwrite when multiple text blocks exist.

2. Frontend (streamingCallbacks): onStreamEnd extracts the backend's final snapshot from window.__pendingUpdateJson before cancelling the pending rAF, ensuring the authoritative raw blocks and content are used for the final message. onStreamStart clears stale snapshot data from the previous turn to prevent cross-turn contamination.

3. Frontend (useStreamingMessages): trimDuplicateTextLikeContent gains suffix-prefix overlap detection (min 10 chars, max 200 chars) to handle markdown code block fence duplication (e.g. closing ```) that the existing startsWith/includes checks missed.

Also fixes type guard for backendSnapshotRaw to accept string-format raw values, and extracts getTextLenFromRaw helper outside setMessages updater for clarity.

Tests: 2 new overlap detection test cases; 35/35 frontend tests pass.