### PR TITLE
fix: resolve race condition between onStreamEnd and updateMessages

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -1,12 +1,12 @@
 package com.github.claudecodegui.session;
 
-import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.handler.PermissionHandler;
 import com.github.claudecodegui.permission.PermissionRequest;
 import com.github.claudecodegui.util.JsUtils;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.util.Alarm;
 
 import java.util.List;
 import java.util.function.BooleanSupplier;
@@ -36,7 +36,10 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     private final Runnable streamEndCallback;
     private final StreamDeltaThrottler contentDeltaThrottler;
     private final StreamDeltaThrottler thinkingDeltaThrottler;
+    private final Alarm streamEndFallbackAlarm;
     private volatile boolean active = true;
+    /** Guards against duplicate onStreamEnd delivery from dual-path dispatch. */
+    private volatile boolean streamEndSignalSent = false;
 
     public SessionCallbackAdapter(
             StreamMessageCoalescer streamCoalescer,
@@ -66,12 +69,14 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
                     }
                 }
         );
+        this.streamEndFallbackAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD);
     }
 
     public void deactivate() {
         active = false;
         contentDeltaThrottler.dispose();
         thinkingDeltaThrottler.dispose();
+        streamEndFallbackAlarm.cancelAllRequests();
     }
 
     private boolean isInactive() {
@@ -209,6 +214,9 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
+        // Cancel any stale fallback alarm from the previous turn to prevent
+        // it from firing during the new turn's streaming phase.
+        streamEndFallbackAlarm.cancelAllRequests();
         contentDeltaThrottler.reset();
         thinkingDeltaThrottler.reset();
         streamCoalescer.onStreamStart();
@@ -227,6 +235,12 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
+        // Reset the signal guard so this turn's dual-path dispatch can proceed.
+        // Thread-safety: this runs on the process reader thread; the callbacks that
+        // read/write streamEndSignalSent all run on EDT (via invokeLater or Alarm).
+        // The reset happens-before flush() schedules any callbacks, so no race exists.
+        streamEndSignalSent = false;
+
         // Each step is wrapped in safeRun so that a failure in one step
         // (e.g., flushNow throwing due to a disposed throttler, or JCEF
         // rejecting a large payload) does not prevent the critical
@@ -235,28 +249,61 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         safeRun("thinkingDeltaThrottler.flushNow", thinkingDeltaThrottler::flushNow);
         safeRun("streamCoalescer.onStreamEnd", streamCoalescer::onStreamEnd);
 
-        // Flush pending messages first (fire-and-forget — do NOT nest onStreamEnd
-        // inside the flush callback).  Previously the JS onStreamEnd signal was
-        // chained inside flush's 3-layer async pipeline:
-        //   flush → executeOnPooledThread → invokeLater(1) → callback → callJavaScript → invokeLater(2)
-        // Any failure in that chain silently swallowed the signal, leaving the
-        // frontend permanently stuck in streaming state.
-        streamCoalescer.flush(null);
+        // ── Dual-path onStreamEnd delivery ──
+        //
+        // Primary path: chain onStreamEnd inside the flush callback. The callback
+        // runs on the EDT *after* the updateMessages JS call has been dispatched,
+        // guaranteeing the frontend receives the final message snapshot before the
+        // stream-end signal.
+        //
+        // Fallback path: an independent Alarm fires after 300ms. This covers the
+        // scenario where the flush's 3-layer async pipeline fails silently (JCEF
+        // large payload rejection, disposed browser, JSON serialization OOM).
+        //
+        // The frontend's onStreamEnd is idempotent (per-turn guard), so receiving
+        // both signals is harmless — only the first takes effect.
 
-        // Send onStreamEnd independently via a single invokeLater.
-        // This guarantees the signal reaches the frontend even if the flush
-        // payload is rejected by JCEF (large payload, disposed browser, etc.).
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
+        // Primary: ordered delivery via flush callback
+        streamCoalescer.flush(sequence -> {
+            if (streamEndSignalSent) {
                 return;
             }
-            safeRun("callJavaScript(onStreamEnd)", () -> jsTarget.callJavaScript("onStreamEnd"));
-            safeRun("callJavaScript(showLoading, false)", () -> jsTarget.callJavaScript("showLoading", "false"));
-            if (streamEndCallback != null) {
-                safeRun("streamEndCallback", streamEndCallback);
-            }
-            LOG.debug("Stream ended - notified frontend independently of flush");
+            streamEndSignalSent = true;
+            streamEndFallbackAlarm.cancelAllRequests();
+            sendStreamEndToFrontend(sequence);
         });
+
+        // Fallback: independent delivery after timeout
+        streamEndFallbackAlarm.cancelAllRequests();
+        streamEndFallbackAlarm.addRequest(() -> {
+            if (streamEndSignalSent || isInactive()) {
+                return;
+            }
+            streamEndSignalSent = true;
+            LOG.warn("Stream end signal delivered via fallback (primary flush callback did not fire within 300ms)");
+            sendStreamEndToFrontend(-1);
+        }, 300);
+    }
+
+    /**
+     * Send the onStreamEnd signal and associated cleanup to the frontend.
+     * Called from either the primary (flush callback) or fallback (Alarm) path.
+     *
+     * @param sequence the flush sequence number, or -1 if fired from fallback
+     */
+    private void sendStreamEndToFrontend(long sequence) {
+        if (isInactive()) {
+            LOG.debug("Skipping sendStreamEndToFrontend — adapter deactivated (sequence=" + sequence + ")");
+            return;
+        }
+        safeRun("callJavaScript(onStreamEnd)", () ->
+                jsTarget.callJavaScript("onStreamEnd", String.valueOf(sequence)));
+        safeRun("callJavaScript(showLoading, false)", () ->
+                jsTarget.callJavaScript("showLoading", "false"));
+        if (streamEndCallback != null) {
+            safeRun("streamEndCallback", streamEndCallback);
+        }
+        LOG.debug("Stream ended - notified frontend (sequence=" + sequence + ")");
     }
 
     private static void safeRun(String label, Runnable action) {
@@ -313,5 +360,10 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
      */
     public void dispose() {
         deactivate();
+        try {
+            streamEndFallbackAlarm.dispose();
+        } catch (Exception e) {
+            LOG.warn("Failed to dispose streamEndFallbackAlarm: " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
@@ -1,0 +1,175 @@
+package com.github.claudecodegui.session;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongConsumer;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the dual-path onStreamEnd delivery mechanism.
+ *
+ * <p>The actual SessionCallbackAdapter depends on IntelliJ's Alarm and
+ * ApplicationManager, so these tests verify the core ordering/idempotency
+ * contract using a simulated flush callback + fallback sequence.
+ */
+public class SessionCallbackAdapterStreamEndTest {
+
+    /**
+     * Records callJavaScript invocations for assertion.
+     */
+    private static final class RecordingJsTarget implements SessionCallbackAdapter.JsTarget {
+        final List<String> calls = new ArrayList<>();
+
+        @Override
+        public void callJavaScript(String functionName, String... args) {
+            StringBuilder sb = new StringBuilder(functionName);
+            for (String arg : args) {
+                sb.append(':').append(arg);
+            }
+            calls.add(sb.toString());
+        }
+    }
+
+    /**
+     * Simulates the dual-path dispatch logic extracted from onStreamEnd().
+     * This mirrors the actual implementation's control flow without needing
+     * IntelliJ Alarm/invokeLater.
+     */
+    private static final class DualPathSimulator {
+        private volatile boolean streamEndSignalSent = false;
+        private final RecordingJsTarget jsTarget;
+
+        DualPathSimulator(RecordingJsTarget jsTarget) {
+            this.jsTarget = jsTarget;
+        }
+
+        /** Simulate the flush callback path (primary). */
+        void simulateFlushCallback(long sequence) {
+            if (streamEndSignalSent) return;
+            streamEndSignalSent = true;
+            jsTarget.callJavaScript("onStreamEnd", String.valueOf(sequence));
+            jsTarget.callJavaScript("showLoading", "false");
+        }
+
+        /** Simulate the fallback alarm path. */
+        void simulateFallback() {
+            if (streamEndSignalSent) return;
+            streamEndSignalSent = true;
+            jsTarget.callJavaScript("onStreamEnd", String.valueOf(-1));
+            jsTarget.callJavaScript("showLoading", "false");
+        }
+
+        /** Reset for a new onStreamEnd call. */
+        void reset() {
+            streamEndSignalSent = false;
+        }
+
+        boolean isStreamEndSent() {
+            return streamEndSignalSent;
+        }
+    }
+
+    @Test
+    public void primaryPathSendsStreamEndWithSequence() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+
+        sim.reset();
+        sim.simulateFlushCallback(42);
+
+        assertTrue(sim.isStreamEndSent());
+        assertEquals(2, jsTarget.calls.size());
+        assertEquals("onStreamEnd:42", jsTarget.calls.get(0));
+        assertEquals("showLoading:false", jsTarget.calls.get(1));
+    }
+
+    @Test
+    public void fallbackPathSendsStreamEndWithNegativeSequence() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+
+        sim.reset();
+        sim.simulateFallback();
+
+        assertTrue(sim.isStreamEndSent());
+        assertEquals(2, jsTarget.calls.size());
+        assertEquals("onStreamEnd:-1", jsTarget.calls.get(0));
+        assertEquals("showLoading:false", jsTarget.calls.get(1));
+    }
+
+    @Test
+    public void primaryPathBlocksFallback() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+
+        sim.reset();
+        // Primary fires first
+        sim.simulateFlushCallback(42);
+        // Fallback fires after — should be no-op
+        sim.simulateFallback();
+
+        assertEquals(2, jsTarget.calls.size()); // Only primary's calls
+        assertEquals("onStreamEnd:42", jsTarget.calls.get(0));
+    }
+
+    @Test
+    public void fallbackBlocksPrimary() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+
+        sim.reset();
+        // Fallback fires first (primary flush failed)
+        sim.simulateFallback();
+        // Primary fires late — should be no-op
+        sim.simulateFlushCallback(42);
+
+        assertEquals(2, jsTarget.calls.size()); // Only fallback's calls
+        assertEquals("onStreamEnd:-1", jsTarget.calls.get(0));
+    }
+
+    @Test
+    public void resetAllowsNextTurn() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+
+        // First turn
+        sim.reset();
+        sim.simulateFlushCallback(10);
+        assertEquals(2, jsTarget.calls.size());
+
+        // Second turn — reset allows new delivery
+        sim.reset();
+        assertFalse(sim.isStreamEndSent());
+        sim.simulateFlushCallback(20);
+        assertEquals(4, jsTarget.calls.size());
+        assertEquals("onStreamEnd:20", jsTarget.calls.get(2));
+    }
+
+    /**
+     * Verify the flush LongConsumer callback contract:
+     * when StreamMessageCoalescer.flush() invokes the callback with a
+     * sequence number, the onStreamEnd signal uses that sequence.
+     */
+    @Test
+    public void flushCallbackPassesSequenceToOnStreamEnd() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+
+        // Simulate what happens when flush(callback) is called:
+        // The callback receives the sequence from the coalescer.
+        final long[] capturedSequence = {-999};
+        LongConsumer flushCallback = seq -> {
+            capturedSequence[0] = seq;
+            jsTarget.callJavaScript("onStreamEnd", String.valueOf(seq));
+        };
+
+        flushCallback.accept(77);
+
+        assertEquals(77, capturedSequence[0]);
+        assertEquals(1, jsTarget.calls.size());
+        assertEquals("onStreamEnd:77", jsTarget.calls.get(0));
+    }
+}
+

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -593,9 +593,19 @@ interface Window {
    * Used with __lastStreamEndedTurnId to implement a time-based cleanup.
    * @default undefined (no stream end recorded)
    */
-  __lastStreamEndedAt?: number;
+   __lastStreamEndedAt?: number;
 
-  /**
+   /**
+    * Turn ID for which onStreamEnd has already been processed.
+    * Used as an idempotency guard: when dual-path delivery sends onStreamEnd
+    * twice (primary via flush callback + fallback via Alarm), only the first
+    * arrival takes effect; the second is a no-op.
+    * Cleared in onStreamStart to allow the next turn.
+    * @default undefined (no processed turn)
+    */
+   __streamEndProcessedTurnId?: number;
+
+   /**
    * Timestamp when the current streaming turn started.
    * Used to calculate durationMs on the assistant message when the stream ends.
    */

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -504,4 +504,58 @@ describe('useWindowCallbacks integration', () => {
     });
     expect(nextMessages[0].__turnId).toBe(7);
   });
+
+  // ===== onStreamEnd idempotency (dual-path delivery) =====
+
+  describe('onStreamEnd idempotency', () => {
+    it('second onStreamEnd for same turn is ignored', () => {
+      const opts = createOptions();
+      // Simulate streaming state
+      opts.streamingTurnIdRef.current = 5;
+      opts.isStreamingRef.current = true;
+      opts.streamingMessageIndexRef.current = 0;
+      opts.turnIdCounterRef.current = 5;
+
+      renderHook(() => useWindowCallbacks(opts));
+
+      // Simulate onStreamStart to set up streaming state
+      act(() => {
+        (window as any).onStreamStart();
+      });
+
+      const turnId = opts.streamingTurnIdRef.current;
+
+      // First onStreamEnd — should process
+      act(() => {
+        (window as any).onStreamEnd('10');
+      });
+      expect(window.__streamEndProcessedTurnId).toBe(turnId);
+
+      // Record call count after first onStreamEnd
+      const callsAfterFirstEnd = (opts.setStreamingActive as any).mock.calls.length;
+
+      // Second onStreamEnd with same turn — should be no-op
+      act(() => {
+        (window as any).onStreamEnd('10');
+      });
+
+      // setStreamingActive should not have been called again (idempotency)
+      expect((opts.setStreamingActive as any).mock.calls.length).toBe(callsAfterFirstEnd);
+    });
+
+    it('onStreamStart clears __streamEndProcessedTurnId for next turn', () => {
+      const opts = createOptions();
+      renderHook(() => useWindowCallbacks(opts));
+
+      // Simulate a completed turn
+      window.__streamEndProcessedTurnId = 3;
+
+      // New turn starts
+      act(() => {
+        (window as any).onStreamStart();
+      });
+
+      expect(window.__streamEndProcessedTurnId).toBeUndefined();
+    });
+  });
 });

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -111,6 +111,8 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Clear the previous stream-ended marker when a new turn starts
     window.__lastStreamEndedTurnId = undefined;
     window.__lastStreamEndedAt = undefined;
+    // Clear idempotency guard for the new turn
+    window.__streamEndProcessedTurnId = undefined;
     // Record turn start time for duration calculation in onStreamEnd
     window.__turnStartedAt = Date.now();
     streamingContentRef.current = '';
@@ -261,9 +263,31 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
 
   window.onStreamEnd = (sequence?: string | number) => {
     if (window.__sessionTransitioning) return;
+
+    // Idempotency guard: dual-path delivery (primary via flush callback +
+    // fallback via Alarm) may send onStreamEnd twice for the same turn.
+    // Only the first arrival takes effect; the second is a no-op.
+    //
+    // After the first onStreamEnd processes, streamingTurnIdRef is cleared to -1
+    // and isStreamingRef is set to false. The second arrival sees these cleared
+    // refs and should bail out. We check both conditions:
+    // 1. If the current turn ID was already processed (before refs were cleared)
+    // 2. If streaming is already inactive (refs were already cleared by first call)
+    const currentTurnId = streamingTurnIdRef.current;
+    if (currentTurnId > 0 && window.__streamEndProcessedTurnId === currentTurnId) {
+      return;
+    }
+    if (!isStreamingRef.current && currentTurnId <= 0) {
+      // Streaming refs already cleared by a previous onStreamEnd — nothing to do
+      return;
+    }
+
     clearStallWatchdog();
     const parsedSequence = parseSequence(sequence);
-    if (parsedSequence != null) {
+    // Only update minAcceptedUpdateSequence for valid positive sequences.
+    // The fallback path sends sequence=-1 which means "no sequence info" —
+    // it should not participate in sequence tracking.
+    if (parsedSequence != null && parsedSequence >= 0) {
       window.__minAcceptedUpdateSequence = Math.max(window.__minAcceptedUpdateSequence ?? 0, parsedSequence);
     }
     // Notify backend about stream completion for tab status indicator
@@ -452,6 +476,9 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     setLoading(false);
     setLoadingStartTime(null);
     setIsThinking(false);
+
+    // Mark this turn as processed — idempotency guard for dual-path delivery
+    window.__streamEndProcessedTurnId = endedStreamingTurnId;
   };
 
   // Streaming heartbeat — lightweight signal from backend during tool execution

--- a/webview/src/hooks/windowCallbacks/sessionTransition.ts
+++ b/webview/src/hooks/windowCallbacks/sessionTransition.ts
@@ -62,6 +62,8 @@ export const buildResetTransientUiState = (opts: ResetTransientUiStateOptions) =
     // increasing across sessions so that stale messages from an old session can never
     // collide with a new session's turn IDs (and React keys like "turn-N" stay unique).
     opts.streamingTurnIdRef.current = -1;
+    // Clear stream-end idempotency guard to avoid stale state across sessions.
+    window.__streamEndProcessedTurnId = undefined;
     if (opts.contentUpdateTimeoutRef.current) {
       clearTimeout(opts.contentUpdateTimeoutRef.current);
       opts.contentUpdateTimeoutRef.current = null;


### PR DESCRIPTION
The onStreamEnd signal could arrive at the frontend before the final updateMessages snapshot was delivered, causing the last assistant message to be lost or rendered incomplete.

Solution: dual-path delivery for onStreamEnd signal.

Backend (SessionCallbackAdapter):
- Primary path: chain onStreamEnd inside flush afterSendOnEdt callback, ensuring it is ordered after the final updateMessages snapshot
- Fallback path: 300ms class-level Alarm guarantees delivery even if the primary path fails (flush error, disposed target, etc.)
- Volatile streamEndSignalSent flag ensures mutual exclusion between the two paths within a single turn
- Cancel stale fallback alarm on new onStreamStart

Frontend (streamingCallbacks):
- Add idempotency guard using __streamEndProcessedTurnId to prevent duplicate onStreamEnd processing from dual-path delivery
- Filter fallback sequence=-1 from __minAcceptedUpdateSequence tracking
- Clear idempotency state on onStreamStart and session transitions

Tests:
- Add SessionCallbackAdapterStreamEndTest verifying dual-path mutual exclusion, reset behavior, and sequence passthrough
- Add frontend tests for onStreamEnd idempotency and state cleanup