### PR TITLE
Fix message rendering and streaming content loss

### DIFF
--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -63,47 +63,40 @@ export function processMessageContent(msg, turnState) {
     for (const block of content) {
       if (block.type === 'text') {
         const currentText = block.text || '';
-        if (turnState.streamingEnabled && !turnState.hasStreamEvents && currentText.length > turnState.lastAssistantContent.length) {
+        // Send delta if content grew, regardless of hasStreamEvents
+        // This ensures conservative sync works correctly and prevents content loss
+        // (especially important for markdown tables which need complete row structures)
+        if (turnState.streamingEnabled && currentText.length > turnState.lastAssistantContent.length) {
           const delta = currentText.substring(turnState.lastAssistantContent.length);
           if (delta) {
             process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastAssistantContent = currentText;
-        } else if (turnState.streamingEnabled && turnState.hasStreamEvents) {
-          if (currentText.length > turnState.lastAssistantContent.length) {
-            turnState.lastAssistantContent = currentText;
-          }
         } else if (!turnState.streamingEnabled) {
           console.log('[CONTENT]', truncateErrorContent(currentText));
         }
       } else if (block.type === 'thinking') {
         const thinkingText = block.thinking || block.text || '';
-        if (turnState.streamingEnabled && !turnState.hasStreamEvents && thinkingText.length > turnState.lastThinkingContent.length) {
+        // Send delta if thinking grew, regardless of hasStreamEvents
+        if (turnState.streamingEnabled && thinkingText.length > turnState.lastThinkingContent.length) {
           const delta = thinkingText.substring(turnState.lastThinkingContent.length);
           if (delta) {
             process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastThinkingContent = thinkingText;
-        } else if (turnState.streamingEnabled && turnState.hasStreamEvents) {
-          if (thinkingText.length > turnState.lastThinkingContent.length) {
-            turnState.lastThinkingContent = thinkingText;
-          }
         } else if (!turnState.streamingEnabled) {
           console.log('[THINKING]', thinkingText);
         }
       }
     }
   } else if (typeof content === 'string') {
-    if (turnState.streamingEnabled && !turnState.hasStreamEvents && content.length > turnState.lastAssistantContent.length) {
+    // Send delta if content grew, regardless of hasStreamEvents
+    if (turnState.streamingEnabled && content.length > turnState.lastAssistantContent.length) {
       const delta = content.substring(turnState.lastAssistantContent.length);
       if (delta) {
         process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
       }
       turnState.lastAssistantContent = content;
-    } else if (turnState.streamingEnabled && turnState.hasStreamEvents) {
-      if (content.length > turnState.lastAssistantContent.length) {
-        turnState.lastAssistantContent = content;
-      }
     } else if (!turnState.streamingEnabled) {
       console.log('[CONTENT]', truncateErrorContent(content));
     }
@@ -122,10 +115,21 @@ export function processToolResultMessages(msg) {
 }
 
 export function shouldOutputMessage(msg, turnState) {
-  if (!(turnState.streamingEnabled && msg.type === 'assistant')) {
+  // Always output non-assistant messages
+  if (msg.type !== 'assistant') {
     return true;
   }
-  const msgContent = msg.message?.content;
-  const hasToolUse = Array.isArray(msgContent) && msgContent.some(block => block.type === 'tool_use');
-  return !!hasToolUse;
+
+  // For assistant messages:
+  // - In streaming mode: output if has tool_use OR always output for conservative sync
+  //   (needed to prevent content loss - Java layer's handleAssistantMessage performs
+  //   conservative sync which catches any missed deltas)
+  // - In non-streaming mode: always output
+  if (!turnState.streamingEnabled) {
+    return true;
+  }
+
+  // Always output assistant messages for conservative sync (prevents delta loss)
+  // The Java layer uses the full assistant JSON to fill any gaps in streaming content
+  return true;
 }

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -10,6 +10,7 @@ import {
   TaskExecutionBlock,
 } from '../toolBlocks';
 import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../utils/toolConstants';
+import { TASK_STATUS_COLORS } from '../../utils/messageUtils';
 
 /**
  * Get file icon class (consistent with AttachmentList)
@@ -216,6 +217,18 @@ export function ContentBlockRenderer({
         result={findToolResult(block.id, messageIndex)}
         toolId={block.id}
       />
+    );
+  }
+
+  // Task notification block - renders as "● summary" with status color
+  if (block.type === 'task_notification') {
+    // TypeScript narrows block to { type: 'task_notification'; icon: string; summary: string; status: string }
+    const statusColor = TASK_STATUS_COLORS[block.status] || 'text';
+    return (
+      <div className={`task-notification-block task-notification-${statusColor}`}>
+        <span className="task-notification-icon">{block.icon}</span>
+        <span className="task-notification-summary">{block.summary}</span>
+      </div>
     );
   }
 

--- a/webview/src/hooks/useMessageProcessing.ts
+++ b/webview/src/hooks/useMessageProcessing.ts
@@ -7,6 +7,9 @@ import {
   shouldShowMessage as shouldShowMessageUtil,
   getContentBlocks as getContentBlocksUtil,
   mergeConsecutiveAssistantMessages,
+  isTaskNotificationOnlyMessage,
+  hasNonHumanOrigin,
+  MESSAGE_TYPES,
 } from '../utils/messageUtils';
 import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage } from '../types';
 
@@ -103,6 +106,9 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
 
   // Merge assistant fragments before visibility filtering so hidden boundary
   // messages still separate distinct turns in the rendered timeline.
+  // Also transform non-human origin messages to have 'notification' type
+  // instead of 'user' type so they render correctly (left-aligned, no bubble).
+  // This includes task_notification, hook, agent, queue, channel, etc.
   const mergedMessages = useMemo(() => {
     const merged = mergeConsecutiveAssistantMessages(
       messages,
@@ -113,10 +119,23 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
     const visible: ClaudeMessage[] = [];
     for (const message of merged) {
       if (shouldShowMessageCached(message)) {
-        visible.push(message);
+        // Transform task_notification messages to have specific type
+        if (message.type === MESSAGE_TYPES.USER && isTaskNotificationOnlyMessage(message)) {
+          visible.push({ ...message, type: MESSAGE_TYPES.TASK_NOTIFICATION });
+        }
+        // Transform other non-human origin messages
+        // to 'notification' type for left-aligned display
+        else if (message.type === MESSAGE_TYPES.USER && hasNonHumanOrigin(message)) {
+          visible.push({ ...message, type: MESSAGE_TYPES.NOTIFICATION });
+        } else {
+          visible.push(message);
+        }
       }
     }
     return visible;
+    // Note: isTaskNotificationOnlyMessage and hasNonHumanOrigin are stable module-level
+    // pure functions imported from messageUtils — their references never change,
+    // so they don't need to be in the dependency array.
   }, [messages, shouldShowMessageCached, normalizeBlocks]);
 
   return {

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -20,6 +20,7 @@ describe('useSessionManagement', () => {
     setStreamingActive: vi.fn(),
     clearToasts: vi.fn(),
     addToast: vi.fn(),
+    setBackgroundTasks: vi.fn(),
   });
 
   beforeEach(() => {

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -64,6 +64,24 @@
     white-space: pre-wrap;
 }
 
+/* System notification messages: left-aligned, no bubble (task_notification + non-human origin) */
+.message.task_notification,
+.message.notification {
+    background-color: transparent;
+    border-left: none;
+    align-items: flex-start;
+    padding: 8px 20px;
+}
+
+.message.task_notification .message-content,
+.message.notification .message-content {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+    border: none;
+    max-width: 100%;
+}
+
 .message-header-row {
     display: flex;
     align-items: center;
@@ -1011,5 +1029,48 @@
 
     .message-duration-value {
         font-family: var(--idea-editor-font-family, monospace);
+    }
+}
+
+/* Task Notification Block - matching CLI's UserAgentNotificationMessage */
+.task-notification-block {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    font-size: 13px;
+}
+
+.task-notification-icon {
+    font-size: 12px;
+}
+
+.task-notification-summary {
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+/* Status-based colors - matching CLI behavior */
+.task-notification-success {
+    .task-notification-icon {
+        color: var(--color-success, #22c55e);
+    }
+}
+
+.task-notification-error {
+    .task-notification-icon {
+        color: var(--color-error, #ef4444);
+    }
+}
+
+.task-notification-warning {
+    .task-notification-icon {
+        color: var(--color-warning, #f59e0b);
+    }
+}
+
+.task-notification-text {
+    .task-notification-icon {
+        color: var(--text-tertiary);
     }
 }

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -1,4 +1,4 @@
-export type ClaudeRole = 'user' | 'assistant' | 'error' | string;
+export type ClaudeRole = 'user' | 'assistant' | 'error' | 'task_notification' | 'notification' | string;
 
 export type ToolInput = Record<string, unknown>;
 
@@ -7,7 +7,8 @@ export type ClaudeContentBlock =
   | { type: 'thinking'; thinking?: string; text?: string }
   | { type: 'tool_use'; id?: string; name?: string; input?: ToolInput }
   | { type: 'image'; src?: string; mediaType?: string; alt?: string }
-  | { type: 'attachment'; fileName?: string; mediaType?: string };
+  | { type: 'attachment'; fileName?: string; mediaType?: string }
+  | { type: 'task_notification'; icon: string; summary: string; status: string };
 
 export interface ToolResultBlock {
   type: 'tool_result';
@@ -23,6 +24,11 @@ export interface ClaudeRawMessage {
   content?: string | ClaudeContentOrResultBlock[];
   message?: { content?: string | ClaudeContentOrResultBlock[] };
   type?: string;
+  /** Origin indicates message source - used to filter synthetic messages */
+  origin?: { kind: string };
+  isMeta?: boolean;
+  toolUseResult?: unknown;
+  isCompactSummary?: boolean;
   [key: string]: unknown;
 }
 

--- a/webview/src/utils/copyUtils.ts
+++ b/webview/src/utils/copyUtils.ts
@@ -1,4 +1,11 @@
 import type { ClaudeMessage, ClaudeContentBlock, ClaudeRawMessage } from '../types';
+import {
+  hasCommandMessageTag,
+  formatCommandForDisplay,
+  formatCommandForResubmit,
+  hasTaskNotificationTag,
+  formatTaskNotificationForDisplay,
+} from './messageUtils';
 
 /**
  * Normalize raw message blocks to ClaudeContentBlock array
@@ -11,6 +18,8 @@ function normalizeBlocks(raw: ClaudeRawMessage | string | undefined): ClaudeCont
   }
 
   // Check raw.content
+  // Note: task_notification blocks only exist after messageUtils.normalizeBlocks processing,
+  // not in raw SDK data. Raw text blocks with <task-notification> tags are handled by formatTextForCopy.
   if (Array.isArray(raw.content)) {
     return raw.content.filter(
       (block): block is ClaudeContentBlock =>
@@ -39,6 +48,37 @@ function normalizeBlocks(raw: ClaudeRawMessage | string | undefined): ClaudeCont
 }
 
 /**
+ * Format text content for copy/export, converting XML tags to readable format
+ */
+function formatTextForCopy(text: string): string {
+  if (!text) return text;
+
+  // Format command messages: use formatCommandForResubmit for copy (uses <command-name>)
+  // which already contains the / prefix, matching CLI's textForResubmit behavior
+  if (hasCommandMessageTag(text)) {
+    const resubmitContent = formatCommandForResubmit(text);
+    if (resubmitContent) {
+      return resubmitContent;
+    }
+    // Fallback to display format if no command-name tag
+    const displayContent = formatCommandForDisplay(text);
+    if (displayContent) {
+      return displayContent;
+    }
+  }
+
+  // Format task-notification for copy
+  if (hasTaskNotificationTag(text)) {
+    const notification = formatTaskNotificationForDisplay(text);
+    if (notification) {
+      return `${notification.icon} ${notification.summary}`;
+    }
+  }
+
+  return text;
+}
+
+/**
  * Extract Markdown content from a message for copying
  * @param message - The ClaudeMessage to extract content from
  * @param includeThinking - Whether to include thinking blocks (default: false)
@@ -51,7 +91,8 @@ export function extractMarkdownContent(message: ClaudeMessage, includeThinking =
   if (rawBlocks && rawBlocks.length > 0) {
     for (const block of rawBlocks) {
       if (block.type === 'text' && block.text) {
-        parts.push(block.text);
+        // Format command/notification messages for copy
+        parts.push(formatTextForCopy(block.text));
       } else if (includeThinking && block.type === 'thinking') {
         const thinkingText = (block as { thinking?: string; text?: string }).thinking ||
                             (block as { thinking?: string; text?: string }).text;
@@ -65,7 +106,7 @@ export function extractMarkdownContent(message: ClaudeMessage, includeThinking =
 
   // Fallback to message.content if no text blocks found
   if (parts.length === 0 && message.content && message.content.trim()) {
-    parts.push(message.content);
+    parts.push(formatTextForCopy(message.content));
   }
 
   return parts.join('\n\n');

--- a/webview/src/utils/exportMarkdown.ts
+++ b/webview/src/utils/exportMarkdown.ts
@@ -1,4 +1,24 @@
-import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../types';
+import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock, ClaudeRawMessage } from '../types';
+import {
+  hasCommandMessageTag,
+  hasTaskNotificationTag,
+  formatCommandForResubmit,
+  formatTaskNotificationForDisplay,
+  HIDDEN_OUTPUT_TAGS,
+  INTERNAL_METADATA_TAGS,
+  containsAnyTag,
+} from './messageUtils';
+
+// ---------------------------------------------------------------------------
+// Type guard for text blocks in raw content arrays
+// ---------------------------------------------------------------------------
+
+/** Type guard: check if an unknown block is a text content block */
+function isTextBlock(block: unknown): block is { type: 'text'; text: string } {
+  return !!block && typeof block === 'object'
+    && (block as Record<string, unknown>).type === 'text'
+    && typeof (block as Record<string, unknown>).text === 'string';
+}
 
 /**
  * Convert a message list to JSON format
@@ -25,13 +45,14 @@ export function convertMessagesToJSON(messages: ClaudeMessage[], sessionTitle: s
 /**
  * Process a single message for export
  */
-function processMessageForExport(message: ClaudeMessage): any {
+function processMessageForExport(message: ClaudeMessage) {
   const contentBlocks = getContentBlocks(message);
 
   // Process content blocks
-  let processedBlocks: any[] = [];
+  type ProcessedBlock = { type: string } & Record<string, unknown>;
+  let processedBlocks: ProcessedBlock[] = [];
   if (contentBlocks.length > 0) {
-    processedBlocks = contentBlocks.map(block => processContentBlock(block));
+    processedBlocks = contentBlocks.map(block => processContentBlock(block)) as ProcessedBlock[];
   } else if (message.content && message.content.trim()) {
     // If no content blocks but content field exists, use content
     processedBlocks = [{ type: 'text', text: message.content }];
@@ -55,26 +76,28 @@ function processMessageForExport(message: ClaudeMessage): any {
 /**
  * Extract text content from raw data
  */
-function extractRawContent(raw: any): string | null {
+function extractRawContent(raw: ClaudeRawMessage | unknown): string | null {
   if (!raw) return null;
 
   if (typeof raw === 'string') return raw;
 
-  if (typeof raw.content === 'string') return raw.content;
+  const rawObj = raw as Record<string, unknown>;
+  if (typeof rawObj.content === 'string') return rawObj.content;
 
-  if (Array.isArray(raw.content)) {
-    return raw.content
-      .filter((block: any) => block && block.type === 'text')
-      .map((block: any) => block.text || '')
+  if (Array.isArray(rawObj.content)) {
+    return rawObj.content
+      .filter(isTextBlock)
+      .map(block => block.text || '')
       .join('\n');
   }
 
-  if (raw.message?.content) {
-    if (typeof raw.message.content === 'string') return raw.message.content;
-    if (Array.isArray(raw.message.content)) {
-      return raw.message.content
-        .filter((block: any) => block && block.type === 'text')
-        .map((block: any) => block.text || '')
+  if (rawObj.message && typeof rawObj.message === 'object') {
+    const msg = rawObj.message as Record<string, unknown>;
+    if (typeof msg.content === 'string') return msg.content;
+    if (Array.isArray(msg.content)) {
+      return msg.content
+        .filter(isTextBlock)
+        .map(block => block.text || '')
         .join('\n');
     }
   }
@@ -85,17 +108,18 @@ function extractRawContent(raw: any): string | null {
 /**
  * Process a content block
  */
-function processContentBlock(block: ClaudeContentBlock | ToolResultBlock): any {
+function processContentBlock(block: ClaudeContentBlock | ToolResultBlock) {
   if (block.type === 'text') {
     return {
       type: 'text',
       text: block.text
     };
   } else if (block.type === 'thinking') {
+    const tb = block as { type: 'thinking'; thinking?: string; text?: string };
     return {
       type: 'thinking',
-      thinking: (block as any).thinking,
-      text: (block as any).text
+      thinking: tb.thinking,
+      text: tb.text
     };
   } else if (block.type === 'tool_use') {
     return {
@@ -115,12 +139,19 @@ function processContentBlock(block: ClaudeContentBlock | ToolResultBlock): any {
       is_error: toolResult.is_error
     };
   } else if (block.type === 'image') {
-    const imageBlock = block as any;
+    const ib = block as { type: 'image'; src?: string; source?: { data?: string; media_type?: string }; mediaType?: string; alt?: string };
     return {
       type: 'image',
-      src: imageBlock.src || imageBlock.source?.data,
-      mediaType: imageBlock.mediaType || imageBlock.source?.media_type,
-      alt: imageBlock.alt
+      src: ib.src || ib.source?.data,
+      mediaType: ib.mediaType || ib.source?.media_type,
+      alt: ib.alt
+    };
+  } else if (block.type === 'task_notification') {
+    const tb = block as { type: 'task_notification'; icon?: string; summary?: string };
+    // Export task_notification as formatted text: "● summary"
+    return {
+      type: 'text',
+      text: `${tb.icon || '●'} ${tb.summary || ''}`
     };
   }
 
@@ -130,7 +161,7 @@ function processContentBlock(block: ClaudeContentBlock | ToolResultBlock): any {
 /**
  * Limit content length
  */
-function limitContentLength(content: any, maxLength: number): any {
+function limitContentLength(content: unknown, maxLength: number): unknown {
   if (typeof content === 'string') {
     if (content.length > maxLength) {
       return content.substring(0, maxLength) + '\n... (content too long, truncated)';
@@ -138,11 +169,15 @@ function limitContentLength(content: any, maxLength: number): any {
     return content;
   } else if (Array.isArray(content)) {
     return content.map(item => {
-      if (item.text && item.text.length > maxLength) {
-        return {
-          ...item,
-          text: item.text.substring(0, maxLength) + '\n... (content too long, truncated)'
-        };
+      if (item && typeof item === 'object') {
+        const objItem = item as Record<string, unknown>;
+        const text = objItem.text as string | undefined;
+        if (text && text.length > maxLength) {
+          return {
+            ...item,
+            text: text.substring(0, maxLength) + '\n... (content too long, truncated)'
+          };
+        }
       }
       return item;
     });
@@ -172,15 +207,20 @@ function formatTimestamp(timestamp: string): string {
  * Determine whether a message should be exported
  */
 function shouldExportMessage(message: ClaudeMessage): boolean {
-  // Skip special command messages
   const text = getMessageText(message);
-  if (text && (
-    text.includes('<command-name>') ||
-    text.includes('<local-command-stdout>') ||
-    text.includes('<local-command-stderr>') ||
-    text.includes('<command-message>') ||
-    text.includes('<command-args>')
-  )) {
+
+  // Allow task-notification messages - they will be formatted properly
+  if (text && hasTaskNotificationTag(text)) {
+    return true;
+  }
+
+  // Allow command messages with <command-message> - format with formatCommandForResubmit
+  if (text && hasCommandMessageTag(text)) {
+    return true;
+  }
+
+  // Skip special internal tags (but not command-message or task-notification)
+  if (text && (containsAnyTag(text, HIDDEN_OUTPUT_TAGS) || containsAnyTag(text, INTERNAL_METADATA_TAGS))) {
     return false;
   }
 
@@ -210,15 +250,15 @@ function getMessageText(message: ClaudeMessage): string {
 
   if (Array.isArray(raw.content)) {
     return raw.content
-      .filter((block: any) => block && block.type === 'text')
-      .map((block: any) => block.text ?? '')
+      .filter(isTextBlock)
+      .map(block => block.text ?? '')
       .join('\n');
   }
 
   if (raw.message?.content && Array.isArray(raw.message.content)) {
     return raw.message.content
-      .filter((block: any) => block && block.type === 'text')
-      .map((block: any) => block.text ?? '')
+      .filter(isTextBlock)
+      .map(block => block.text ?? '')
       .join('\n');
   }
 
@@ -248,52 +288,81 @@ function getContentBlocks(message: ClaudeMessage): (ClaudeContentBlock | ToolRes
 /**
  * Normalize content blocks
  */
-function normalizeBlocks(raw: any): (ClaudeContentBlock | ToolResultBlock)[] | null {
+function normalizeBlocks(raw: ClaudeRawMessage | unknown): (ClaudeContentBlock | ToolResultBlock)[] | null {
   if (!raw) {
     return null;
   }
 
-  let contentArray: any[] | null = null;
+  // Type-safe access helpers
+  const rawObj = raw as Record<string, unknown>;
+  let contentArray: unknown[] | null = null;
 
   // Handle backend ConversationMessage format
-  if (raw.message && Array.isArray(raw.message.content)) {
-    contentArray = raw.message.content;
+  if (rawObj.message && typeof rawObj.message === 'object') {
+    const msg = rawObj.message as Record<string, unknown>;
+    if (Array.isArray(msg.content)) {
+      contentArray = msg.content;
+    }
   }
   // Handle other formats
   else if (Array.isArray(raw)) {
-    contentArray = raw;
-  } else if (Array.isArray(raw.content)) {
-    contentArray = raw.content;
-  } else if (typeof raw.content === 'string' && raw.content.trim()) {
-    return [{ type: 'text', text: raw.content }];
-  } else if (raw.message && typeof raw.message.content === 'string' && raw.message.content.trim()) {
-    return [{ type: 'text', text: raw.message.content }];
+    contentArray = raw as unknown[];
+  } else if (Array.isArray(rawObj.content)) {
+    contentArray = rawObj.content;
+  } else if (typeof rawObj.content === 'string' && (rawObj.content as string).trim()) {
+    return [{ type: 'text', text: rawObj.content as string }];
+  } else if (rawObj.message && typeof rawObj.message === 'object') {
+    const msg = rawObj.message as Record<string, unknown>;
+    if (typeof msg.content === 'string' && (msg.content as string).trim()) {
+      return [{ type: 'text', text: msg.content as string }];
+    }
   }
 
   if (contentArray) {
-    return contentArray.map((block: any) => {
-      if (block.type === 'text') {
-        return { type: 'text', text: block.text };
+    return contentArray.map((block: unknown) => {
+      if (!block || typeof block !== 'object') return block;
+      const b = block as Record<string, unknown>;
+      if (b.type === 'text') {
+        let text = (b.text as string) || '';
+        // Format command messages for export using formatCommandForResubmit
+        if (hasCommandMessageTag(text)) {
+          const formatted = formatCommandForResubmit(text);
+          if (formatted) {
+            text = formatted;
+          }
+        }
+        // Format task-notification for export
+        if (hasTaskNotificationTag(text)) {
+          const notification = formatTaskNotificationForDisplay(text);
+          if (notification) {
+            text = `${notification.icon} ${notification.summary}`;
+          }
+        }
+        return { type: 'text', text };
       }
-      if (block.type === 'thinking') {
-        return { type: 'thinking', thinking: block.thinking, text: block.text };
+      if (b.type === 'thinking') {
+        return { type: 'thinking', thinking: b.thinking, text: b.text };
       }
-      if (block.type === 'tool_use') {
-        return { type: 'tool_use', id: block.id, name: block.name, input: block.input };
+      if (b.type === 'tool_use') {
+        return { type: 'tool_use', id: b.id, name: b.name, input: b.input };
       }
-      if (block.type === 'tool_result') {
+      if (b.type === 'tool_result') {
         return {
           type: 'tool_result',
-          tool_use_id: block.tool_use_id,
-          content: block.content,
-          is_error: block.is_error
+          tool_use_id: b.tool_use_id,
+          content: b.content,
+          is_error: b.is_error
         };
       }
-      if (block.type === 'image') {
-        return { type: 'image', src: block.source?.data, mediaType: block.source?.media_type };
+      if (b.type === 'image') {
+        const source = b.source as Record<string, unknown> | undefined;
+        return { type: 'image', src: source?.data, mediaType: source?.media_type };
+      }
+      if (b.type === 'task_notification') {
+        return { type: 'task_notification', icon: b.icon, summary: b.summary, status: b.status };
       }
       return block;
-    });
+    }) as (ClaudeContentBlock | ToolResultBlock)[];
   }
 
   return null;

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import type { ClaudeMessage } from '../types';
-import { getMessageKey, mergeConsecutiveAssistantMessages } from './messageUtils';
+import {
+  getMessageKey,
+  mergeConsecutiveAssistantMessages,
+  formatCommandForDisplay,
+  formatCommandForResubmit,
+  formatTaskNotificationForDisplay,
+  hasCommandMessageTag,
+  hasTaskNotificationTag,
+  isTaskNotificationOnlyMessage,
+  hasNonHumanOrigin,
+  shouldShowMessage,
+  TASK_STATUS_COLORS,
+} from './messageUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -240,3 +252,419 @@ describe('mergeConsecutiveAssistantMessages', () => {
     expect(result.filter((m) => m.type === 'assistant')).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatCommandForDisplay — CLI-aligned command message rendering
+// ---------------------------------------------------------------------------
+
+describe('formatCommandForDisplay', () => {
+  it('returns null for text without command-message tag', () => {
+    expect(formatCommandForDisplay('hello world')).toBeNull();
+    expect(formatCommandForDisplay('<command-name>/clear</command-name>')).toBeNull();
+  });
+
+  it('returns Skill format when skill-format=true', () => {
+    const text = '<command-message>opsx:ff</command-message><skill-format>true</skill-format>';
+    expect(formatCommandForDisplay(text)).toBe('Skill(opsx:ff)');
+  });
+
+  it('returns Skill format with skill-format and no args', () => {
+    const text = '<command-message>init</command-message>\n<skill-format>true</skill-format>';
+    expect(formatCommandForDisplay(text)).toBe('Skill(init)');
+  });
+
+  it('returns slash format without skill-format', () => {
+    const text = '<command-message>opsx:ff</command-message>';
+    expect(formatCommandForDisplay(text)).toBe('/opsx:ff');
+  });
+
+  it('returns slash format with args', () => {
+    const text = '<command-message>opsx:ff</command-message><command-args>hello there</command-args>';
+    expect(formatCommandForDisplay(text)).toBe('/opsx:ff hello there');
+  });
+
+  it('returns slash format without args when command-args is empty', () => {
+    const text = '<command-message>clear</command-message><command-args></command-args>';
+    expect(formatCommandForDisplay(text)).toBe('/clear');
+  });
+
+  it('handles multiline XML content', () => {
+    const text = `<command-message>opsx:ff</command-message>
+<command-args>hello world</command-args>`;
+    expect(formatCommandForDisplay(text)).toBe('/opsx:ff hello world');
+  });
+
+  it('trims whitespace from extracted content', () => {
+    const text = '<command-message>  opsx:ff  </command-message><command-args>  hello  </command-args>';
+    expect(formatCommandForDisplay(text)).toBe('/opsx:ff hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCommandForResubmit — CLI-aligned copy/resubmit behavior
+// ---------------------------------------------------------------------------
+
+describe('formatCommandForResubmit', () => {
+  it('returns null for text without command-name tag', () => {
+    expect(formatCommandForResubmit('hello world')).toBeNull();
+    expect(formatCommandForResubmit('<command-message>opsx:ff</command-message>')).toBeNull();
+  });
+
+  it('returns command-name with args', () => {
+    const text = '<command-name>/opsx:ff</command-name><command-args>hello</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/opsx:ff hello');
+  });
+
+  it('returns command-name without args', () => {
+    const text = '<command-name>/clear</command-name>';
+    expect(formatCommandForResubmit(text)).toBe('/clear');
+  });
+
+  it('command-name already contains the / prefix', () => {
+    const text = '<command-name>/review</command-name><command-args>code</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/review code');
+  });
+
+  it('handles multiline XML content', () => {
+    const text = `<command-name>/opsx:ff</command-name>
+<command-args>hello world</command-args>`;
+    expect(formatCommandForResubmit(text)).toBe('/opsx:ff hello world');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTaskNotificationForDisplay — CLI-aligned task notification rendering
+// ---------------------------------------------------------------------------
+
+describe('formatTaskNotificationForDisplay', () => {
+  it('returns null for text without summary tag', () => {
+    expect(formatTaskNotificationForDisplay('<task-notification><status>completed</status></task-notification>')).toBeNull();
+    expect(formatTaskNotificationForDisplay('hello world')).toBeNull();
+  });
+
+  it('returns ● summary with completed status', () => {
+    const text = '<task-notification><status>completed</status><summary>Review finished</summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result).toEqual({
+      icon: '●',
+      summary: 'Review finished',
+      status: 'completed',
+    });
+  });
+
+  it('returns ● summary with failed status', () => {
+    const text = '<task-notification><status>failed</status><summary>Connection error</summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result).toEqual({
+      icon: '●',
+      summary: 'Connection error',
+      status: 'failed',
+    });
+  });
+
+  it('returns ● summary with killed status', () => {
+    const text = '<task-notification><status>killed</status><summary>User cancelled</summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result).toEqual({
+      icon: '●',
+      summary: 'User cancelled',
+      status: 'killed',
+    });
+  });
+
+  it('defaults to completed status when status tag missing', () => {
+    const text = '<task-notification><summary>Task done</summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result).toEqual({
+      icon: '●',
+      summary: 'Task done',
+      status: 'completed',
+    });
+  });
+
+  it('trims whitespace from summary', () => {
+    const text = '<task-notification><status>completed</status><summary>  Task done  </summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result?.summary).toBe('Task done');
+  });
+
+  it('handles actual SDK format with task-id, result, usage tags', () => {
+    // Actual SDK format from JSONL: task-id, tool-use-id, output-file, status, summary, result, usage
+    const text = `<task-notification>
+<task-id>a31e69ffd788b2055</task-id>
+<tool-use-id>toolu_tool-62921666a9104a878d13f7aa038f05af</tool-use-id>
+<output-file>C:\\Users\\test\\output.file</output-file>
+<status>completed</status>
+<summary>Agent "分析仓库结构" completed</summary>
+<result>## 仓库分析报告\n\n详细内容...</result>
+<usage><total_tokens>19874</total_tokens><tool_uses>12</tool_uses><duration_ms>19665</duration_ms></usage>
+</task-notification>`;
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result).toEqual({
+      icon: '●',
+      summary: 'Agent "分析仓库结构" completed',
+      status: 'completed',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TASK_STATUS_COLORS — status color mapping
+// ---------------------------------------------------------------------------
+
+describe('TASK_STATUS_COLORS', () => {
+  it('maps completed to success', () => {
+    expect(TASK_STATUS_COLORS['completed']).toBe('success');
+  });
+
+  it('maps failed to error', () => {
+    expect(TASK_STATUS_COLORS['failed']).toBe('error');
+  });
+
+  it('maps killed to warning', () => {
+    expect(TASK_STATUS_COLORS['killed']).toBe('warning');
+  });
+
+  it('maps stopped to text', () => {
+    expect(TASK_STATUS_COLORS['stopped']).toBe('text');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag detection helpers
+// ---------------------------------------------------------------------------
+
+describe('hasCommandMessageTag', () => {
+  it('returns true for text with command-message tag', () => {
+    expect(hasCommandMessageTag('<command-message>test</command-message>')).toBe(true);
+  });
+
+  it('returns false for text without command-message tag', () => {
+    expect(hasCommandMessageTag('<command-name>/test</command-name>')).toBe(false);
+    expect(hasCommandMessageTag('hello world')).toBe(false);
+  });
+
+  it('returns false for empty text', () => {
+    expect(hasCommandMessageTag('')).toBe(false);
+    expect(hasCommandMessageTag(null as any)).toBe(false);
+  });
+});
+
+describe('hasTaskNotificationTag', () => {
+  it('returns true for text with task-notification tag', () => {
+    expect(hasTaskNotificationTag('<task-notification><status>completed</status></task-notification>')).toBe(true);
+  });
+
+  it('returns false for text without task-notification tag', () => {
+    expect(hasTaskNotificationTag('hello world')).toBe(false);
+  });
+
+  it('returns false for empty text', () => {
+    expect(hasTaskNotificationTag('')).toBe(false);
+    expect(hasTaskNotificationTag(null as any)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTaskNotificationOnlyMessage — detect task-notification user messages
+// ---------------------------------------------------------------------------
+
+describe('isTaskNotificationOnlyMessage', () => {
+  it('returns false for non-user messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'assistant',
+      content: '<task-notification><summary>done</summary></task-notification>',
+      timestamp: '1',
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(false);
+  });
+
+  it('returns true when message.content has task-notification tag', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '<task-notification><status>completed</status><summary>done</summary></task-notification>',
+      timestamp: '1',
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(true);
+  });
+
+  it('returns true when raw.content array has task-notification text block', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        content: [
+          { type: 'text', text: '<task-notification><summary>task done</summary></task-notification>' },
+        ],
+      },
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(true);
+  });
+
+  it('returns true when raw.message.content string has task-notification', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        message: {
+          content: '<task-notification><summary>hello</summary></task-notification>',
+        },
+      },
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(true);
+  });
+
+  it('returns true when raw.message.content array has task-notification', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        message: {
+          content: [
+            { type: 'text', text: '<task-notification><summary>hey</summary></task-notification>' },
+          ],
+        },
+      },
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(true);
+  });
+
+  it('returns false when no task-notification tag found', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hello world',
+      timestamp: '1',
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(false);
+  });
+
+  it('returns false when raw is undefined', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'normal message',
+      timestamp: '1',
+      raw: undefined,
+    };
+    expect(isTaskNotificationOnlyMessage(msg)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasNonHumanOrigin — detect synthetic messages via origin.kind
+// ---------------------------------------------------------------------------
+
+describe('hasNonHumanOrigin', () => {
+  it('returns false for non-user messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'assistant',
+      content: 'hello',
+      timestamp: '1',
+      raw: { origin: { kind: 'task-notification' } },
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(false);
+  });
+
+  it('returns true for user message with origin.kind = task-notification', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'notification',
+      timestamp: '1',
+      raw: { origin: { kind: 'task-notification' } },
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(true);
+  });
+
+  it('returns true for user message with origin.kind = hook', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hook msg',
+      timestamp: '1',
+      raw: { origin: { kind: 'hook' } },
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(true);
+  });
+
+  it('returns false for user message with origin.kind = human', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hi',
+      timestamp: '1',
+      raw: { origin: { kind: 'human' } },
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(false);
+  });
+
+  it('returns false when raw has no origin field', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hi',
+      timestamp: '1',
+      raw: { content: 'hi' },
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(false);
+  });
+
+  it('returns false when raw is undefined', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hi',
+      timestamp: '1',
+      raw: undefined,
+    };
+    expect(hasNonHumanOrigin(msg)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldShowMessage — message visibility filtering
+// ---------------------------------------------------------------------------
+
+describe('shouldShowMessage', () => {
+  const mockGetMessageText = (msg: ClaudeMessage) => msg.content || '';
+  const mockNormalizeBlocks = () => null;
+  const mockT = ((key: string) => key) as any;
+
+  it('filters toolUseResult messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'some content',
+      timestamp: '1',
+      raw: { toolUseResult: true },
+    };
+    expect(shouldShowMessage(msg, mockGetMessageText, mockNormalizeBlocks, mockT)).toBe(false);
+  });
+
+  it('filters isCompactSummary messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'assistant',
+      content: 'summary content',
+      timestamp: '1',
+      raw: { isCompactSummary: true },
+    };
+    expect(shouldShowMessage(msg, mockGetMessageText, mockNormalizeBlocks, mockT)).toBe(false);
+  });
+
+  it('does not filter messages without toolUseResult or isCompactSummary', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'normal message',
+      timestamp: '1',
+      raw: { content: 'normal message' },
+    };
+    expect(shouldShowMessage(msg, mockGetMessageText, mockNormalizeBlocks, mockT)).toBe(true);
+  });
+
+  it('filters isMeta messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'meta content',
+      timestamp: '1',
+      raw: { isMeta: true },
+    };
+    expect(shouldShowMessage(msg, mockGetMessageText, mockNormalizeBlocks, mockT)).toBe(false);
+  });
+});
+

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -16,6 +16,8 @@ export function getMessageKey(message: ClaudeMessage, index: number): string {
  * Extract content from <command-message> and <command-args> tags if present.
  * Returns the combined content: "command-message content command-args content"
  *
+ * @deprecated Use {@link formatCommandForDisplay} instead. Kept as fallback only.
+ *
  * Example:
  *   Input: "<command-message>aimax:auto</command-message>\n<command-name>/aimax:auto</command-name>\n<command-args>hello there</command-args>"
  *   Output: "aimax:auto hello there"
@@ -52,12 +54,258 @@ export function extractCommandMessageContent(text: string): string {
   return text;
 }
 
+// ---------------------------------------------------------------------------
+// Constants - avoid magic strings throughout the codebase
+// ---------------------------------------------------------------------------
+
+export const MESSAGE_TYPES = {
+  USER: 'user',
+  ASSISTANT: 'assistant',
+  TASK_NOTIFICATION: 'task_notification',
+  NOTIFICATION: 'notification',
+  ERROR: 'error',
+} as const;
+
+export const ORIGIN_KINDS = {
+  HUMAN: 'human',
+  TASK_NOTIFICATION: 'task-notification',
+  HOOK: 'hook',
+  AGENT: 'agent',
+  QUEUE: 'queue',
+  CHANNEL: 'channel',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Optimized regex patterns - single pattern instead of multiple matches
+// NOTE: These regexes assume SDK outputs tags in a fixed order
+// (command-message → command-name → command-args → skill-format).
+// If SDK changes tag order, these must be updated.
+// ---------------------------------------------------------------------------
+
+// Regex to extract command-message and related tags (supports multiline content)
+const COMMAND_TAGS_REGEX = /<command-message>([\s\S]*?)<\/command-message>(?:[\s\n]*<command-name>([\s\S]*?)<\/command-name>)?(?:[\s\n]*<command-args>([\s\S]*?)<\/command-args>)?(?:[\s\n]*<skill-format>([\s\S]*?)<\/skill-format>)?/;
+
+// Regex for resubmit format - only needs command-name and command-args (no command-message required)
+const COMMAND_NAME_REGEX = /<command-name>([\s\S]*?)<\/command-name>(?:[\s\n]*<command-args>([\s\S]*?)<\/command-args>)?/;
+
+// Regex to extract task-notification tags (supports multiline content)
+// Actual SDK format: <task-notification><task-id>...<status>...<summary>...<result>...<usage>...</task-notification>
+// We only need status and summary, so match them regardless of position
+// Two regexes: one for full format (with status), one for minimal format (only summary)
+const TASK_NOTIFICATION_REGEX_WITH_STATUS = /<task-notification>[\s\S]*?<status>([\s\S]*?)<\/status>[\s\S]*?<summary>([\s\S]*?)<\/summary>[\s\S]*?<\/task-notification>/;
+const TASK_NOTIFICATION_REGEX_NO_STATUS = /<task-notification>[\s\S]*?<summary>([\s\S]*?)<\/summary>[\s\S]*?<\/task-notification>/;
+
+// ---------------------------------------------------------------------------
+// Internal XML tags that should be hidden (not rendered as user messages)
+// ---------------------------------------------------------------------------
+
+/** Tags that represent hidden terminal output */
+export const HIDDEN_OUTPUT_TAGS = ['<local-command-stdout>', '<local-command-stderr>'] as const;
+
+/** Tags that represent internal command metadata (no <command-message>) */
+export const INTERNAL_METADATA_TAGS = ['<command-name>', '<command-args>', '<skill-format>', '<local-command-caveat>'] as const;
+
+/** All tags that should be filtered out in normalizeBlocks text entries.
+ *  Composed from INTERNAL_METADATA_TAGS + HIDDEN_OUTPUT_TAGS to stay in sync. */
+export const FILTERED_NORMALIZE_TAGS = [...INTERNAL_METADATA_TAGS, ...HIDDEN_OUTPUT_TAGS] as const;
+
+/** Check if text contains any tag from the given array */
+export function containsAnyTag(text: string, tags: readonly string[]): boolean {
+  return tags.some(tag => text.includes(tag));
+}
+
 /**
  * Check if text contains a <command-message> tag
  */
 export function hasCommandMessageTag(text: string): boolean {
   if (!text) return false;
   return text.includes('<command-message>') && text.includes('</command-message>');
+}
+
+/**
+ * Format command message for display, matching CLI's UserCommandMessage behavior.
+ * - If <skill-format>true</skill-format>: return "Skill(name)"
+ * - Otherwise: return "/name args" (prepend / to command-message)
+ *
+ * @param text - Raw text containing XML tags
+ * @returns Formatted display string, or null if no command-message tag
+ */
+export function formatCommandForDisplay(text: string): string | null {
+  if (!text) return null;
+
+  // Single regex match extracts all tags at once (performance optimization)
+  const match = COMMAND_TAGS_REGEX.exec(text);
+  if (!match?.[1]) return null;
+
+  const commandMessage = match[1].trim();
+  if (!commandMessage) return null;
+
+  const args = match[3]?.trim() ?? '';
+  const isSkillFormat = match[4]?.trim() === 'true';
+
+  if (isSkillFormat) {
+    // Skill loading message: "Skill(name)"
+    // CLI's UserCommandMessage ignores args in skill-format mode
+    return `Skill(${commandMessage})`;
+  }
+
+  // Slash command format: "/name args" (no prefix symbol for GUI)
+  return args ? `/${commandMessage} ${args}` : `/${commandMessage}`;
+}
+
+/**
+ * Format command message for copy/resubmit, matching CLI's textForResubmit behavior.
+ * Uses <command-name> tag which already contains the / prefix.
+ *
+ * @param text - Raw text containing XML tags
+ * @returns Formatted resubmit string, or null if no command-name tag
+ */
+export function formatCommandForResubmit(text: string): string | null {
+  if (!text) return null;
+
+  // Use dedicated regex that matches command-name without requiring command-message
+  const match = COMMAND_NAME_REGEX.exec(text);
+  if (!match?.[1]) return null;
+
+  const commandName = match[1].trim();
+  if (!commandName) return null;
+
+  const args = match[2]?.trim() ?? '';
+  return args ? `${commandName} ${args}` : commandName;
+}
+
+/**
+ * Check if text contains a <task-notification> tag
+ */
+export function hasTaskNotificationTag(text: string): boolean {
+  if (!text) return false;
+  return text.includes('<task-notification>');
+}
+
+// ---------------------------------------------------------------------------
+// Type guards - safer than type assertions
+// ---------------------------------------------------------------------------
+
+/**
+ * Type guard: check if raw message has valid origin field
+ */
+function hasOriginField(raw: unknown): raw is { origin: { kind: string } } {
+  if (!raw || typeof raw !== 'object') return false;
+  const r = raw as Record<string, unknown>;
+  const origin = r.origin;
+  if (!origin || typeof origin !== 'object') return false;
+  const o = origin as Record<string, unknown>;
+  return typeof o.kind === 'string';
+}
+
+/**
+ * Check if a message has non-human origin (should be rendered as system notification, not user message).
+ * CLI uses origin.kind to distinguish synthetic messages from human input.
+ */
+export function hasNonHumanOrigin(message: ClaudeMessage): boolean {
+  if (message.type !== MESSAGE_TYPES.USER) return false;
+
+  const raw = message.raw;
+  if (!hasOriginField(raw)) return false;
+
+  // If origin.kind exists and is not 'human', this is a synthetic message
+  return raw.origin.kind !== ORIGIN_KINDS.HUMAN;
+}
+
+/**
+ * Extract all text strings from a raw message's content (handles various structures).
+ * Shared helper to avoid duplicating traversal logic.
+ */
+function extractTextsFromRaw(raw: ClaudeRawMessage | string | undefined): string[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const texts: string[] = [];
+  const extractFromContent = (content: unknown) => {
+    if (typeof content === 'string') {
+      texts.push(content);
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block && typeof block === 'object') {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'text' && typeof b.text === 'string') {
+            texts.push(b.text);
+          }
+        }
+      }
+    }
+  };
+  const rawObj = raw as Record<string, unknown>;
+  extractFromContent(rawObj.content);
+  if (rawObj.message && typeof rawObj.message === 'object') {
+    extractFromContent((rawObj.message as Record<string, unknown>).content);
+  }
+  return texts;
+}
+
+/**
+ * Check if a message is a task_notification only message (should be rendered as system notification, not user message).
+ * This is used to change message type from 'user' to 'task_notification' for proper rendering.
+ */
+export function isTaskNotificationOnlyMessage(message: ClaudeMessage): boolean {
+  if (message.type !== 'user') return false;
+
+  // Check raw content structures for task-notification tag
+  const rawTexts = extractTextsFromRaw(message.raw);
+  if (rawTexts.some(hasTaskNotificationTag)) return true;
+
+  // Fallback: check message.content (may differ from raw when set independently)
+  return typeof message.content === 'string' && hasTaskNotificationTag(message.content);
+}
+
+/**
+ * Task notification status color mapping, matching CLI behavior.
+ */
+export const TASK_STATUS_COLORS: Record<string, string> = {
+  completed: 'success',
+  failed: 'error',
+  killed: 'warning',
+  stopped: 'text',
+};
+
+/**
+ * Format task-notification for display, matching CLI's UserAgentNotificationMessage behavior.
+ * Returns "● summary" with status-based color (no status text prefix).
+ *
+ * @param text - Raw text containing <task-notification> tags
+ * @returns Object with icon, summary, and status, or null if no summary
+ */
+export function formatTaskNotificationForDisplay(
+  text: string
+): { icon: string; summary: string; status: string } | null {
+  if (!text) return null;
+
+  // Try full format first (with status)
+  const matchWithStatus = TASK_NOTIFICATION_REGEX_WITH_STATUS.exec(text);
+  if (matchWithStatus?.[2]) {
+    const summary = matchWithStatus[2].trim();
+    if (!summary) return null;
+    const status = matchWithStatus[1]?.trim() ?? 'completed';
+    return { icon: '●', summary, status };
+  }
+
+  // Fallback: minimal format (only summary)
+  const matchNoStatus = TASK_NOTIFICATION_REGEX_NO_STATUS.exec(text);
+  if (matchNoStatus?.[1]) {
+    const summary = matchNoStatus[1].trim();
+    if (!summary) return null;
+    return { icon: '●', summary, status: 'completed' };
+  }
+
+  return null;
+}
+
+/**
+ * Create a task_notification content block from raw text.
+ * Shared helper to avoid duplicating creation logic across normalizeBlocks/getContentBlocks.
+ */
+function createTaskNotificationBlock(text: string): ClaudeContentBlock | null {
+  const n = formatTaskNotificationForDisplay(text);
+  if (!n) return null;
+  return { type: 'task_notification' as const, icon: n.icon, summary: n.summary, status: n.status };
 }
 
 // Performance optimization constants
@@ -98,6 +346,32 @@ export function normalizeBlocks(
         if (rawText.trim() === '(no content)') {
           return;
         }
+
+        // Check for XML tags and format accordingly
+        if (hasTaskNotificationTag(rawText)) {
+          const block = createTaskNotificationBlock(rawText);
+          if (block) {
+            blocks.push(block);
+            return;
+          }
+        }
+
+        if (hasCommandMessageTag(rawText)) {
+          const displayContent = formatCommandForDisplay(rawText);
+          if (displayContent) {
+            blocks.push({
+              type: 'text',
+              text: localizeMessage(displayContent),
+            });
+            return;
+          }
+        }
+
+        // Filter out messages that only contain command tags without command-message
+        if (containsAnyTag(rawText, FILTERED_NORMALIZE_TAGS)) {
+          return;
+        }
+
         blocks.push({
           type: 'text',
           text: localizeMessage(rawText),
@@ -164,16 +438,26 @@ export function normalizeBlocks(
       return null;
     }
     if (typeof content === 'string') {
-      // If has <command-message>, extract and show content
+      // Handle <task-notification> messages - create special block type
+      if (hasTaskNotificationTag(content)) {
+        const block = createTaskNotificationBlock(content);
+        if (block) return [block];
+        return null;
+      }
+
+      // If has <command-message>, format for display
       if (hasCommandMessageTag(content)) {
+        const displayContent = formatCommandForDisplay(content);
+        if (displayContent) {
+          return [{ type: 'text' as const, text: localizeMessage(displayContent) }];
+        }
+        // Fallback to old extraction if formatCommandForDisplay returned null
         const processedContent = extractCommandMessageContent(content);
         return [{ type: 'text' as const, text: localizeMessage(processedContent) }];
       }
 
-      // Filter empty strings and command messages (without <command-message>)
-      if (!content.trim() ||
-          content.includes('<command-name>') ||
-          content.includes('<local-command-stdout>')) {
+      // Filter empty strings and command tags (without <command-message>)
+      if (!content.trim() || containsAnyTag(content, FILTERED_NORMALIZE_TAGS)) {
         return null;
       }
       return [{ type: 'text' as const, text: localizeMessage(content) }];
@@ -242,9 +526,23 @@ export function getMessageText(
   // Apply localization
   let result = localizeMessage(text);
 
-  // Extract <command-message> content if present
+  // Format <command-message> content using formatCommandForDisplay
   if (hasCommandMessageTag(result)) {
-    result = extractCommandMessageContent(result);
+    const displayContent = formatCommandForDisplay(result);
+    if (displayContent) {
+      result = displayContent;
+    } else {
+      // Fallback to old extraction
+      result = extractCommandMessageContent(result);
+    }
+  }
+
+  // Format <task-notification> for copy/resubmit purposes
+  if (hasTaskNotificationTag(result)) {
+    const notification = formatTaskNotificationForDisplay(result);
+    if (notification) {
+      result = `${notification.icon} ${notification.summary}`;
+    }
   }
 
   return result;
@@ -260,8 +558,23 @@ export function shouldShowMessage(
   t: TFunction
 ): boolean {
   // Filter isMeta messages (like "Caveat: The messages below were generated...")
+  // CLI: isMeta messages are hidden in normal transcript (except channel messages)
   if (message.raw && typeof message.raw === 'object' && 'isMeta' in message.raw && message.raw.isMeta === true) {
     return false;
+  }
+
+  // Note: origin.kind filtering is ONLY for title extraction (extractTitleText, sessionTitle),
+  // NOT for hiding messages in the main chat. CLI displays these messages with different formats.
+  // See CLI's wrapCommandText() and isVisibleInTranscript() functions.
+
+  // Filter toolUseResult and isCompactSummary messages (CLI filters these in extractTitleText)
+  if (message.raw && typeof message.raw === 'object') {
+    if ('toolUseResult' in message.raw && message.raw.toolUseResult) {
+      return false;
+    }
+    if ('isCompactSummary' in message.raw && message.raw.isCompactSummary) {
+      return false;
+    }
   }
 
   // Filter command messages (containing <command-name> or <local-command-stdout> tags)
@@ -294,26 +607,36 @@ export function shouldShowMessage(
 
   const rawText = getRawTextContent();
 
+  // CLI renders these messages with specific components:
+  // - <command-message> → UserCommandMessage (skill/slash command)
+  // - <local-command-stdout/stderr> → UserLocalCommandOutputMessage
+  // - <task-notification> → UserAgentNotificationMessage
+  // - Plain text (like "Unknown skill: xxx") → UserPromptMessage (displayed with ❯ prefix)
+  // So we should NOT filter these messages, just handle their rendering.
+
   // If message has <command-message>, allow it to be shown
-  // (the content will be extracted by extractCommandMessageContent)
+  // (the content will be extracted by formatCommandForDisplay)
   if (rawText && hasCommandMessageTag(rawText)) {
-    // Only filter if it has stdout/stderr output (which should be hidden)
-    const hasOutputTags =
-      rawText.includes('<local-command-stdout>') ||
-      rawText.includes('<local-command-stderr>');
-    if (!hasOutputTags) {
-      return true;
-    }
+    return true;
   }
 
-  // Filter messages with command tags but no <command-message>
-  if (rawText && (
-    rawText.includes('<command-name>') ||
-    rawText.includes('<local-command-stdout>') ||
-    rawText.includes('<local-command-stderr>') ||
-    rawText.includes('<command-args>')
-  )) {
+  // Messages with <local-command-stdout> or <local-command-stderr> should be shown
+  // CLI renders them with UserLocalCommandOutputMessage component
+  // But for GUI, we filter these as they are internal terminal output
+  if (rawText && containsAnyTag(rawText, HIDDEN_OUTPUT_TAGS)) {
     return false;
+  }
+
+  // Filter messages with command tags (internal metadata, not user input)
+  // BUT keep "Unknown skill: xxx" messages which are plain text user-visible messages
+  if (rawText && containsAnyTag(rawText, INTERNAL_METADATA_TAGS)) {
+    return false;
+  }
+
+  // Task-notification messages are always shown — normalizeBlocks converts them
+  // to task_notification blocks, no need to re-parse here (performance optimization).
+  if (rawText && hasTaskNotificationTag(rawText)) {
+    return true;
   }
 
   const text = getMessageTextFn(message);
@@ -336,6 +659,9 @@ export function shouldShowMessage(
         if (block.type === 'text') {
           return block.text && block.text.trim().length > 0;
         }
+        if (block.type === 'task_notification') {
+          return block.summary && block.summary.trim().length > 0;
+        }
         // Images, tool_use and other block types should be shown
         return true;
       });
@@ -356,16 +682,37 @@ export function getContentBlocks(
 ): ClaudeContentBlock[] {
   const rawBlocks = normalizeBlocksFn(message.raw);
   if (rawBlocks && rawBlocks.length > 0) {
+    // Don't add message.content if we have task_notification blocks
+    // (those are formatted from the raw XML content).
+    // Note: command-message text blocks are already formatted by normalizeBlocks
+    // (e.g., "/opsx:ff hello") and no longer contain raw XML tags.
+    const hasSpecialBlock = rawBlocks.some((block) => block.type === 'task_notification');
+    if (hasSpecialBlock) {
+      return rawBlocks;
+    }
     // Streaming/tool scenario: if raw doesn't have text but message.content has text, still need to show text
     const hasTextBlock = rawBlocks.some(
-      (block) => block.type === 'text' && typeof (block as any).text === 'string' && String((block as any).text).trim().length > 0,
+      (block) => block.type === 'text' && typeof block.text === 'string' && String(block.text).trim().length > 0,
     );
     if (!hasTextBlock && message.content && message.content.trim()) {
       return [...rawBlocks, { type: 'text', text: localizeMessage(message.content) }];
     }
     return rawBlocks;
   }
+  // If no raw blocks, check if content needs special handling
   if (message.content && message.content.trim()) {
+    // Handle task-notification in message.content directly
+    if (hasTaskNotificationTag(message.content)) {
+      const block = createTaskNotificationBlock(message.content);
+      if (block) return [block];
+    }
+    // Handle command-message in message.content directly
+    if (hasCommandMessageTag(message.content)) {
+      const displayContent = formatCommandForDisplay(message.content);
+      if (displayContent) {
+        return [{ type: 'text' as const, text: localizeMessage(displayContent) }];
+      }
+    }
     return [{ type: 'text', text: localizeMessage(message.content) }];
   }
   // If no content at all, return empty array instead of showing "(empty message)"


### PR DESCRIPTION
### Summary

This PR contains two bug fixes that align GUI message rendering with CLI behavior and prevent streaming content loss:

1. **XML tag rendering alignment** - Format XML protocol tags (command-message, task-notification) to match CLI display behavior
2. **Streaming content preservation** - Fix content loss during streaming by always sending deltas and assistant messages

### Changes

#### 1. fix(message): align XML tag rendering with CLI behavior

**Problem**: XML protocol tags from SDK CLI were displayed as raw XML text instead of user-friendly format.

**Solution**:
- Format `<command-message>` as `Skill(name)` when `<skill-format>true</skill-format>`, or `/command args` otherwise
- Format `<task-notification>` as `● summary` with status-based color (green/red/yellow)
- Transform task_notification/notification messages to render left-aligned (no user bubble styling)
- Fix `TASK_NOTIFICATION_REGEX` to match actual SDK format (includes `<task-id>`, `<result>`, `<usage>` tags)

**Type safety improvements**:
- Remove all `any` types from `exportMarkdown.ts`
- Add explicit type checking in `ContentBlockRenderer.tsx` for task_notification blocks
- Add type guards for origin field validation

**Files changed**:
- `messageUtils.ts`: New formatting functions, constants, type guards
- `useMessageProcessing.ts`: Message type transformation for rendering
- `ContentBlockRenderer.tsx`: task_notification block rendering
- `message.less`: CSS for left-aligned notification styling
- `copyUtils.ts`, `exportMarkdown.ts`: Copy/export formatting

#### 2. fix(streaming): prevent content loss by always sending deltas

**Problem**: Markdown tables and other structured content rendered incompletely when stream_event messages were received.

**Root cause**: When `hasStreamEvents=true`, the code only updated internal refs but didn't send `[CONTENT_DELTA]` tags, causing gaps that conservative sync couldn't fill.

**Solution**:
- Always send deltas when content grows (regardless of `hasStreamEvents` flag)
- Always output assistant messages so Java's `handleAssistantMessage` can perform conservative sync

**Files changed**:
- `ai-bridge/services/claude/stream-event-processor.js`: Delta and assistant message handling
