### PR TITLE
feat(history): implement lite-read for efficient session metadata loading

### DIFF
--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
@@ -10,17 +10,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.file.*;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
@@ -37,7 +28,11 @@ public class SessionIndexManager {
     private static final String CLAUDE_INDEX_FILE = "claude-session-index.json";
     private static final String CODEX_INDEX_FILE = "codex-session-index.json";
 
-    private static final int INDEX_VERSION = 2;
+    // v3 (2026-04): SessionIndexEntry.fileLastModified now populated and used by incremental
+    // scan for mtime-driven re-read of already indexed sessions. Bumping forces rebuild of any
+    // v2 index, which was produced by the legacy full-parser and has different metadata semantics
+    // (title/messageCount/lastTimestamp) than the lite-read pipeline.
+    private static final int INDEX_VERSION = 3;
 
     private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
@@ -105,6 +100,11 @@ public class SessionIndexManager {
 
         // Used to detect whether the file has changed
         public long fileLastModified;
+
+        // Path relative to the provider's root dir (Claude: projectDir; Codex: sessionsDir).
+        // Enables sessionId -> file lookup during incremental rescan even when the session ID
+        // does not equal the file basename (e.g. Codex session_meta.id overrides).
+        public String fileRelativePath;
     }
 
     /**
@@ -319,9 +319,9 @@ public class SessionIndexManager {
             long currentFileCount;
             try (Stream<Path> paths = Files.walk(sessionsDir)) {
                 currentFileCount = paths
-                    .filter(Files::isRegularFile)
-                    .filter(p -> p.toString().endsWith(".jsonl"))
-                    .count();
+                        .filter(Files::isRegularFile)
+                        .filter(p -> p.toString().endsWith(".jsonl"))
+                        .count();
             }
 
             if (currentFileCount == projectIndex.fileCount) {

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexService.java
@@ -3,60 +3,70 @@ package com.github.claudecodegui.provider.claude;
 import com.github.claudecodegui.cache.SessionIndexCache;
 import com.github.claudecodegui.cache.SessionIndexManager;
 import com.github.claudecodegui.util.PathUtils;
-import com.google.gson.Gson;
 import com.intellij.openapi.diagnostic.Logger;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Manages session index: cache, incremental scanning, and full scanning.
+ * Uses lite-read strategy for efficient metadata extraction.
  */
 class ClaudeHistoryIndexService {
 
     private static final Logger LOG = Logger.getInstance(ClaudeHistoryIndexService.class);
 
+    /**
+     * Batch size for concurrent reads when walking the sorted candidate list.
+     */
+    private static final int READ_BATCH_SIZE = 32;
+
     private final Path projectsDir;
     private final ClaudeHistoryParser parser;
-    private final Gson gson = new Gson();
+    private final ClaudeSessionLiteReader liteReader;
 
     ClaudeHistoryIndexService(Path projectsDir, ClaudeHistoryParser parser) {
         this.projectsDir = projectsDir;
         this.parser = parser;
+        this.liteReader = new ClaudeSessionLiteReader();
     }
 
     /**
-     * Read all sessions from a project directory.
+     * Read sessions from a project directory with optional pagination.
      * Uses memory cache and file index for performance optimization.
+     *
+     * @param projectPath the project path
+     * @param limit       maximum number of sessions to return (0 = no limit)
+     * @param offset      number of sessions to skip
+     * @return list of session info
      */
-    List<ClaudeHistoryReader.SessionInfo> readProjectSessions(String projectPath) throws IOException {
-        List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
-
+    List<ClaudeHistoryReader.SessionInfo> readProjectSessions(String projectPath, int limit, int offset) throws IOException {
         if (projectPath == null || projectPath.isEmpty()) {
-            return sessions;
+            return new ArrayList<>();
         }
 
         String sanitizedPath = PathUtils.sanitizePath(projectPath);
-        Path projectDir = projectsDir.resolve(sanitizedPath);
+        Path projectDir = this.projectsDir.resolve(sanitizedPath);
 
         if (!Files.exists(projectDir) || !Files.isDirectory(projectDir)) {
-            return sessions;
+            return new ArrayList<>();
         }
 
-        // 1. Check memory cache
+        // 1. Check memory cache (only for non-paginated requests)
         SessionIndexCache cache = SessionIndexCache.getInstance();
-        List<ClaudeHistoryReader.SessionInfo> cachedSessions = cache.getClaudeSessions(projectPath, projectDir);
-        if (cachedSessions != null) {
-            LOG.info("[ClaudeHistoryReader] Using memory cache for " + projectPath + ", sessions: " + cachedSessions.size());
-            return cachedSessions;
+        if (limit == 0 && offset == 0) {
+            List<ClaudeHistoryReader.SessionInfo> cachedSessions = cache.getClaudeSessions(projectPath, projectDir);
+            if (cachedSessions != null) {
+                LOG.info("[ClaudeHistoryIndexService] Using memory cache for " + projectPath + ", sessions: " + cachedSessions.size());
+                return cachedSessions;
+            }
         }
 
         // 2. Check index file and determine update type
@@ -67,76 +77,378 @@ class ClaudeHistoryIndexService {
 
         if (updateType == SessionIndexManager.UpdateType.NONE) {
             // Index is valid, restore from index
-            LOG.info("[ClaudeHistoryReader] Using file index for " + projectPath + ", sessions: " + projectIndex.sessions.size());
-            sessions = restoreSessionsFromIndex(projectIndex);
-            // Update memory cache
-            cache.updateClaudeCache(projectPath, projectDir, sessions);
-            return sessions;
+            LOG.info("[ClaudeHistoryIndexService] Using file index for " + projectPath + ", sessions: " + projectIndex.sessions.size());
+            List<ClaudeHistoryReader.SessionInfo> restored = restoreSessionsFromIndex(projectIndex);
+            // Apply pagination if needed
+            List<ClaudeHistoryReader.SessionInfo> paged = applySortAndLimit(restored, limit, offset);
+            // Update memory cache (full list)
+            if (limit == 0 && offset == 0) {
+                cache.updateClaudeCache(projectPath, projectDir, restoreSessionsFromIndex(projectIndex));
+            }
+            return paged;
         }
 
         long startTime = System.currentTimeMillis();
 
+        ScanResult scanResult;
         if (updateType == SessionIndexManager.UpdateType.INCREMENTAL && projectIndex != null) {
-            // 3a. Incremental update: only scan new files
-            LOG.info("[ClaudeHistoryReader] Incremental scan for " + projectPath);
-            sessions = incrementalScan(projectDir, projectIndex);
+            // 3a. Incremental update: only scan new files using lite-read
+            LOG.info("[ClaudeHistoryIndexService] Incremental scan for " + projectPath);
+            scanResult = incrementalScanLite(projectDir, projectIndex);
         } else {
-            // 3b. Full scan
-            LOG.info("[ClaudeHistoryReader] Full scan for " + projectPath);
-            sessions = scanProjectSessions(projectDir);
+            // 3b. Full scan using lite-read with pagination support
+            LOG.info("[ClaudeHistoryIndexService] Full scan for " + projectPath);
+            scanResult = scanProjectSessionsLite(projectDir, limit, offset);
         }
 
         long scanTime = System.currentTimeMillis() - startTime;
-        LOG.info("[ClaudeHistoryReader] Scan completed in " + scanTime + "ms, sessions: " + sessions.size());
+        LOG.info("[ClaudeHistoryIndexService] Scan completed in " + scanTime + "ms, sessions: " + scanResult.sessions.size());
 
-        // 4. Update index
-        updateProjectIndex(index, projectPath, projectDir, sessions);
-        indexManager.saveClaudeIndex(index);
+        // 4. Update index (for non-paginated full scans)
+        if (limit == 0 && offset == 0) {
+            updateProjectIndex(index, projectPath, projectDir, scanResult.sessions, scanResult.sessionMtimes);
+            indexManager.saveClaudeIndex(index);
+            // 5. Update memory cache
+            cache.updateClaudeCache(projectPath, projectDir, scanResult.sessions);
+        }
 
-        // 5. Update memory cache
-        cache.updateClaudeCache(projectPath, projectDir, sessions);
+        return scanResult.sessions;
+    }
+
+    /**
+     * Legacy method without pagination for backward compatibility.
+     */
+    List<ClaudeHistoryReader.SessionInfo> readProjectSessions(String projectPath) throws IOException {
+        return readProjectSessions(projectPath, 0, 0);
+    }
+
+    /**
+     * Incremental scan using lite-read.
+     * <p>
+     * Classifies each .jsonl file under the project directory into one of three buckets:
+     * <ul>
+     *   <li>not in index -- lite-read as new</li>
+     *   <li>in index but mtime drifted (active session appended) -- lite-read to refresh</li>
+     *   <li>in index with matching mtime -- restored directly from the index</li>
+     * </ul>
+     * Also returns the sessionId -> mtime map so the index-update step can persist
+     * fileLastModified without a second stat. Package-private for test access.
+     */
+    ScanResult incrementalScanLite(
+            Path projectDir,
+            SessionIndexManager.ProjectIndex existingIndex
+    ) throws IOException {
+        Map<String, SessionIndexManager.SessionIndexEntry> indexedById = new HashMap<>();
+        for (SessionIndexManager.SessionIndexEntry entry : existingIndex.sessions) {
+            if (entry != null && entry.sessionId != null) {
+                indexedById.put(entry.sessionId, entry);
+            }
+        }
+
+        List<Path> newFiles = new ArrayList<>();
+        List<Path> changedFiles = new ArrayList<>();
+        Set<String> restoredIds = new HashSet<>();
+        Map<String, Long> sessionMtimes = new HashMap<>();
+        AtomicInteger skipped = new AtomicInteger();
+
+        try (Stream<Path> paths = Files.list(projectDir)) {
+            paths.filter(p -> p.toString().endsWith(".jsonl"))
+                    .forEach(p -> {
+                        String fileName = p.getFileName() != null ? p.getFileName().toString() : "";
+                        String sessionId = extractSessionId(fileName);
+                        if (sessionId == null) {
+                            skipped.incrementAndGet();
+                            return;
+                        }
+
+                        BasicFileAttributes attrs;
+                        try {
+                            attrs = Files.readAttributes(p, BasicFileAttributes.class);
+                        } catch (IOException e) {
+                            skipped.incrementAndGet();
+                            return;
+                        }
+                        if (attrs.size() <= 0) {
+                            skipped.incrementAndGet();
+                            return;
+                        }
+                        long mtime = attrs.lastModifiedTime().toMillis();
+
+                        SessionIndexManager.SessionIndexEntry indexed = indexedById.get(sessionId);
+                        if (indexed == null) {
+                            newFiles.add(p);
+                        } else if (indexed.fileLastModified <= 0 || indexed.fileLastModified != mtime) {
+                            // mtime drifted (active session appended, or legacy entry without mtime) -- re-read
+                            changedFiles.add(p);
+                        } else {
+                            restoredIds.add(sessionId);
+                            // Carry the current mtime forward so the index keeps an authoritative value.
+                            sessionMtimes.put(sessionId, mtime);
+                        }
+                    });
+        }
+
+        List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
+        for (SessionIndexManager.SessionIndexEntry entry : existingIndex.sessions) {
+            if (entry != null && entry.sessionId != null && restoredIds.contains(entry.sessionId)) {
+                sessions.add(restoreEntry(entry));
+            }
+        }
+
+        List<ReadResult> refreshed = batchReadLite(changedFiles);
+        List<ReadResult> newSessions = batchReadLite(newFiles);
+        for (ReadResult rr : refreshed) {
+            sessions.add(rr.info);
+            sessionMtimes.put(rr.info.sessionId, rr.mtime);
+        }
+        for (ReadResult rr : newSessions) {
+            sessions.add(rr.info);
+            sessionMtimes.put(rr.info.sessionId, rr.mtime);
+        }
+        LOG.info("[ClaudeHistoryIndexService] Incremental scan: " + refreshed.size() + " refreshed, "
+                + newSessions.size() + " new, " + restoredIds.size() + " unchanged, "
+                + skipped.get() + " skipped");
+
+        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
+        return new ScanResult(sessions, sessionMtimes);
+    }
+
+    /**
+     * Full scan using lite-read with pagination support.
+     * Always does stat to get correct mtime for sorting.
+     */
+    private ScanResult scanProjectSessionsLite(
+            Path projectDir,
+            int limit,
+            int offset
+    ) throws IOException {
+        // Always gather candidates with stat for correct sorting
+        List<SessionCandidate> candidates = gatherCandidates(projectDir, true);
+
+        Map<String, Long> sessionMtimes = new HashMap<>();
+        if (candidates.isEmpty()) {
+            return new ScanResult(new ArrayList<>(), sessionMtimes);
+        }
+
+        List<ClaudeHistoryReader.SessionInfo> sessions = applySortAndLimitLite(candidates, limit, offset, sessionMtimes);
+        return new ScanResult(sessions, sessionMtimes);
+    }
+
+    /**
+     * Gather candidate session files. Uses a single readAttributes call per file so
+     * size and mtime come from the same stat.
+     */
+    private List<SessionCandidate> gatherCandidates(Path projectDir, boolean doStat) throws IOException {
+        List<SessionCandidate> candidates = new ArrayList<>();
+
+        try (Stream<Path> paths = Files.list(projectDir)) {
+            paths.filter(p -> p.toString().endsWith(".jsonl"))
+                    .forEach(p -> {
+                        String fileName = p.getFileName().toString();
+                        String sessionId = extractSessionId(fileName);
+                        if (sessionId == null) {
+                            return;
+                        }
+
+                        long mtime = 0;
+                        if (doStat) {
+                            try {
+                                BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
+                                if (attrs.size() <= 0) {
+                                    return;
+                                }
+                                mtime = attrs.lastModifiedTime().toMillis();
+                            } catch (IOException e) {
+                                return;
+                            }
+                        }
+
+                        candidates.add(new SessionCandidate(sessionId, p, mtime));
+                    });
+        }
+
+        return candidates;
+    }
+
+    /**
+     * Extract session ID from file name (UUID validation).
+     * Accepts both lowercase and uppercase UUID formats.
+     */
+    private String extractSessionId(String fileName) {
+        if (!fileName.endsWith(".jsonl")) {
+            return null;
+        }
+        String sessionId = fileName.substring(0, fileName.length() - 6);
+        // UUID pattern validation (case-insensitive)
+        if (!sessionId.matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")) {
+            return null;
+        }
+        return sessionId.toLowerCase(); // Normalize to lowercase for consistency
+    }
+
+    /**
+     * Apply sort and limit using lite-read on sorted candidates.
+     *
+     * @param sessionMtimes output map populated with (sessionId -> file mtime) for every
+     *                      session successfully read, so the caller can persist them in the index
+     *                      without a second stat
+     */
+    private List<ClaudeHistoryReader.SessionInfo> applySortAndLimitLite(
+            List<SessionCandidate> candidates,
+            int limit,
+            int offset,
+            Map<String, Long> sessionMtimes
+    ) {
+        // Sort by mtime descending
+        candidates.sort((a, b) -> {
+            if (b.mtime != a.mtime) {
+                return Long.compare(b.mtime, a.mtime);
+            }
+            return b.sessionId.compareTo(a.sessionId);
+        });
+
+        List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
+        int want = limit > 0 ? limit : Integer.MAX_VALUE;
+        int skipped = 0;
+        Set<String> seen = new HashSet<>();
+
+        // Batch read in sorted order
+        for (int i = 0; i < candidates.size() && sessions.size() < want; ) {
+            int batchEnd = Math.min(i + READ_BATCH_SIZE, candidates.size());
+            List<SessionCandidate> batch = candidates.subList(i, batchEnd);
+            List<ReadResult> batchResults = batchReadLite(
+                    batch.stream().map(c -> c.filePath).collect(Collectors.toList())
+            );
+
+            for (ReadResult rr : batchResults) {
+                i++;
+                if (rr.info == null) {
+                    continue;
+                }
+                if (seen.contains(rr.info.sessionId)) {
+                    continue;
+                }
+                seen.add(rr.info.sessionId);
+                if (skipped < offset) {
+                    skipped++;
+                    continue;
+                }
+                sessions.add(rr.info);
+                sessionMtimes.put(rr.info.sessionId, rr.mtime);
+                if (sessions.size() >= want) {
+                    break;
+                }
+            }
+        }
+
+        // Final sort by lastTimestamp to ensure correct order
+        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
 
         return sessions;
     }
 
     /**
-     * Incremental scan: only scan new files and merge with existing index.
+     * Batch read session files using lite-read. Carries the file mtime alongside each
+     * session so that the index-update step can persist fileLastModified without a
+     * second stat. lite-read already stats the file when producing ClaudeLiteSessionInfo,
+     * so the mtime is free; fallback paths pay a single extra stat.
      */
-    private List<ClaudeHistoryReader.SessionInfo> incrementalScan(Path projectDir, SessionIndexManager.ProjectIndex existingIndex) throws IOException {
-        Set<String> indexedIds = existingIndex.getIndexedSessionIds();
-        List<ClaudeHistoryReader.SessionInfo> sessions = restoreSessionsFromIndex(existingIndex);
+    private List<ReadResult> batchReadLite(List<Path> filePaths) {
+        List<CompletableFuture<ReadResult>> futures = new ArrayList<>();
 
-        List<ClaudeHistoryReader.SessionInfo> newSessions = new ArrayList<>();
-        Files.list(projectDir)
-                .filter(path -> path.toString().endsWith(".jsonl"))
-                .filter(path -> {
-                    String fileName = path.getFileName().toString();
-                    String sessionId = fileName.substring(0, fileName.lastIndexOf(".jsonl"));
-                    return !indexedIds.contains(sessionId);
-                })
-                .filter(path -> {
-                    try {
-                        return Files.size(path) > 0;
-                    } catch (IOException e) {
-                        return false;
+        for (Path path : filePaths) {
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                try {
+                    ClaudeSessionLiteReader.ClaudeLiteSessionInfo liteInfo = this.liteReader.readSessionLite(path);
+                    if (liteInfo != null) {
+                        return new ReadResult(convertToSessionInfo(liteInfo), liteInfo.lastModified);
                     }
-                })
-                .forEach(path -> {
-                    try {
-                        ClaudeHistoryReader.SessionInfo session = parser.scanSingleSession(path);
-                        if (session != null) {
-                            newSessions.add(session);
-                        }
-                    } catch (Exception e) {
-                        LOG.error("[ClaudeHistoryReader] Failed to scan new session file: " + e.getMessage());
-                    }
-                });
+                    // Fallback to full scan if lite-read fails.
+                    ClaudeHistoryReader.SessionInfo info = fallbackFullScan(path);
+                    long mtime = info != null ? safeStatMillis(path) : 0L;
+                    return new ReadResult(info, mtime);
+                } catch (Exception e) {
+                    LOG.debug("[ClaudeHistoryIndexService] Lite-read failed for " + path + ", trying fallback: " + e.getMessage());
+                    ClaudeHistoryReader.SessionInfo info = fallbackFullScan(path);
+                    long mtime = info != null ? safeStatMillis(path) : 0L;
+                    return new ReadResult(info, mtime);
+                }
+            }));
+        }
 
-        LOG.info("[ClaudeHistoryReader] Incremental scan found " + newSessions.size() + " new sessions");
-        sessions.addAll(newSessions);
+        List<ReadResult> results = new ArrayList<>();
+        for (CompletableFuture<ReadResult> future : futures) {
+            try {
+                ReadResult rr = future.get();
+                if (rr.info != null) {
+                    results.add(rr);
+                }
+            } catch (Exception e) {
+                LOG.warn("[ClaudeHistoryIndexService] Failed to read session: " + e.getMessage());
+            }
+        }
+
+        return results;
+    }
+
+    private static long safeStatMillis(Path path) {
+        try {
+            return Files.getLastModifiedTime(path).toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    /**
+     * Pair of SessionInfo and the file mtime captured during the read.
+     */
+    private record ReadResult(ClaudeHistoryReader.SessionInfo info, long mtime) {
+    }
+
+    /**
+     * Fallback to full scan when lite-read fails to extract essential metadata.
+     */
+    private ClaudeHistoryReader.SessionInfo fallbackFullScan(Path path) {
+        try {
+            return this.parser.scanSingleSession(path);
+        } catch (Exception e) {
+            LOG.error("[ClaudeHistoryIndexService] Fallback scan failed for " + path + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Convert lite-read result to SessionInfo.
+     */
+    private ClaudeHistoryReader.SessionInfo convertToSessionInfo(ClaudeSessionLiteReader.ClaudeLiteSessionInfo liteInfo) {
+        ClaudeHistoryReader.SessionInfo session = new ClaudeHistoryReader.SessionInfo();
+        session.sessionId = liteInfo.sessionId;
+        session.title = liteInfo.summary;
+        session.messageCount = liteInfo.messageCount;
+        session.lastTimestamp = liteInfo.lastModified;
+        session.firstTimestamp = liteInfo.createdAt;
+        return session;
+    }
+
+    /**
+     * Apply sort and limit to existing session list.
+     */
+    private List<ClaudeHistoryReader.SessionInfo> applySortAndLimit(
+            List<ClaudeHistoryReader.SessionInfo> sessions,
+            int limit,
+            int offset
+    ) {
         sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
 
-        return sessions;
+        if (offset > 0) {
+            sessions = sessions.subList(Math.min(offset, sessions.size()), sessions.size());
+        }
+
+        if (limit > 0 && sessions.size() > limit) {
+            sessions = sessions.subList(0, limit);
+        }
+
+        return new ArrayList<>(sessions);
     }
 
     /**
@@ -145,25 +457,34 @@ class ClaudeHistoryIndexService {
     private List<ClaudeHistoryReader.SessionInfo> restoreSessionsFromIndex(SessionIndexManager.ProjectIndex projectIndex) {
         List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
         for (SessionIndexManager.SessionIndexEntry entry : projectIndex.sessions) {
-            ClaudeHistoryReader.SessionInfo session = new ClaudeHistoryReader.SessionInfo();
-            session.sessionId = entry.sessionId;
-            session.title = entry.title;
-            session.messageCount = entry.messageCount;
-            session.lastTimestamp = entry.lastTimestamp;
-            session.firstTimestamp = entry.firstTimestamp;
-            sessions.add(session);
+            sessions.add(restoreEntry(entry));
         }
         return sessions;
     }
 
     /**
-     * Update project index.
+     * Convert a single index entry to a SessionInfo.
+     */
+    private ClaudeHistoryReader.SessionInfo restoreEntry(SessionIndexManager.SessionIndexEntry entry) {
+        ClaudeHistoryReader.SessionInfo session = new ClaudeHistoryReader.SessionInfo();
+        session.sessionId = entry.sessionId;
+        session.title = entry.title;
+        session.messageCount = entry.messageCount;
+        session.lastTimestamp = entry.lastTimestamp;
+        session.firstTimestamp = entry.firstTimestamp;
+        return session;
+    }
+
+    /**
+     * Update project index. Uses mtimes captured during the scan phase so no second
+     * stat call is required.
      */
     private void updateProjectIndex(
             SessionIndexManager.SessionIndex index,
             String projectPath,
             Path projectDir,
-            List<ClaudeHistoryReader.SessionInfo> sessions
+            List<ClaudeHistoryReader.SessionInfo> sessions,
+            Map<String, Long> sessionMtimes
     ) {
         SessionIndexManager.ProjectIndex projectIndex = new SessionIndexManager.ProjectIndex();
         projectIndex.lastDirScanTime = System.currentTimeMillis();
@@ -181,6 +502,10 @@ class ClaudeHistoryIndexService {
             entry.messageCount = session.messageCount;
             entry.lastTimestamp = session.lastTimestamp;
             entry.firstTimestamp = session.firstTimestamp;
+            // Claude: session files live flat under projectDir with the sessionId as basename.
+            entry.fileRelativePath = session.sessionId != null ? session.sessionId + ".jsonl" : null;
+            Long mtime = session.sessionId != null ? sessionMtimes.get(session.sessionId) : null;
+            entry.fileLastModified = mtime != null ? mtime : 0L;
             projectIndex.sessions.add(entry);
         }
 
@@ -188,89 +513,16 @@ class ClaudeHistoryIndexService {
     }
 
     /**
-     * Scan the project directory to build the session list (full scan).
+     * Scan result bundle: session list and the sessionId -> mtime map captured during
+     * the scan so callers can persist fileLastModified without another stat.
+     * Package-private for test access.
      */
-    private List<ClaudeHistoryReader.SessionInfo> scanProjectSessions(Path projectDir) throws IOException {
-        List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
-        Map<String, List<ClaudeHistoryReader.ConversationMessage>> sessionMessagesMap = new HashMap<>();
+    record ScanResult(List<ClaudeHistoryReader.SessionInfo> sessions, Map<String, Long> sessionMtimes) {
+    }
 
-        Files.list(projectDir)
-                .filter(path -> path.toString().endsWith(".jsonl"))
-                .filter(path -> {
-                    try {
-                        return Files.size(path) > 0;
-                    } catch (IOException e) {
-                        return false;
-                    }
-                })
-                .forEach(path -> {
-                    try (BufferedReader reader = Files.newBufferedReader(path, java.nio.charset.StandardCharsets.UTF_8)) {
-                        String fileName = path.getFileName().toString();
-                        String sessionId = fileName.substring(0, fileName.lastIndexOf(".jsonl"));
-
-                        List<ClaudeHistoryReader.ConversationMessage> messages = new ArrayList<>();
-                        String line;
-
-                        while ((line = reader.readLine()) != null) {
-                            if (line.trim().isEmpty()) continue;
-
-                            try {
-                                ClaudeHistoryReader.ConversationMessage msg = gson.fromJson(line, ClaudeHistoryReader.ConversationMessage.class);
-                                if (msg != null) {
-                                    messages.add(msg);
-                                }
-                            } catch (Exception e) {
-                                LOG.error("[ClaudeHistoryReader] Failed to parse message line: " + e.getMessage());
-                            }
-                        }
-
-                        if (!messages.isEmpty()) {
-                            sessionMessagesMap.put(sessionId, messages);
-                        }
-
-                    } catch (Exception e) {
-                        LOG.error("[ClaudeHistoryReader] Failed to read session file: " + e.getMessage());
-                    }
-                });
-
-        for (Map.Entry<String, List<ClaudeHistoryReader.ConversationMessage>> entry : sessionMessagesMap.entrySet()) {
-            String sessionId = entry.getKey();
-            List<ClaudeHistoryReader.ConversationMessage> messages = entry.getValue();
-
-            if (messages.isEmpty()) continue;
-
-            String summary = parser.generateSummary(messages);
-
-            long lastTimestamp = 0;
-            for (ClaudeHistoryReader.ConversationMessage msg : messages) {
-                if (msg.timestamp != null) {
-                    try {
-                        long ts = parser.parseTimestamp(msg.timestamp);
-                        if (ts > lastTimestamp) {
-                            lastTimestamp = ts;
-                        }
-                    } catch (Exception e) {
-                        // Ignore invalid timestamp
-                    }
-                }
-            }
-
-            if (!parser.isValidSession(sessionId, summary, messages.size())) {
-                continue;
-            }
-
-            ClaudeHistoryReader.SessionInfo session = new ClaudeHistoryReader.SessionInfo();
-            session.sessionId = sessionId;
-            session.title = summary;
-            session.messageCount = messages.size();
-            session.lastTimestamp = lastTimestamp;
-            session.firstTimestamp = lastTimestamp;
-
-            sessions.add(session);
-        }
-
-        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
-
-        return sessions;
+    /**
+     * Candidate session file for stat-first sorting.
+     */
+    private record SessionCandidate(String sessionId, Path filePath, long mtime) {
     }
 }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionLiteReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionLiteReader.java
@@ -1,0 +1,228 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.github.claudecodegui.provider.common.SessionLiteReader;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+/**
+ * Claude-specific lite session reader.
+ * Extracts metadata from Claude JSONL session files using lite-read strategy.
+ */
+public class ClaudeSessionLiteReader {
+
+    private static final Logger LOG = Logger.getInstance(ClaudeSessionLiteReader.class);
+
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private final SessionLiteReader liteReader;
+
+    public ClaudeSessionLiteReader() {
+        this.liteReader = new SessionLiteReader();
+    }
+
+    /**
+     * Claude session info extracted via lite-read.
+     */
+    public static class ClaudeLiteSessionInfo {
+        public final String sessionId;
+        public final String summary;
+        public final long lastModified;
+        public final long fileSize;
+        public final String customTitle;
+        public final String firstPrompt;
+        public final int messageCount;
+        public final long createdAt;
+
+        public ClaudeLiteSessionInfo(
+                String sessionId,
+                String summary,
+                long lastModified,
+                long fileSize,
+                String customTitle,
+                String firstPrompt,
+                int messageCount,
+                long createdAt
+        ) {
+            this.sessionId = sessionId;
+            this.summary = summary;
+            this.lastModified = lastModified;
+            this.fileSize = fileSize;
+            this.customTitle = customTitle;
+            this.firstPrompt = firstPrompt;
+            this.messageCount = messageCount;
+            this.createdAt = createdAt;
+        }
+    }
+
+    /**
+     * Reads a Claude session file and extracts metadata using lite-read.
+     *
+     * @param sessionPath the path to the session JSONL file
+     * @return ClaudeLiteSessionInfo or null if should be filtered
+     */
+    public ClaudeLiteSessionInfo readSessionLite(Path sessionPath) {
+        SessionLiteReader.LiteSessionFile lite = this.liteReader.readSessionLite(sessionPath);
+        if (lite == null) {
+            return null;
+        }
+
+        String fileName = sessionPath.getFileName().toString();
+        String sessionId = this.extractSessionId(fileName);
+        if (sessionId == null) {
+            return null;
+        }
+
+        // Skip sidechain sessions
+        if (this.liteReader.isSidechainSession(lite.head)) {
+            return null;
+        }
+
+        return this.parseSessionInfoFromLite(sessionId, lite);
+    }
+
+    /**
+     * Parses SessionInfo fields from a lite session read (head/tail/stat).
+     * Returns null for sidechain sessions or metadata-only sessions with no extractable summary.
+     *
+     * @param sessionId the session ID
+     * @param lite      the lite session file data
+     * @return ClaudeLiteSessionInfo or null
+     */
+    public ClaudeLiteSessionInfo parseSessionInfoFromLite(
+            String sessionId,
+            SessionLiteReader.LiteSessionFile lite
+    ) {
+        if (lite == null || sessionId == null) {
+            return null;
+        }
+
+        // Extract title: customTitle wins over aiTitle (same as CLI)
+        // CLI merges customTitle and aiTitle into one variable for priority
+        String userTitle = this.liteReader.extractLastJsonStringField(lite.tail, "customTitle");
+        if (userTitle == null) {
+            userTitle = this.liteReader.extractLastJsonStringField(lite.head, "customTitle");
+        }
+        if (userTitle == null) {
+            userTitle = this.liteReader.extractLastJsonStringField(lite.tail, "aiTitle");
+        }
+        if (userTitle == null) {
+            userTitle = this.liteReader.extractLastJsonStringField(lite.head, "aiTitle");
+        }
+
+        String firstPrompt = this.liteReader.extractFirstPromptFromHead(lite.head);
+
+        // Extract last-prompt from tail (captured at write time)
+        String lastPrompt = this.liteReader.extractLastJsonStringField(lite.tail, "lastPrompt");
+
+        // Summary priority: userTitle > lastPrompt > summary > firstPrompt (same as CLI)
+        String summary = userTitle;
+        if (summary == null) {
+            summary = lastPrompt;
+        }
+        if (summary == null) {
+            summary = this.liteReader.extractLastJsonStringField(lite.tail, "summary");
+        }
+        if (summary == null) {
+            summary = firstPrompt;
+        }
+
+        // Skip metadata-only sessions (no title, no summary, no prompt)
+        if (summary == null || summary.isEmpty()) {
+            return null;
+        }
+
+        // Skip invalid sessions (agent files, warmup, etc.)
+        if (!this.isValidSession(sessionId, summary)) {
+            return null;
+        }
+
+        // Extract first timestamp for createdAt
+        String firstTimestamp = this.liteReader.extractJsonStringField(lite.head, "timestamp");
+        long createdAt = 0;
+        if (firstTimestamp != null) {
+            try {
+                createdAt = this.parseTimestamp(firstTimestamp);
+            } catch (Exception e) {
+                // Ignore invalid timestamp
+            }
+        }
+
+        // Count messages in head (approximation)
+        int messageCount = this.liteReader.countMessagesInHead(lite.head);
+
+        return new ClaudeLiteSessionInfo(
+                sessionId,
+                summary,
+                lite.mtime,
+                lite.size,
+                userTitle,
+                firstPrompt,
+                messageCount,
+                createdAt
+        );
+    }
+
+    /**
+     * Extracts session ID from file name (UUID validation).
+     *
+     * @param fileName the file name (e.g., "abc123.jsonl")
+     * @return validated session ID or null
+     */
+    private String extractSessionId(String fileName) {
+        if (!fileName.endsWith(".jsonl")) {
+            return null;
+        }
+        String sessionId = fileName.substring(0, fileName.length() - 6);
+        if (!UUID_PATTERN.matcher(sessionId).matches()) {
+            return null;
+        }
+        return sessionId;
+    }
+
+    /**
+     * Check if a session is valid (not an agent file, not warmup, etc.).
+     */
+    private boolean isValidSession(String sessionId, String summary) {
+        if (sessionId != null && sessionId.startsWith("agent-")) {
+            return false;
+        }
+
+        if (summary == null || summary.isEmpty()) {
+            return false;
+        }
+
+        String lowerSummary = summary.toLowerCase();
+        if (lowerSummary.equals("warmup") ||
+                lowerSummary.equals("no prompt") ||
+                lowerSummary.startsWith("warmup") ||
+                lowerSummary.startsWith("no prompt")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Parse an ISO timestamp string to epoch milliseconds.
+     */
+    private long parseTimestamp(String timestamp) {
+        try {
+            java.time.Instant instant = java.time.Instant.parse(timestamp);
+            return instant.toEpochMilli();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Returns the underlying SessionLiteReader for reuse.
+     */
+    public SessionLiteReader getLiteReader() {
+        return this.liteReader;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexService.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexService.java
@@ -7,47 +7,63 @@ import com.intellij.openapi.diagnostic.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Handles Codex session indexing, cache coordination, and full/incremental scans.
+ * Uses lite-read strategy for efficient metadata extraction.
  */
 class CodexHistoryIndexService {
 
     private static final Logger LOG = Logger.getInstance(CodexHistoryIndexService.class);
 
+    /**
+     * Batch size for concurrent reads when walking the sorted candidate list.
+     */
+    private static final int READ_BATCH_SIZE = 32;
+
     private final Path sessionsDir;
     private final CodexHistoryParser parser;
+    private final CodexSessionLiteReader liteReader;
 
     CodexHistoryIndexService(Path sessionsDir, CodexHistoryParser parser) {
         this.sessionsDir = sessionsDir;
         this.parser = parser;
+        this.liteReader = new CodexSessionLiteReader();
     }
 
     List<CodexHistoryReader.SessionInfo> readAllSessions() throws IOException {
-        return readAllSessionsWithCache("__all__");
+        return readAllSessionsWithPagination(0, 0);
     }
 
-    private List<CodexHistoryReader.SessionInfo> readAllSessionsWithCache(String cacheKey) throws IOException {
-        List<CodexHistoryReader.SessionInfo> sessions = new ArrayList<>();
+    /**
+     * Read sessions with optional pagination support.
+     *
+     * @param limit  maximum number of sessions to return (0 = no limit)
+     * @param offset number of sessions to skip
+     * @return list of session info
+     */
+    List<CodexHistoryReader.SessionInfo> readAllSessionsWithPagination(int limit, int offset) throws IOException {
+        String cacheKey = "__all__";
 
         if (!Files.exists(sessionsDir) || !Files.isDirectory(sessionsDir)) {
-            LOG.info("[CodexHistoryReader] Codex sessions directory not found: " + sessionsDir);
-            return sessions;
+            LOG.info("[CodexHistoryIndexService] Codex sessions directory not found: " + sessionsDir);
+            return new ArrayList<>();
         }
 
+        // Check memory cache (only for non-paginated requests)
         SessionIndexCache cache = SessionIndexCache.getInstance();
-        List<CodexHistoryReader.SessionInfo> cachedSessions = cache.getCodexSessions(cacheKey, sessionsDir);
-        if (cachedSessions != null) {
-            LOG.info("[CodexHistoryReader] Using memory cache for " + cacheKey + ", sessions: " + cachedSessions.size());
-            return cachedSessions;
+        if (limit == 0 && offset == 0) {
+            List<CodexHistoryReader.SessionInfo> cachedSessions = cache.getCodexSessions(cacheKey, sessionsDir);
+            if (cachedSessions != null) {
+                LOG.info("[CodexHistoryIndexService] Using memory cache for " + cacheKey + ", sessions: " + cachedSessions.size());
+                return cachedSessions;
+            }
         }
 
         SessionIndexManager indexManager = SessionIndexManager.getInstance();
@@ -56,100 +72,359 @@ class CodexHistoryIndexService {
         SessionIndexManager.UpdateType updateType = indexManager.getUpdateTypeRecursive(projectIndex, sessionsDir);
 
         if (updateType == SessionIndexManager.UpdateType.NONE) {
-            LOG.info("[CodexHistoryReader] Using file index for " + cacheKey + ", sessions: " + projectIndex.sessions.size());
-            sessions = restoreSessionsFromIndex(projectIndex);
-            cache.updateCodexCache(cacheKey, sessionsDir, sessions);
+            LOG.info("[CodexHistoryIndexService] Using file index for " + cacheKey + ", sessions: " + projectIndex.sessions.size());
+            List<CodexHistoryReader.SessionInfo> sessions = restoreSessionsFromIndex(projectIndex);
+            sessions = applySortAndLimit(sessions, limit, offset);
+            if (limit == 0 && offset == 0) {
+                cache.updateCodexCache(cacheKey, sessionsDir, restoreSessionsFromIndex(projectIndex));
+            }
             return sessions;
         }
 
         long startTime = System.currentTimeMillis();
 
+        ScanResult scanResult;
         if (updateType == SessionIndexManager.UpdateType.INCREMENTAL && projectIndex != null) {
-            LOG.info("[CodexHistoryReader] Incremental scan for Codex sessions");
-            sessions = incrementalScan(projectIndex);
+            LOG.info("[CodexHistoryIndexService] Incremental scan for Codex sessions");
+            scanResult = incrementalScanLite(projectIndex);
         } else {
-            LOG.info("[CodexHistoryReader] Full scan for Codex sessions");
-            sessions = scanAllSessions();
-            preserveExistingTitles(projectIndex, sessions);
+            LOG.info("[CodexHistoryIndexService] Full scan for Codex sessions");
+            scanResult = scanAllSessionsLite(limit, offset);
+            // Note: we no longer call preserveExistingTitles here.
+            // Custom titles are handled by HistoryLoadService.enhanceHistoryWithTitles() at display time,
+            // which reads from session-titles.json and overrides the auto-extracted title.
+            // Preserving stale index titles would mask updates to active sessions, contradicting
+            // the fix goal of making "first entry" and "refresh" show consistent content.
         }
 
         long scanTime = System.currentTimeMillis() - startTime;
-        LOG.info("[CodexHistoryReader] Scan completed in " + scanTime + "ms, sessions: " + sessions.size());
+        LOG.info("[CodexHistoryIndexService] Scan completed in " + scanTime + "ms, sessions: " + scanResult.sessions.size());
 
-        updateCodexIndex(index, cacheKey, sessions);
-        indexManager.saveCodexIndex(index);
-        cache.updateCodexCache(cacheKey, sessionsDir, sessions);
-
-        return sessions;
-    }
-
-    private void preserveExistingTitles(
-            SessionIndexManager.ProjectIndex projectIndex,
-            List<CodexHistoryReader.SessionInfo> sessions
-    ) {
-        if (projectIndex == null || projectIndex.sessions.isEmpty()) {
-            return;
+        // Update index (for non-paginated full scans)
+        if (limit == 0 && offset == 0) {
+            updateCodexIndex(index, cacheKey, scanResult.sessions, scanResult.sessionFiles);
+            indexManager.saveCodexIndex(index);
+            cache.updateCodexCache(cacheKey, sessionsDir, scanResult.sessions);
         }
 
-        Map<String, String> existingTitles = new HashMap<>();
-        for (SessionIndexManager.SessionIndexEntry entry : projectIndex.sessions) {
-            if (entry.title != null && !entry.title.isEmpty()) {
-                existingTitles.put(entry.sessionId, entry.title);
+        return scanResult.sessions;
+    }
+
+    /**
+     * Result bundle for scan operations: sessions and the sessionId -> file metadata
+     * (path + mtime) captured during lite-read / index restore. Both are needed by
+     * updateCodexIndex to persist fileRelativePath and fileLastModified without a
+     * second stat. Package-private for test access.
+     */
+    record ScanResult(List<CodexHistoryReader.SessionInfo> sessions, Map<String, FileMeta> sessionFiles) {
+    }
+
+    /**
+     * Captures a session file's location and last-modified time, carried from scan
+     * to index-update to avoid redundant stat calls.
+     */
+    record FileMeta(Path path, long mtime) {
+    }
+
+    /**
+     * Incremental scan using lite-read.
+     * <p>
+     * Three buckets:
+     * <ul>
+     *   <li>new files (not present in the existing index) -- lite-read</li>
+     *   <li>indexed files whose mtime drifted since the last index write -- lite-read</li>
+     *   <li>indexed files with unchanged mtime -- restored from index</li>
+     * </ul>
+     * Relative path is used as the stable key because Codex session IDs may come from
+     * session_meta.id and therefore are not directly derivable from the filename.
+     * Package-private for test access.
+     */
+    ScanResult incrementalScanLite(SessionIndexManager.ProjectIndex existingIndex) throws IOException {
+        Map<String, SessionIndexManager.SessionIndexEntry> indexedByPath = new HashMap<>();
+        for (SessionIndexManager.SessionIndexEntry entry : existingIndex.sessions) {
+            if (entry != null && entry.fileRelativePath != null && !entry.fileRelativePath.isEmpty()) {
+                indexedByPath.put(entry.fileRelativePath, entry);
             }
         }
 
-        if (existingTitles.isEmpty()) {
-            return;
-        }
-
-        for (CodexHistoryReader.SessionInfo session : sessions) {
-            String oldTitle = existingTitles.get(session.sessionId);
-            if (oldTitle != null) {
-                session.title = oldTitle;
-            }
-        }
-
-        LOG.info("[CodexHistoryReader] Preserved " + existingTitles.size() + " existing titles from old index");
-    }
-
-    private List<CodexHistoryReader.SessionInfo> incrementalScan(SessionIndexManager.ProjectIndex existingIndex) throws IOException {
-        Set<String> indexedIds = existingIndex.getIndexedSessionIds();
-        List<CodexHistoryReader.SessionInfo> sessions = restoreSessionsFromIndex(existingIndex);
-        List<CodexHistoryReader.SessionInfo> newSessions = new ArrayList<>();
+        List<Path> newFiles = new ArrayList<>();
+        List<Path> changedFiles = new ArrayList<>();
+        Map<String, SessionIndexManager.SessionIndexEntry> restoredEntriesByPath = new HashMap<>();
+        Map<String, FileMeta> sessionFiles = new HashMap<>();
+        AtomicInteger skipped = new AtomicInteger();
 
         try (Stream<Path> paths = Files.walk(sessionsDir)) {
-            List<Path> newFiles = paths
+            paths
                     .filter(Files::isRegularFile)
-                    .filter(path -> path.toString().endsWith(".jsonl"))
-                    .filter(path -> {
-                        String fileName = path.getFileName().toString();
-                        for (String indexedId : indexedIds) {
-                            if (fileName.contains(indexedId)) {
-                                return false;
+                    .filter(p -> p.toString().endsWith(".jsonl"))
+                    .forEach(p -> {
+                        String relative;
+                        BasicFileAttributes attrs;
+                        try {
+                            relative = this.sessionsDir.relativize(p).toString();
+                            attrs = Files.readAttributes(p, BasicFileAttributes.class);
+                        } catch (Exception e) {
+                            skipped.incrementAndGet();
+                            return;
+                        }
+                        if (attrs.size() <= 0) {
+                            skipped.incrementAndGet();
+                            return;
+                        }
+                        long mtime = attrs.lastModifiedTime().toMillis();
+
+                        SessionIndexManager.SessionIndexEntry indexed = indexedByPath.get(relative);
+                        if (indexed == null) {
+                            newFiles.add(p);
+                        } else if (indexed.fileLastModified <= 0 || indexed.fileLastModified != mtime) {
+                            changedFiles.add(p);
+                        } else {
+                            restoredEntriesByPath.put(relative, indexed);
+                            if (indexed.sessionId != null) {
+                                sessionFiles.put(indexed.sessionId, new FileMeta(p, mtime));
                             }
                         }
-                        return true;
-                    })
-                    .filter(CodexHistoryParser::isNonEmptyFile)
-                    .collect(Collectors.toList());
+                    });
+        }
 
-            LOG.info("[CodexHistoryReader] Found " + newFiles.size() + " new Codex session files");
+        List<CodexHistoryReader.SessionInfo> sessions = new ArrayList<>();
+        for (SessionIndexManager.SessionIndexEntry entry : restoredEntriesByPath.values()) {
+            sessions.add(restoreEntry(entry));
+        }
 
-            for (Path sessionFile : newFiles) {
-                try {
-                    CodexHistoryReader.SessionInfo session = parser.parseSessionFile(sessionFile);
-                    if (session != null && parser.isValidSession(session)) {
-                        newSessions.add(session);
-                    }
-                } catch (Exception e) {
-                    LOG.warn("[CodexHistoryReader] Failed to parse new session file: " + sessionFile + " - " + e.getMessage());
+        List<ReadResult> refreshed = batchReadLite(changedFiles);
+        List<ReadResult> newSessions = batchReadLite(newFiles);
+        for (ReadResult rr : refreshed) {
+            sessions.add(rr.info);
+            sessionFiles.put(rr.info.sessionId, new FileMeta(rr.path, rr.mtime));
+        }
+        for (ReadResult rr : newSessions) {
+            sessions.add(rr.info);
+            sessionFiles.put(rr.info.sessionId, new FileMeta(rr.path, rr.mtime));
+        }
+        LOG.info("[CodexHistoryIndexService] Incremental scan: " + refreshed.size() + " refreshed, "
+                + newSessions.size() + " new, " + restoredEntriesByPath.size() + " unchanged, "
+                + skipped.get() + " skipped");
+
+        return new ScanResult(deduplicateSessions(sessions), sessionFiles);
+    }
+
+    private CodexHistoryReader.SessionInfo restoreEntry(SessionIndexManager.SessionIndexEntry entry) {
+        CodexHistoryReader.SessionInfo session = new CodexHistoryReader.SessionInfo();
+        session.sessionId = entry.sessionId;
+        session.title = entry.title;
+        session.messageCount = entry.messageCount;
+        session.lastTimestamp = entry.lastTimestamp;
+        session.firstTimestamp = entry.firstTimestamp;
+        session.cwd = entry.cwd;
+        return session;
+    }
+
+    /**
+     * Full scan using lite-read with pagination support.
+     * Always does stat to get correct mtime for sorting.
+     */
+    private ScanResult scanAllSessionsLite(int limit, int offset) throws IOException {
+        List<SessionCandidate> candidates = gatherCandidates(true);
+
+        Map<String, FileMeta> sessionFiles = new HashMap<>();
+        if (candidates.isEmpty()) {
+            return new ScanResult(new ArrayList<>(), sessionFiles);
+        }
+
+        List<CodexHistoryReader.SessionInfo> sessions = applySortAndLimitLite(candidates, limit, offset, sessionFiles);
+        return new ScanResult(sessions, sessionFiles);
+    }
+
+    /**
+     * Gather candidate session files. Uses a single readAttributes call per file so
+     * size and mtime come from the same stat.
+     */
+    private List<SessionCandidate> gatherCandidates(boolean doStat) throws IOException {
+        List<SessionCandidate> candidates = new ArrayList<>();
+
+        try (Stream<Path> paths = Files.walk(sessionsDir)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".jsonl"))
+                    .forEach(p -> {
+                        String fileName = p.getFileName().toString();
+                        String sessionId = fileName.substring(0, fileName.length() - 6);
+
+                        long mtime = 0;
+                        if (doStat) {
+                            try {
+                                BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
+                                if (attrs.size() <= 0) {
+                                    return;
+                                }
+                                mtime = attrs.lastModifiedTime().toMillis();
+                            } catch (IOException e) {
+                                return;
+                            }
+                        }
+
+                        candidates.add(new SessionCandidate(sessionId, p, mtime));
+                    });
+        }
+
+        return candidates;
+    }
+
+    /**
+     * Apply sort and limit using lite-read on sorted candidates.
+     *
+     * @param sessionFiles output map populated with (sessionId -> FileMeta) for every
+     *                     valid session read during this call
+     */
+    private List<CodexHistoryReader.SessionInfo> applySortAndLimitLite(
+            List<SessionCandidate> candidates,
+            int limit,
+            int offset,
+            Map<String, FileMeta> sessionFiles
+    ) {
+        // Sort by mtime descending
+        candidates.sort((a, b) -> {
+            if (b.mtime != a.mtime) {
+                return Long.compare(b.mtime, a.mtime);
+            }
+            return b.sessionId.compareTo(a.sessionId);
+        });
+
+        List<CodexHistoryReader.SessionInfo> sessions = new ArrayList<>();
+        int want = limit > 0 ? limit : Integer.MAX_VALUE;
+        int skipped = 0;
+        Set<String> seen = new HashSet<>();
+
+        // Batch read in sorted order
+        for (int i = 0; i < candidates.size() && sessions.size() < want; ) {
+            int batchEnd = Math.min(i + READ_BATCH_SIZE, candidates.size());
+            List<SessionCandidate> batch = candidates.subList(i, batchEnd);
+            List<ReadResult> batchResults = batchReadLite(
+                    batch.stream().map(c -> c.filePath).collect(Collectors.toList())
+            );
+
+            for (ReadResult rr : batchResults) {
+                i++;
+                if (rr.info == null) {
+                    continue;
+                }
+                if (seen.contains(rr.info.sessionId)) {
+                    continue;
+                }
+                seen.add(rr.info.sessionId);
+                if (skipped < offset) {
+                    skipped++;
+                    continue;
+                }
+                sessions.add(rr.info);
+                sessionFiles.put(rr.info.sessionId, new FileMeta(rr.path, rr.mtime));
+                if (sessions.size() >= want) {
+                    break;
                 }
             }
         }
 
-        LOG.info("[CodexHistoryReader] Incremental scan found " + newSessions.size() + " new valid sessions");
+        return deduplicateSessions(sessions);
+    }
 
-        sessions.addAll(newSessions);
+    /**
+     * Batch read session files using lite-read. Each result carries the file path
+     * (so callers can persist fileRelativePath) and its mtime (so callers can persist
+     * fileLastModified without a second stat). lite-read already stats the file, so
+     * the mtime is free; fallback paths pay a single extra stat.
+     */
+    private List<ReadResult> batchReadLite(List<Path> filePaths) {
+        List<CompletableFuture<ReadResult>> futures = new ArrayList<>();
+
+        for (Path path : filePaths) {
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                try {
+                    CodexSessionLiteReader.CodexLiteSessionInfo liteInfo = this.liteReader.readSessionLite(path);
+                    if (liteInfo != null) {
+                        return new ReadResult(convertToSessionInfo(liteInfo), path, liteInfo.lastModified);
+                    }
+                    CodexHistoryReader.SessionInfo info = fallbackFullScan(path);
+                    long mtime = info != null ? safeStatMillis(path) : 0L;
+                    return new ReadResult(info, path, mtime);
+                } catch (Exception e) {
+                    LOG.debug("[CodexHistoryIndexService] Lite-read failed for " + path + ", trying fallback: " + e.getMessage());
+                    CodexHistoryReader.SessionInfo info = fallbackFullScan(path);
+                    long mtime = info != null ? safeStatMillis(path) : 0L;
+                    return new ReadResult(info, path, mtime);
+                }
+            }));
+        }
+
+        List<ReadResult> results = new ArrayList<>();
+        for (CompletableFuture<ReadResult> future : futures) {
+            try {
+                ReadResult rr = future.get();
+                if (rr.info != null && this.parser.isValidSession(rr.info)) {
+                    results.add(rr);
+                }
+            } catch (Exception e) {
+                LOG.warn("[CodexHistoryIndexService] Failed to read session: " + e.getMessage());
+            }
+        }
+
+        return results;
+    }
+
+    private static long safeStatMillis(Path path) {
+        try {
+            return Files.getLastModifiedTime(path).toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    private record ReadResult(CodexHistoryReader.SessionInfo info, Path path, long mtime) {
+    }
+
+    /**
+     * Fallback to full scan when lite-read fails.
+     */
+    private CodexHistoryReader.SessionInfo fallbackFullScan(Path path) {
+        try {
+            return this.parser.parseSessionFile(path);
+        } catch (Exception e) {
+            LOG.error("[CodexHistoryIndexService] Fallback scan failed for " + path + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Convert lite-read result to SessionInfo.
+     */
+    private CodexHistoryReader.SessionInfo convertToSessionInfo(CodexSessionLiteReader.CodexLiteSessionInfo liteInfo) {
+        CodexHistoryReader.SessionInfo session = new CodexHistoryReader.SessionInfo();
+        session.sessionId = liteInfo.sessionId;
+        session.title = liteInfo.summary;
+        session.messageCount = liteInfo.messageCount;
+        session.lastTimestamp = liteInfo.lastModified;
+        session.firstTimestamp = liteInfo.createdAt;
+        session.cwd = liteInfo.cwd;
+        return session;
+    }
+
+    /**
+     * Apply sort and limit to existing session list.
+     */
+    private List<CodexHistoryReader.SessionInfo> applySortAndLimit(
+            List<CodexHistoryReader.SessionInfo> sessions,
+            int limit,
+            int offset
+    ) {
+        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
+
+        if (offset > 0) {
+            sessions = new ArrayList<>(sessions.subList(Math.min(offset, sessions.size()), sessions.size()));
+        }
+
+        if (limit > 0 && sessions.size() > limit) {
+            sessions = new ArrayList<>(sessions.subList(0, limit));
+        }
+
         return deduplicateSessions(sessions);
     }
 
@@ -171,7 +446,8 @@ class CodexHistoryIndexService {
     private void updateCodexIndex(
             SessionIndexManager.SessionIndex index,
             String cacheKey,
-            List<CodexHistoryReader.SessionInfo> sessions
+            List<CodexHistoryReader.SessionInfo> sessions,
+            Map<String, FileMeta> sessionFiles
     ) throws IOException {
         List<CodexHistoryReader.SessionInfo> deduplicatedSessions = deduplicateSessions(sessions);
         SessionIndexManager.ProjectIndex projectIndex = new SessionIndexManager.ProjectIndex();
@@ -186,39 +462,21 @@ class CodexHistoryIndexService {
             entry.lastTimestamp = session.lastTimestamp;
             entry.firstTimestamp = session.firstTimestamp;
             entry.cwd = session.cwd;
+
+            FileMeta meta = sessionFiles.get(session.sessionId);
+            if (meta != null && meta.path != null) {
+                try {
+                    entry.fileRelativePath = this.sessionsDir.relativize(meta.path).toString();
+                    entry.fileLastModified = meta.mtime;
+                } catch (Exception e) {
+                    LOG.debug("[CodexHistoryIndexService] Failed to relativize " + meta.path + ": " + e.getMessage());
+                }
+            }
+
             projectIndex.sessions.add(entry);
         }
 
         index.projects.put(cacheKey, projectIndex);
-    }
-
-    private List<CodexHistoryReader.SessionInfo> scanAllSessions() throws IOException {
-        List<CodexHistoryReader.SessionInfo> sessions = new ArrayList<>();
-
-        try (Stream<Path> paths = Files.walk(sessionsDir)) {
-            List<Path> jsonlFiles = paths
-                    .filter(Files::isRegularFile)
-                    .filter(path -> path.toString().endsWith(".jsonl"))
-                    .filter(CodexHistoryParser::isNonEmptyFile)
-                    .collect(Collectors.toList());
-
-            LOG.info("[CodexHistoryReader] Found " + jsonlFiles.size() + " Codex session files");
-
-            for (Path sessionFile : jsonlFiles) {
-                try {
-                    CodexHistoryReader.SessionInfo session = parser.parseSessionFile(sessionFile);
-                    if (session != null && parser.isValidSession(session)) {
-                        sessions.add(session);
-                    }
-                } catch (Exception e) {
-                    LOG.warn("[CodexHistoryReader] Failed to parse session file: " + sessionFile + " - " + e.getMessage());
-                }
-            }
-        }
-
-        List<CodexHistoryReader.SessionInfo> deduplicatedSessions = deduplicateSessions(sessions);
-        LOG.info("[CodexHistoryReader] Successfully loaded " + deduplicatedSessions.size() + " valid Codex sessions");
-        return deduplicatedSessions;
     }
 
     static List<CodexHistoryReader.SessionInfo> deduplicateSessions(List<CodexHistoryReader.SessionInfo> sessions) {
@@ -283,5 +541,11 @@ class CodexHistoryIndexService {
                     .filter(path -> path.toString().endsWith(".jsonl"))
                     .count();
         }
+    }
+
+    /**
+     * Candidate session file for stat-first sorting.
+     */
+    private record SessionCandidate(String sessionId, Path filePath, long mtime) {
     }
 }

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReader.java
@@ -1,0 +1,321 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.github.claudecodegui.provider.common.SessionLiteReader;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Codex-specific lite session reader.
+ * Extracts metadata from Codex JSONL session files using lite-read strategy.
+ */
+public class CodexSessionLiteReader {
+
+    private static final Logger LOG = Logger.getInstance(CodexSessionLiteReader.class);
+
+    private static final Pattern THREAD_ID_PATTERN = Pattern.compile(
+            "^thread_[a-zA-Z0-9]{10,}$"
+    );
+
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private final SessionLiteReader liteReader;
+
+    public CodexSessionLiteReader() {
+        this.liteReader = new SessionLiteReader();
+    }
+
+    /**
+     * Codex session info extracted via lite-read.
+     */
+    public static class CodexLiteSessionInfo {
+        public final String sessionId;
+        public final String summary;
+        public final long lastModified;
+        public final long fileSize;
+        public final int messageCount;
+        public final long createdAt;
+        public final String cwd;
+
+        public CodexLiteSessionInfo(
+                String sessionId,
+                String summary,
+                long lastModified,
+                long fileSize,
+                int messageCount,
+                long createdAt,
+                String cwd
+        ) {
+            this.sessionId = sessionId;
+            this.summary = summary;
+            this.lastModified = lastModified;
+            this.fileSize = fileSize;
+            this.messageCount = messageCount;
+            this.createdAt = createdAt;
+            this.cwd = cwd;
+        }
+    }
+
+    /**
+     * Reads a Codex session file and extracts metadata using lite-read.
+     *
+     * @param sessionPath the path to the session JSONL file
+     * @return CodexLiteSessionInfo or null if should be filtered
+     */
+    public CodexLiteSessionInfo readSessionLite(Path sessionPath) {
+        SessionLiteReader.LiteSessionFile lite = this.liteReader.readSessionLite(sessionPath);
+        if (lite == null) {
+            return null;
+        }
+
+        String fileName = sessionPath.getFileName().toString();
+        String sessionId = this.extractSessionId(fileName);
+        if (sessionId == null) {
+            return null;
+        }
+
+        return this.parseSessionInfoFromLite(sessionId, lite);
+    }
+
+    /**
+     * Parses SessionInfo fields from a lite session read (head/tail/stat).
+     *
+     * @param sessionId the default session ID from filename
+     * @param lite      the lite session file data
+     * @return CodexLiteSessionInfo or null
+     */
+    public CodexLiteSessionInfo parseSessionInfoFromLite(
+            String sessionId,
+            SessionLiteReader.LiteSessionFile lite
+    ) {
+        if (lite == null || sessionId == null) {
+            return null;
+        }
+
+        // Extract session_meta.id if available (preferred over filename)
+        String metaId = this.extractSessionMetaId(lite.head);
+        if (metaId != null) {
+            sessionId = metaId;
+        }
+
+        // Extract cwd from session_meta
+        String cwd = this.extractSessionMetaField(lite.head, "cwd");
+
+        // Extract timestamp from session_meta for createdAt
+        String timestamp = this.extractSessionMetaField(lite.head, "timestamp");
+        long createdAt = 0;
+        if (timestamp != null) {
+            try {
+                createdAt = this.parseTimestamp(timestamp);
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+
+        // Extract title from first user_message
+        String summary = this.extractFirstUserMessageTitle(lite.head);
+
+        // Skip sessions with no title
+        if (summary == null || summary.isEmpty()) {
+            return null;
+        }
+
+        // Count response_item messages (approximate from head)
+        int messageCount = this.countResponseItems(lite.head);
+
+        // Use mtime as lastTimestamp (more reliable than last message timestamp)
+        long lastModified = lite.mtime;
+        if (createdAt == 0) {
+            createdAt = lastModified;
+        }
+
+        return new CodexLiteSessionInfo(
+                sessionId,
+                summary,
+                lastModified,
+                lite.size,
+                messageCount,
+                createdAt,
+                cwd
+        );
+    }
+
+    /**
+     * Extracts session_meta.id from head chunk.
+     */
+    private String extractSessionMetaId(String head) {
+        // Look for {"type":"session_meta", "payload":{"id":"..."}}
+        String[] patterns = {"\"type\":\"session_meta\"", "\"type\": \"session_meta\""};
+        for (String pattern : patterns) {
+            int idx = head.indexOf(pattern);
+            if (idx < 0) {
+                continue;
+            }
+
+            // Find the payload.id within this line
+            int lineEnd = head.indexOf('\n', idx);
+            String line = lineEnd >= 0 ? head.substring(idx, lineEnd) : head.substring(idx);
+
+            String id = this.liteReader.extractJsonStringField(line, "id");
+            if (id != null && (THREAD_ID_PATTERN.matcher(id).matches() || UUID_PATTERN.matcher(id).matches())) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts a field from session_meta payload.
+     */
+    private String extractSessionMetaField(String head, String field) {
+        String[] patterns = {"\"type\":\"session_meta\"", "\"type\": \"session_meta\""};
+        for (String pattern : patterns) {
+            int idx = head.indexOf(pattern);
+            if (idx < 0) {
+                continue;
+            }
+
+            int lineEnd = head.indexOf('\n', idx);
+            String line = lineEnd >= 0 ? head.substring(idx, lineEnd) : head.substring(idx);
+
+            return this.liteReader.extractJsonStringField(line, field);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the first user message title from event_msg.
+     */
+    private String extractFirstUserMessageTitle(String head) {
+        int start = 0;
+        while (start < head.length()) {
+            int newlineIdx = head.indexOf('\n', start);
+            String line = newlineIdx >= 0 ? head.substring(start, newlineIdx) : head.substring(start);
+            start = newlineIdx >= 0 ? newlineIdx + 1 : head.length();
+
+            if (!line.contains("\"type\":\"event_msg\"") && !line.contains("\"type\": \"event_msg\"")) {
+                continue;
+            }
+
+            // Check if payload contains user_message
+            if (!line.contains("\"user_message\"")) {
+                continue;
+            }
+
+            String message = this.liteReader.extractLastJsonStringField(line, "message");
+            if (message != null && !message.isEmpty()) {
+                // Strip system tags
+                message = stripSystemTags(message);
+                message = message.replace("\n", " ").trim();
+
+                // Skip auto-generated patterns
+                if (message.startsWith("<") && message.length() > 1) {
+                    char nextChar = message.charAt(1);
+                    if (Character.isLowerCase(nextChar)) {
+                        continue;
+                    }
+                }
+
+                // Truncate to 45 chars
+                if (message.length() > 45) {
+                    message = message.substring(0, 45).trim() + "\u2026";
+                }
+                return message;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Remove known system/instruction XML tag blocks from text.
+     */
+    private String stripSystemTags(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        String[] systemTags = {"agents-instructions", "system-reminder", "system-prompt"};
+        String result = text;
+        for (String tag : systemTags) {
+            result = removeTagBlock(result, tag);
+        }
+        return result.trim();
+    }
+
+    /**
+     * Remove a complete XML tag block from text.
+     */
+    private String removeTagBlock(String text, String tagName) {
+        String openTag = "<" + tagName + ">";
+        String closeTag = "</" + tagName + ">";
+        int start = text.indexOf(openTag);
+        if (start == -1) {
+            return text;
+        }
+        int end = text.indexOf(closeTag, start);
+        if (end == -1) {
+            return text;
+        }
+        return text.substring(0, start) + text.substring(end + closeTag.length());
+    }
+
+    /**
+     * Counts response_item messages in head chunk.
+     */
+    private int countResponseItems(String head) {
+        int count = 0;
+        int start = 0;
+        while (start < head.length()) {
+            int newlineIdx = head.indexOf('\n', start);
+            String line = newlineIdx >= 0 ? head.substring(start, newlineIdx) : head.substring(start);
+            start = newlineIdx >= 0 ? newlineIdx + 1 : head.length();
+
+            if (line.contains("\"type\":\"response_item\"") || line.contains("\"type\": \"response_item\"")) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Extracts session ID from file name.
+     */
+    private String extractSessionId(String fileName) {
+        if (!fileName.endsWith(".jsonl")) {
+            return null;
+        }
+        String sessionId = fileName.substring(0, fileName.length() - 6);
+
+        // Validate: must be UUID or thread_xxx format
+        Matcher uuidMatcher = UUID_PATTERN.matcher(sessionId);
+        Matcher threadMatcher = THREAD_ID_PATTERN.matcher(sessionId);
+
+        if (uuidMatcher.matches() || threadMatcher.matches()) {
+            return sessionId;
+        }
+        return null;
+    }
+
+    /**
+     * Parse an ISO timestamp string to epoch milliseconds.
+     */
+    private long parseTimestamp(String timestamp) {
+        try {
+            java.time.Instant instant = java.time.Instant.parse(timestamp);
+            return instant.toEpochMilli();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Returns the underlying SessionLiteReader for reuse.
+     */
+    public SessionLiteReader getLiteReader() {
+        return this.liteReader;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/common/SessionLiteReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/SessionLiteReader.java
@@ -1,0 +1,389 @@
+package com.github.claudecodegui.provider.common;
+
+import com.google.gson.Gson;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Lightweight session file reader that only reads head and tail chunks.
+ * Provides efficient metadata extraction without full JSONL parsing.
+ * <p>
+ * Buffer size: 64KB (same as Claude CLI's LITE_READ_BUF_SIZE).
+ */
+public class SessionLiteReader {
+
+    private static final Logger LOG = Logger.getInstance(SessionLiteReader.class);
+
+    private static final Gson GSON = new Gson();
+
+    /**
+     * Size of the head/tail buffer for lite metadata reads (64KB).
+     */
+    public static final int LITE_READ_BUF_SIZE = 65536;
+
+    /**
+     * Lite session file data structure.
+     */
+    public static class LiteSessionFile {
+        public final long mtime;
+        public final long size;
+        public final String head;
+        public final String tail;
+
+        public LiteSessionFile(long mtime, long size, String head, String tail) {
+            this.mtime = mtime;
+            this.size = size;
+            this.head = head;
+            this.tail = tail;
+        }
+    }
+
+    /**
+     * Reads the first and last LITE_READ_BUF_SIZE bytes of a file.
+     * For small files where head covers tail, returns same content for both.
+     *
+     * @param path the file path to read
+     * @return LiteSessionFile with head and tail content, or null on error
+     */
+    public LiteSessionFile readSessionLite(Path path) {
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            long fileSize = channel.size();
+            long mtime = java.nio.file.Files.getLastModifiedTime(path).toMillis();
+
+            if (fileSize == 0) {
+                return null;
+            }
+
+            ByteBuffer buffer = ByteBuffer.allocate(LITE_READ_BUF_SIZE);
+
+            // Read head
+            buffer.clear();
+            int headBytesRead = channel.read(buffer, 0);
+            if (headBytesRead <= 0) {
+                return null;
+            }
+            String head = new String(buffer.array(), 0, headBytesRead, StandardCharsets.UTF_8);
+
+            // Read tail (if file is large enough)
+            String tail = head;
+            long tailOffset = Math.max(0, fileSize - LITE_READ_BUF_SIZE);
+            if (tailOffset > 0) {
+                buffer.clear();
+                int tailBytesRead = channel.read(buffer, tailOffset);
+                if (tailBytesRead > 0) {
+                    tail = new String(buffer.array(), 0, tailBytesRead, StandardCharsets.UTF_8);
+                }
+            }
+
+            return new LiteSessionFile(mtime, fileSize, head, tail);
+        } catch (IOException e) {
+            LOG.debug("[SessionLiteReader] Failed to read file: " + path + " - " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Extracts a JSON string field value from raw text without full parsing.
+     * Looks for "key":"value" or "key": "value" patterns.
+     * Returns the first match, or null if not found.
+     *
+     * @param text the text to search
+     * @param key  the JSON key to find
+     * @return the extracted string value, or null
+     */
+    public String extractJsonStringField(String text, String key) {
+        if (text == null || key == null) {
+            return null;
+        }
+
+        String[] patterns = {"\"" + key + "\":\"", "\"" + key + "\": \""};
+        for (String pattern : patterns) {
+            int idx = text.indexOf(pattern);
+            if (idx < 0) {
+                continue;
+            }
+
+            int valueStart = idx + pattern.length();
+            int i = valueStart;
+            while (i < text.length()) {
+                char c = text.charAt(i);
+                if (c == '\\') {
+                    i += 2;
+                    continue;
+                }
+                if (c == '"') {
+                    String rawValue = text.substring(valueStart, i);
+                    return unescapeJsonString(rawValue);
+                }
+                i++;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Like extractJsonStringField but finds the LAST occurrence.
+     * Useful for fields that are appended (customTitle, tag, etc.).
+     *
+     * @param text the text to search
+     * @param key  the JSON key to find
+     * @return the last extracted string value, or null
+     */
+    public String extractLastJsonStringField(String text, String key) {
+        if (text == null || key == null) {
+            return null;
+        }
+
+        String[] patterns = {"\"" + key + "\":\"", "\"" + key + "\": \""};
+        String lastValue = null;
+        for (String pattern : patterns) {
+            int searchFrom = 0;
+            while (true) {
+                int idx = text.indexOf(pattern, searchFrom);
+                if (idx < 0) {
+                    break;
+                }
+
+                int valueStart = idx + pattern.length();
+                int i = valueStart;
+                while (i < text.length()) {
+                    char c = text.charAt(i);
+                    if (c == '\\') {
+                        i += 2;
+                        continue;
+                    }
+                    if (c == '"') {
+                        String rawValue = text.substring(valueStart, i);
+                        lastValue = unescapeJsonString(rawValue);
+                        break;
+                    }
+                    i++;
+                }
+                searchFrom = i + 1;
+            }
+        }
+        return lastValue;
+    }
+
+    /**
+     * Unescape a JSON string value extracted as raw text.
+     * Only allocates a new string when escape sequences are present.
+     *
+     * @param raw the raw string with possible escape sequences
+     * @return the unescaped string
+     */
+    private String unescapeJsonString(String raw) {
+        if (raw == null || !raw.contains("\\")) {
+            return raw;
+        }
+        try {
+            return GSON.fromJson("\"" + raw + "\"", String.class);
+        } catch (Exception e) {
+            return raw;
+        }
+    }
+
+    /**
+     * Checks if the first line indicates a sidechain session.
+     *
+     * @param head the head chunk content
+     * @return true if the session is a sidechain
+     */
+    public boolean isSidechainSession(String head) {
+        if (head == null || head.isEmpty()) {
+            return false;
+        }
+
+        int firstNewline = head.indexOf('\n');
+        String firstLine = firstNewline >= 0 ? head.substring(0, firstNewline) : head;
+
+        return firstLine.contains("\"isSidechain\":true") ||
+               firstLine.contains("\"isSidechain\": true");
+    }
+
+    /**
+     * Extracts the first meaningful user prompt from a JSONL head chunk.
+     * Skips tool_result, isMeta, isCompactSummary, and auto-generated patterns.
+     * Supports both string content and array content formats.
+     *
+     * @param head the head chunk content
+     * @return the extracted prompt, truncated to 200 chars, or null
+     */
+    public String extractFirstPromptFromHead(String head) {
+        if (head == null || head.isEmpty()) {
+            return null;
+        }
+
+        int start = 0;
+        String commandFallback = null;
+
+        while (start < head.length()) {
+            int newlineIdx = head.indexOf('\n', start);
+            String line = newlineIdx >= 0 ? head.substring(start, newlineIdx) : head.substring(start);
+            start = newlineIdx >= 0 ? newlineIdx + 1 : head.length();
+
+            if (!line.contains("\"type\":\"user\"") && !line.contains("\"type\": \"user\"")) {
+                continue;
+            }
+            if (line.contains("\"tool_result\"")) {
+                continue;
+            }
+            if (line.contains("\"isMeta\":true") || line.contains("\"isMeta\": true")) {
+                continue;
+            }
+            if (line.contains("\"isCompactSummary\":true") || line.contains("\"isCompactSummary\": true")) {
+                continue;
+            }
+
+            // Try to extract the text content (supports both string and array formats)
+            String contentText = this.extractContentFromLine(line);
+            if (contentText != null && !contentText.isEmpty()) {
+                String result = contentText.replace("\n", " ").trim();
+
+                // Check for slash-command pattern
+                if (result.startsWith("<command-name>") && result.contains("</command-name>")) {
+                    int nameStart = result.indexOf("<command-name>") + 14;
+                    int nameEnd = result.indexOf("</command-name>");
+                    if (nameEnd > nameStart) {
+                        commandFallback = result.substring(nameStart, nameEnd);
+                        continue;
+                    }
+                }
+
+                // Check for bash-input pattern
+                if (result.contains("<bash-input>")) {
+                    int bashStart = result.indexOf("<bash-input>") + 12;
+                    int bashEnd = result.indexOf("</bash-input>");
+                    if (bashEnd > bashStart) {
+                        return "! " + result.substring(bashStart, bashEnd).trim();
+                    }
+                }
+
+                // Skip auto-generated patterns (IDE context, hook output, etc.)
+                if (result.startsWith("<") && result.length() > 1) {
+                    char nextChar = result.charAt(1);
+                    if (Character.isLowerCase(nextChar)) {
+                        continue;  // Skip lowercase XML tags like <ide-context>
+                    }
+                }
+
+                if (result.startsWith("[Request interrupted")) {
+                    continue;
+                }
+
+                // Truncate to 200 chars
+                if (result.length() > 200) {
+                    result = result.substring(0, 200).trim() + "\u2026";
+                }
+                return result;
+            }
+        }
+
+        return commandFallback;
+    }
+
+    /**
+     * Extracts text content from a JSON line, supporting both string and array formats.
+     * First tries string format "content":"...", then falls back to JSON parsing for array format.
+     *
+     * @param line the JSON line to parse
+     * @return extracted text content, or null
+     */
+    private String extractContentFromLine(String line) {
+        // First try simple string extraction: "content":"..."
+        String content = this.extractJsonStringField(line, "content");
+        if (content != null && !content.isEmpty()) {
+            return content;
+        }
+
+        // Fallback: parse JSON for array format content
+        // Content array format: [{"type":"text","text":"actual text"},...]
+        if (line.contains("\"content\":[") || line.contains("\"content\": [")) {
+            try {
+                com.google.gson.JsonObject entry = GSON.fromJson(line, com.google.gson.JsonObject.class);
+                if (entry == null || !entry.has("message")) {
+                    return null;
+                }
+
+                com.google.gson.JsonElement messageElem = entry.get("message");
+                if (messageElem == null || !messageElem.isJsonObject()) {
+                    return null;
+                }
+
+                com.google.gson.JsonObject message = messageElem.getAsJsonObject();
+                if (!message.has("content")) {
+                    return null;
+                }
+
+                com.google.gson.JsonElement contentElem = message.get("content");
+                if (contentElem.isJsonArray()) {
+                    // Array format: extract text from type:"text" blocks
+                    com.google.gson.JsonArray contentArray = contentElem.getAsJsonArray();
+                    StringBuilder sb = new StringBuilder();
+                    for (com.google.gson.JsonElement block : contentArray) {
+                        if (block.isJsonObject()) {
+                            com.google.gson.JsonObject blockObj = block.getAsJsonObject();
+                            if (blockObj.has("type") && "text".equals(blockObj.get("type").getAsString())) {
+                                if (blockObj.has("text") && !blockObj.get("text").isJsonNull()) {
+                                    if (sb.length() > 0) {
+                                        sb.append(" ");
+                                    }
+                                    sb.append(blockObj.get("text").getAsString());
+                                }
+                            }
+                        }
+                    }
+                    String result = sb.toString().trim();
+                    return result.isEmpty() ? null : result;
+                } else if (contentElem.isJsonPrimitive()) {
+                    // String format (already handled above, but just in case)
+                    return contentElem.getAsString();
+                }
+            } catch (Exception e) {
+                // JSON parsing failed, return null
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Counts message entries in the head chunk by counting non-empty lines.
+     * This is an approximation - only counts messages visible in head chunk.
+     * For large files (exceeding LITE_READ_BUF_SIZE), messages in tail are not counted.
+     *
+     * @param head the head chunk content
+     * @return approximate message count (messages in head only)
+     */
+    public int countMessagesInHead(String head) {
+        if (head == null || head.isEmpty()) {
+            return 0;
+        }
+
+        int count = 0;
+        int start = 0;
+        while (start < head.length()) {
+            int newlineIdx = head.indexOf('\n', start);
+            String line = newlineIdx >= 0 ? head.substring(start, newlineIdx) : head.substring(start);
+            start = newlineIdx >= 0 ? newlineIdx + 1 : head.length();
+
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+
+            // Skip sidechain messages in count
+            if (line.contains("\"isSidechain\":true") || line.contains("\"isSidechain\": true")) {
+                continue;
+            }
+
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/cache/SessionIndexSchemaTest.java
+++ b/src/test/java/com/github/claudecodegui/cache/SessionIndexSchemaTest.java
@@ -1,0 +1,68 @@
+package com.github.claudecodegui.cache;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the v3 index schema: SessionIndexEntry serializes the new
+ * fileLastModified + fileRelativePath fields and round-trips cleanly through Gson.
+ * This is the contract that incremental scan depends on.
+ */
+public class SessionIndexSchemaTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    public void sessionIndexEntry_fileLastModified_roundTripsThroughGson() {
+        SessionIndexManager.SessionIndexEntry entry = new SessionIndexManager.SessionIndexEntry();
+        entry.sessionId = "aaaaaaaa-1111-4111-8111-111111111111";
+        entry.title = "Hello";
+        entry.messageCount = 3;
+        entry.lastTimestamp = 1_700_000_000_000L;
+        entry.firstTimestamp = 1_700_000_000_000L;
+        entry.fileLastModified = 1_700_000_123_456L;
+        entry.fileRelativePath = entry.sessionId + ".jsonl";
+
+        String json = gson.toJson(entry);
+        assertTrue("fileLastModified must be serialized", json.contains("\"fileLastModified\":1700000123456"));
+        assertTrue("fileRelativePath must be serialized", json.contains("\"fileRelativePath\""));
+
+        SessionIndexManager.SessionIndexEntry decoded = gson.fromJson(json, SessionIndexManager.SessionIndexEntry.class);
+        assertEquals(entry.sessionId, decoded.sessionId);
+        assertEquals(entry.fileLastModified, decoded.fileLastModified);
+        assertEquals(entry.fileRelativePath, decoded.fileRelativePath);
+    }
+
+    @Test
+    public void sessionIndexEntry_loadingV2Entry_defaultsFileMtimeToZero() {
+        // v2 schema had no fileLastModified / fileRelativePath.
+        String v2Json = "{"
+                + "\"sessionId\":\"old-id\","
+                + "\"title\":\"Legacy\","
+                + "\"messageCount\":5,"
+                + "\"lastTimestamp\":1000,"
+                + "\"firstTimestamp\":999,"
+                + "\"fileSize\":0"
+                + "}";
+
+        SessionIndexManager.SessionIndexEntry decoded = gson.fromJson(v2Json, SessionIndexManager.SessionIndexEntry.class);
+        assertNotNull(decoded);
+        assertEquals("old-id", decoded.sessionId);
+        // Missing fields default to zero / null -- incrementalScanLite uses this to detect legacy entries.
+        assertEquals(0L, decoded.fileLastModified);
+        assertEquals(null, decoded.fileRelativePath);
+    }
+
+    @Test
+    public void sessionIndex_wrapperDefaults_useCurrentVersion() {
+        SessionIndexManager.SessionIndex freshIndex = new SessionIndexManager.SessionIndex();
+        // Sanity: a freshly constructed index must advertise the active schema version.
+        // When readIndex sees a mismatched version on disk it replaces the content with a blank
+        // instance, so this default is what gets returned to callers after an upgrade.
+        assertTrue("version should be at least 3", freshIndex.version >= 3);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexServiceTest.java
@@ -1,0 +1,194 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.github.claudecodegui.cache.SessionIndexManager;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that incrementalScanLite correctly distinguishes unchanged / mtime-drifted /
+ * brand-new session files and re-reads only what is needed, and that mtimes are carried
+ * from scan to index-update without a second stat.
+ */
+public class ClaudeHistoryIndexServiceTest {
+
+    private static final String UUID_1 = "aaaaaaaa-1111-4111-8111-111111111111";
+    private static final String UUID_2 = "bbbbbbbb-2222-4222-8222-222222222222";
+    private static final String UUID_3 = "cccccccc-3333-4333-8333-333333333333";
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void incrementalScan_restoresUnchangedEntries_andRereadsDriftedFile() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-incr").toPath();
+
+        Path fileA = writeSession(projectDir, UUID_1, "Hello A", "2026-04-21T10:00:00Z");
+        Path fileB = writeSession(projectDir, UUID_2, "Hello B", "2026-04-21T10:05:00Z");
+
+        long mtimeA = Files.getLastModifiedTime(fileA).toMillis();
+        long mtimeB = Files.getLastModifiedTime(fileB).toMillis();
+
+        // Seed index: A has a drifted mtime (stale title should be replaced), B matches (title preserved).
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 2;
+        existing.sessions.add(entry(UUID_1, "STALE A", 1, mtimeA + 1000, mtimeA + 1000, UUID_1 + ".jsonl"));
+        existing.sessions.add(entry(UUID_2, "Hello B", 1, mtimeB, mtimeB, UUID_2 + ".jsonl"));
+
+        ClaudeHistoryIndexService service = newService(projectDir);
+        ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
+
+        Map<String, ClaudeHistoryReader.SessionInfo> byId = result.sessions().stream()
+                .collect(Collectors.toMap(s -> s.sessionId, s -> s));
+
+        assertEquals("two sessions expected", 2, byId.size());
+        assertEquals("Hello A", byId.get(UUID_1).title);
+        assertEquals("Hello B", byId.get(UUID_2).title);
+
+        // Mtime map must include entries for both sessions so updateProjectIndex can persist them.
+        assertEquals(Long.valueOf(mtimeA), result.sessionMtimes().get(UUID_1));
+        assertEquals(Long.valueOf(mtimeB), result.sessionMtimes().get(UUID_2));
+    }
+
+    @Test
+    public void incrementalScan_picksUpBrandNewSessionFile() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-new").toPath();
+
+        Path fileA = writeSession(projectDir, UUID_1, "Existing A", "2026-04-21T10:00:00Z");
+        long mtimeA = Files.getLastModifiedTime(fileA).toMillis();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        existing.sessions.add(entry(UUID_1, "Existing A", 1, mtimeA, mtimeA, UUID_1 + ".jsonl"));
+
+        writeSession(projectDir, UUID_3, "Brand New", "2026-04-21T11:00:00Z");
+
+        ClaudeHistoryIndexService service = newService(projectDir);
+        ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
+
+        Map<String, ClaudeHistoryReader.SessionInfo> byId = result.sessions().stream()
+                .collect(Collectors.toMap(s -> s.sessionId, s -> s));
+        assertEquals(2, byId.size());
+        assertEquals("Existing A", byId.get(UUID_1).title);
+        assertNotNull("new session must be surfaced", byId.get(UUID_3));
+        assertEquals("Brand New", byId.get(UUID_3).title);
+    }
+
+    @Test
+    public void incrementalScan_legacyEntryWithoutMtime_triggersReRead() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-legacy").toPath();
+
+        writeSession(projectDir, UUID_1, "Fresh A", "2026-04-21T10:00:00Z");
+
+        // Simulate a v2-era entry: fileLastModified = 0 (never written), fileRelativePath = null.
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        existing.sessions.add(entry(UUID_1, "STALE LEGACY", 42, 9999L, 0L, null));
+
+        ClaudeHistoryIndexService service = newService(projectDir);
+        ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
+
+        assertEquals(1, result.sessions().size());
+        assertEquals("legacy entry should be refreshed from file", "Fresh A", result.sessions().get(0).title);
+    }
+
+    @Test
+    public void incrementalScan_skipsNonUuidJsonlFiles() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-skip").toPath();
+
+        // A backup file with non-UUID filename must not go through lite-read.
+        Path backup = projectDir.resolve("some-random-backup.jsonl");
+        Files.writeString(backup, "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"irrelevant\"}}\n");
+
+        writeSession(projectDir, UUID_1, "Real session", "2026-04-21T10:00:00Z");
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 2;
+
+        ClaudeHistoryIndexService service = newService(projectDir);
+        ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
+
+        assertEquals("non-UUID .jsonl must be ignored", 1, result.sessions().size());
+        assertEquals(UUID_1, result.sessions().get(0).sessionId);
+        assertNull("backup file must not appear in mtime map",
+                result.sessionMtimes().get("some-random-backup"));
+        assertTrue("real session's mtime must be recorded", result.sessionMtimes().containsKey(UUID_1));
+    }
+
+    @Test
+    public void extractSessionId_normalizesUppercaseUuidToLowercase() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-uppercase").toPath();
+
+        // Write a session with uppercase UUID in filename
+        String uppercaseUuid = "AAAAAAAA-1111-4111-8111-111111111111";
+        Path file = writeSession(projectDir, uppercaseUuid, "Upper Case", "2026-04-21T10:00:00Z");
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 0;
+
+        ClaudeHistoryIndexService service = newService(projectDir);
+        ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
+
+        assertEquals("uppercase UUID session must be recognized", 1, result.sessions().size());
+        // sessionId should be normalized to lowercase
+        assertEquals(UUID_1, result.sessions().get(0).sessionId);
+        assertTrue("mtime map should use normalized lowercase key",
+                result.sessionMtimes().containsKey(UUID_1));
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private ClaudeHistoryIndexService newService(Path projectDir) {
+        return new ClaudeHistoryIndexService(projectDir, new ClaudeHistoryParser());
+    }
+
+    private Path writeSession(Path projectDir, String sessionId, String firstUserText, String timestamp) throws IOException {
+        Path file = projectDir.resolve(sessionId + ".jsonl");
+        String line = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\""
+                + firstUserText.replace("\"", "\\\"")
+                + "\"},\"timestamp\":\"" + timestamp + "\"}\n";
+        Files.writeString(file, line);
+        return file;
+    }
+
+    /**
+     * Builds a SessionIndexEntry with explicit separation between the business
+     * timestamps (lastTimestamp/firstTimestamp) and the indexed file mtime. This lets
+     * tests construct scenarios where the indexed mtime has drifted without confusing
+     * the two concepts.
+     */
+    private SessionIndexManager.SessionIndexEntry entry(
+            String sessionId,
+            String title,
+            int messageCount,
+            long lastTimestamp,
+            long indexedFileMtime,
+            String fileRelativePath
+    ) {
+        SessionIndexManager.SessionIndexEntry e = new SessionIndexManager.SessionIndexEntry();
+        e.sessionId = sessionId;
+        e.title = title;
+        e.messageCount = messageCount;
+        e.lastTimestamp = lastTimestamp;
+        e.firstTimestamp = lastTimestamp;
+        e.fileLastModified = indexedFileMtime;
+        e.fileRelativePath = fileRelativePath;
+        return e;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSessionLiteReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSessionLiteReaderTest.java
@@ -1,0 +1,108 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.github.claudecodegui.provider.common.SessionLiteReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ClaudeSessionLiteReaderTest {
+
+    private final ClaudeSessionLiteReader reader = new ClaudeSessionLiteReader();
+
+    @Test
+    public void readSessionLite_claudeSession() throws IOException {
+        Path tempDir = Files.createTempDirectory("claude-lite-test");
+        try {
+            Path tempFile = tempDir.resolve("abc12345-1234-1234-1234-1234567890ab.jsonl");
+            String content = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Hello Claude\"},\"timestamp\":\"2026-01-15T10:00:00Z\",\"sessionId\":\"abc12345-1234-1234-1234-1234567890ab\"}\n" +
+                    "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"Hi there!\"},\"timestamp\":\"2026-01-15T10:01:00Z\"}\n" +
+                    "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"How are you?\"},\"timestamp\":\"2026-01-15T10:02:00Z\"}\n";
+            Files.writeString(tempFile, content);
+
+            ClaudeSessionLiteReader.ClaudeLiteSessionInfo info = reader.readSessionLite(tempFile);
+            assertNotNull(info);
+            assertEquals("abc12345-1234-1234-1234-1234567890ab", info.sessionId);
+            assertNotNull(info.summary);
+            assertTrue(info.messageCount >= 1);
+            assertTrue(info.createdAt > 0);
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    public void readSessionLite_skipsSidechain() throws IOException {
+        Path tempDir = Files.createTempDirectory("claude-lite-test");
+        try {
+            Path tempFile = tempDir.resolve("abc12345-1234-1234-1234-1234567890ab.jsonl");
+            String content = "{\"isSidechain\":true,\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"side\"}}\n";
+            Files.writeString(tempFile, content);
+
+            assertNull(reader.readSessionLite(tempFile));
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_extractsTitle() {
+        String sessionId = "abc12345-1234-1234-1234-1234567890ab";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"user\",\"content\":\"What is Java?\",\"timestamp\":\"2026-01-15T10:00:00Z\"}\n",
+                "{\"customTitle\":\"My Session Title\"}\n"
+        );
+
+        ClaudeSessionLiteReader.ClaudeLiteSessionInfo info = reader.parseSessionInfoFromLite(sessionId, lite);
+        assertNotNull(info);
+        assertEquals("My Session Title", info.summary);
+        assertEquals("My Session Title", info.customTitle);
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_noTitleReturnsNull() {
+        String sessionId = "abc12345-1234-1234-1234-1234567890ab";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"system\",\"content\":\"init\"}\n",
+                ""
+        );
+
+        assertNull(reader.parseSessionInfoFromLite(sessionId, lite));
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_skipsAgentSession() {
+        String sessionId = "agent-12345678";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"user\",\"content\":\"hello\"}\n",
+                ""
+        );
+
+        assertNull(reader.parseSessionInfoFromLite(sessionId, lite));
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_skipsWarmup() {
+        String sessionId = "abc12345-1234-1234-1234-1234567890ab";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"user\",\"content\":\"warmup\"}\n",
+                ""
+        );
+
+        assertNull(reader.parseSessionInfoFromLite(sessionId, lite));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexServiceTest.java
@@ -1,0 +1,161 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.github.claudecodegui.cache.SessionIndexManager;
+import com.google.gson.Gson;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies Codex incrementalScanLite uses fileRelativePath (not sessionId) for index lookup,
+ * which matters because Codex session IDs can be overridden by session_meta.id. Also
+ * verifies that file mtime is carried from scan to index-update.
+ */
+public class CodexHistoryIndexServiceTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void incrementalScan_matchesIndexByRelativePath_andRefreshesDriftedFile() throws IOException {
+        Path sessionsDir = tmp.newFolder("codex-index-incr").toPath();
+        Path nested = sessionsDir.resolve("2026/04/21");
+        Files.createDirectories(nested);
+
+        // File name "rollout-<uuid>.jsonl" with session_meta.id = "thread_xxx" override.
+        Path file = writeSessionFile(nested, "rollout-alpha.jsonl", "thread_abc1234567");
+        long mtime = Files.getLastModifiedTime(file).toMillis();
+        String relative = sessionsDir.relativize(file).toString();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry entry = new SessionIndexManager.SessionIndexEntry();
+        entry.sessionId = "thread_abc1234567";
+        entry.title = "STALE TITLE";
+        entry.messageCount = 0;
+        entry.lastTimestamp = mtime + 5000;
+        entry.firstTimestamp = mtime + 5000;
+        entry.fileRelativePath = relative;
+        entry.fileLastModified = mtime + 5000;  // drifted from actual file mtime
+        existing.sessions.add(entry);
+
+        CodexHistoryIndexService service = newService(sessionsDir);
+        CodexHistoryIndexService.ScanResult result = service.incrementalScanLite(existing);
+
+        assertEquals(1, result.sessions().size());
+        CodexHistoryReader.SessionInfo restored = result.sessions().get(0);
+        assertEquals("thread_abc1234567", restored.sessionId);
+        assertNotNull(restored.title);
+        assertTrue("title should come from the fresh file, not the stale index",
+                !"STALE TITLE".equals(restored.title));
+
+        // sessionFiles must carry the path AND the fresh mtime for updateCodexIndex.
+        CodexHistoryIndexService.FileMeta meta = result.sessionFiles().get("thread_abc1234567");
+        assertNotNull(meta);
+        assertEquals("mtime from scan should reflect the actual file on disk", mtime, meta.mtime());
+    }
+
+    @Test
+    public void incrementalScan_restoresUnchangedEntry_withoutReadingFile() throws IOException {
+        Path sessionsDir = tmp.newFolder("codex-index-unchanged").toPath();
+        Path nested = sessionsDir.resolve("2026/04/21");
+        Files.createDirectories(nested);
+
+        Path file = writeSessionFile(nested, "rollout-beta.jsonl", "thread_beta987654321");
+        long mtime = Files.getLastModifiedTime(file).toMillis();
+        String relative = sessionsDir.relativize(file).toString();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry entry = new SessionIndexManager.SessionIndexEntry();
+        entry.sessionId = "thread_beta987654321";
+        entry.title = "Indexed Title";
+        entry.messageCount = 7;
+        entry.lastTimestamp = mtime;
+        entry.firstTimestamp = mtime;
+        entry.fileRelativePath = relative;
+        entry.fileLastModified = mtime;  // matches actual file mtime
+        existing.sessions.add(entry);
+
+        CodexHistoryIndexService service = newService(sessionsDir);
+        CodexHistoryIndexService.ScanResult result = service.incrementalScanLite(existing);
+
+        assertEquals(1, result.sessions().size());
+        CodexHistoryReader.SessionInfo restored = result.sessions().get(0);
+        assertEquals("Indexed Title", restored.title);
+        assertEquals(7, restored.messageCount);
+
+        // Unchanged entries must still contribute a FileMeta so updateCodexIndex can re-persist the mtime.
+        CodexHistoryIndexService.FileMeta meta = result.sessionFiles().get("thread_beta987654321");
+        assertNotNull(meta);
+        assertEquals(mtime, meta.mtime());
+    }
+
+    @Test
+    public void incrementalScan_picksUpFileMissingFromIndex() throws IOException {
+        Path sessionsDir = tmp.newFolder("codex-index-newfile").toPath();
+        Path nested = sessionsDir.resolve("2026/04/21");
+        Files.createDirectories(nested);
+
+        Path existingFile = writeSessionFile(nested, "rollout-old.jsonl", "thread_old1234567890");
+        long mtime = Files.getLastModifiedTime(existingFile).toMillis();
+        String relative = sessionsDir.relativize(existingFile).toString();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry entry = new SessionIndexManager.SessionIndexEntry();
+        entry.sessionId = "thread_old1234567890";
+        entry.title = "Old";
+        entry.messageCount = 1;
+        entry.lastTimestamp = mtime;
+        entry.firstTimestamp = mtime;
+        entry.fileRelativePath = relative;
+        entry.fileLastModified = mtime;
+        existing.sessions.add(entry);
+
+        writeSessionFile(nested, "rollout-new.jsonl", "thread_new0987654321");
+
+        CodexHistoryIndexService service = newService(sessionsDir);
+        CodexHistoryIndexService.ScanResult result = service.incrementalScanLite(existing);
+
+        Map<String, CodexHistoryReader.SessionInfo> byId = result.sessions().stream()
+                .collect(Collectors.toMap(s -> s.sessionId, s -> s));
+        assertEquals(2, byId.size());
+        assertNotNull(byId.get("thread_old1234567890"));
+        assertNotNull(byId.get("thread_new0987654321"));
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private CodexHistoryIndexService newService(Path sessionsDir) {
+        return new CodexHistoryIndexService(sessionsDir, new CodexHistoryParser(new Gson()));
+    }
+
+    private Path writeSessionFile(Path dir, String fileName, String sessionMetaId) throws IOException {
+        Path file = dir.resolve(fileName);
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"timestamp\":\"2026-04-21T10:00:00Z\",\"type\":\"session_meta\",")
+                .append("\"payload\":{\"id\":\"").append(sessionMetaId)
+                .append("\",\"cwd\":\"/workspace/demo\",\"timestamp\":\"2026-04-21T10:00:00Z\"}}\n");
+        sb.append("{\"timestamp\":\"2026-04-21T10:00:05Z\",\"type\":\"event_msg\",")
+                .append("\"payload\":{\"type\":\"user_message\",\"message\":\"Fresh title for ")
+                .append(sessionMetaId).append("\"}}\n");
+        sb.append("{\"timestamp\":\"2026-04-21T10:00:10Z\",\"type\":\"response_item\",")
+                .append("\"payload\":{\"type\":\"message\"}}\n");
+        Files.writeString(file, sb.toString());
+        return file;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
@@ -1,0 +1,101 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.github.claudecodegui.provider.common.SessionLiteReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CodexSessionLiteReaderTest {
+
+    private final CodexSessionLiteReader reader = new CodexSessionLiteReader();
+
+    @Test
+    public void readSessionLite_codexSession() throws IOException {
+        Path tempDir = Files.createTempDirectory("codex-lite-test");
+        try {
+            Path tempFile = tempDir.resolve("thread_abc123def456.jsonl");
+            String content = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\",\"cwd\":\"/workspace/demo\",\"timestamp\":\"2026-03-10T10:00:00Z\"}}\n" +
+                    "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hello Codex\"},\"timestamp\":\"2026-03-10T10:01:00Z\"}\n" +
+                    "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\"},\"timestamp\":\"2026-03-10T10:02:00Z\"}\n";
+            Files.writeString(tempFile, content);
+
+            CodexSessionLiteReader.CodexLiteSessionInfo info = reader.readSessionLite(tempFile);
+            assertNotNull(info);
+            assertEquals("thread_abc123def456", info.sessionId);
+            assertNotNull(info.summary);
+            assertTrue(info.messageCount >= 1);
+            assertEquals("/workspace/demo", info.cwd);
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_extractsTitle() {
+        String sessionId = "thread_abc123def456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\",\"cwd\":\"/workspace\",\"timestamp\":\"2026-03-10T10:00:00Z\"}}\n" +
+                        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"What is Python?\"}}\n",
+                ""
+        );
+
+        CodexSessionLiteReader.CodexLiteSessionInfo info = reader.parseSessionInfoFromLite(sessionId, lite);
+        assertNotNull(info);
+        assertEquals("thread_abc123def456", info.sessionId);
+        assertNotNull(info.summary);
+        assertTrue(info.summary.contains("Python"));
+        assertEquals("/workspace", info.cwd);
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_noTitleReturnsNull() {
+        String sessionId = "thread_abc123def456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\"}}\n" +
+                        "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\"}}\n",
+                ""
+        );
+
+        assertNull(reader.parseSessionInfoFromLite(sessionId, lite));
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_stripsSystemTags() {
+        String sessionId = "thread_abc123def456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"<agents-instructions>some content</agents-instructions>Real question here\"}}\n",
+                ""
+        );
+
+        CodexSessionLiteReader.CodexLiteSessionInfo info = reader.parseSessionInfoFromLite(sessionId, lite);
+        assertNotNull(info);
+        assertTrue(info.summary.contains("Real question here"));
+        assertTrue(!info.summary.contains("agents-instructions"));
+    }
+
+    @Test
+    public void readSessionLite_invalidSessionId() throws IOException {
+        Path tempDir = Files.createTempDirectory("codex-lite-test");
+        try {
+            Path tempFile = tempDir.resolve("invalid-name.jsonl");
+            Files.writeString(tempFile, "{\"type\":\"session_meta\"}\n");
+            assertNull(reader.readSessionLite(tempFile));
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/common/PaginatedSessionLoadingTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/PaginatedSessionLoadingTest.java
@@ -1,0 +1,115 @@
+package com.github.claudecodegui.provider.common;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PaginatedSessionLoadingTest {
+
+    @Test
+    public void liteRead_producesConsistentResultsWithFullRead() throws IOException {
+        Path tempDir = Files.createTempDirectory("paginated-test");
+        try {
+            Path tempFile = tempDir.resolve("abc12345-1234-1234-1234-1234567890ab.jsonl");
+            String line1 = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Hello Claude, this is a test\"},\"timestamp\":\"2026-01-15T10:00:00Z\"}\n";
+            String line2 = "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"Hi there!\"},\"timestamp\":\"2026-01-15T10:01:00Z\"}\n";
+            String line3 = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Tell me more\"},\"timestamp\":\"2026-01-15T10:02:00Z\"}\n";
+            Files.writeString(tempFile, line1 + line2 + line3);
+
+            // Lite-read should extract metadata
+            SessionLiteReader liteReader = new SessionLiteReader();
+            SessionLiteReader.LiteSessionFile lite = liteReader.readSessionLite(tempFile);
+            assertNotNull(lite);
+            assertTrue(lite.size > 0);
+
+            // Claude-specific reader
+            com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader claudeReader =
+                    new com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader();
+            com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader.ClaudeLiteSessionInfo info =
+                    claudeReader.readSessionLite(tempFile);
+
+            assertNotNull(info);
+            assertNotNull(info.summary);
+            assertTrue(info.messageCount >= 1);
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    public void liteRead_handlesLargeFile() throws IOException {
+        Path tempDir = Files.createTempDirectory("paginated-test");
+        try {
+            Path tempFile = tempDir.resolve("abc12345-1234-1234-1234-1234567890ab.jsonl");
+            // Create a file larger than 128KB
+            StringBuilder content = new StringBuilder();
+            content.append("{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"First prompt\"},\"timestamp\":\"2026-01-15T10:00:00Z\"}\n");
+            for (int i = 0; i < 5000; i++) {
+                content.append("{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"Response ")
+                        .append(i)
+                        .append("\"},\"timestamp\":\"2026-01-15T10:")
+                        .append(String.format("%02d", i % 60))
+                        .append(":00Z\"}\n");
+            }
+            content.append("{\"customTitle\":\"Custom Title for Large Session\"}\n");
+
+            Files.writeString(tempFile, content.toString());
+
+            SessionLiteReader liteReader = new SessionLiteReader();
+            SessionLiteReader.LiteSessionFile lite = liteReader.readSessionLite(tempFile);
+            assertNotNull(lite);
+
+            // Verify that head and tail are different for large files
+            // (head contains first 64KB, tail contains last 64KB)
+            assertTrue(lite.head.contains("First prompt"));
+            assertTrue(lite.tail.contains("Custom Title for Large Session"));
+
+            com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader claudeReader =
+                    new com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader();
+            com.github.claudecodegui.provider.claude.ClaudeSessionLiteReader.ClaudeLiteSessionInfo info =
+                    claudeReader.readSessionLite(tempFile);
+
+            assertNotNull(info);
+            assertEquals("Custom Title for Large Session", info.summary);
+        } finally {
+            Files.walk(tempDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    public void extractJsonStringField_performanceBenchmark() {
+        // Create a large text block to test extraction speed
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            sb.append("{\"index\":")
+                    .append(i)
+                    .append(",\"type\":\"user\",\"message\":\"Message ")
+                    .append(i)
+                    .append("\"}\n");
+        }
+        sb.append("{\"customTitle\":\"Final Title\"}\n");
+        String text = sb.toString();
+
+        SessionLiteReader reader = new SessionLiteReader();
+
+        long startTime = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+            String result = reader.extractLastJsonStringField(text, "customTitle");
+            assertEquals("Final Title", result);
+        }
+        long duration = (System.nanoTime() - startTime) / 1_000_000; // ms
+
+        // String extraction should be fast (< 500ms for 100 iterations on ~70KB text)
+        assertTrue("String extraction too slow: " + duration + "ms", duration < 500);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/common/SessionLiteReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/SessionLiteReaderTest.java
@@ -1,0 +1,185 @@
+package com.github.claudecodegui.provider.common;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SessionLiteReaderTest {
+
+    private final SessionLiteReader reader = new SessionLiteReader();
+
+    @Test
+    public void extractJsonStringField_firstMatch() {
+        String text = "{\"type\":\"user\",\"message\":\"hello world\",\"timestamp\":\"2026-01-01T00:00:00Z\"}";
+        assertEquals("user", reader.extractJsonStringField(text, "type"));
+        assertEquals("hello world", reader.extractJsonStringField(text, "message"));
+        assertEquals("2026-01-01T00:00:00Z", reader.extractJsonStringField(text, "timestamp"));
+    }
+
+    @Test
+    public void extractJsonStringField_withSpaces() {
+        String text = "{\"type\": \"user\", \"message\": \"hello world\"}";
+        assertEquals("user", reader.extractJsonStringField(text, "type"));
+        assertEquals("hello world", reader.extractJsonStringField(text, "message"));
+    }
+
+    @Test
+    public void extractJsonStringField_notFound() {
+        String text = "{\"type\":\"user\"}";
+        assertNull(reader.extractJsonStringField(text, "nonexistent"));
+    }
+
+    @Test
+    public void extractJsonStringField_nullInput() {
+        assertNull(reader.extractJsonStringField(null, "type"));
+        assertNull(reader.extractJsonStringField("text", null));
+    }
+
+    @Test
+    public void extractJsonStringField_escapedValue() {
+        String text = "{\"message\":\"hello \\\"world\\\"\"}";
+        assertEquals("hello \"world\"", reader.extractJsonStringField(text, "message"));
+    }
+
+    @Test
+    public void extractJsonStringField_emptyValue() {
+        String text = "{\"message\":\"\"}";
+        assertEquals("", reader.extractJsonStringField(text, "message"));
+    }
+
+    @Test
+    public void extractLastJsonStringField_returnsLastOccurrence() {
+        String text = "{\"customTitle\":\"first\",\"customTitle\":\"last\"}";
+        assertEquals("last", reader.extractLastJsonStringField(text, "customTitle"));
+    }
+
+    @Test
+    public void extractLastJsonStringField_singleOccurrence() {
+        String text = "{\"customTitle\":\"only one\"}";
+        assertEquals("only one", reader.extractLastJsonStringField(text, "customTitle"));
+    }
+
+    @Test
+    public void extractLastJsonStringField_notFound() {
+        String text = "{\"type\":\"user\"}";
+        assertNull(reader.extractLastJsonStringField(text, "customTitle"));
+    }
+
+    @Test
+    public void isSidechainSession_true() {
+        String head = "{\"isSidechain\":true,\"type\":\"user\"}\nmore content";
+        assertTrue(reader.isSidechainSession(head));
+    }
+
+    @Test
+    public void isSidechainSession_trueWithSpace() {
+        String head = "{\"isSidechain\": true,\"type\":\"user\"}\nmore content";
+        assertTrue(reader.isSidechainSession(head));
+    }
+
+    @Test
+    public void isSidechainSession_false() {
+        String head = "{\"type\":\"user\",\"message\":\"hello\"}\nmore content";
+        assertFalse(reader.isSidechainSession(head));
+    }
+
+    @Test
+    public void isSidechainSession_empty() {
+        assertFalse(reader.isSidechainSession(""));
+        assertFalse(reader.isSidechainSession(null));
+    }
+
+    @Test
+    public void extractFirstPromptFromHead_simplePrompt() {
+        // Lite-read now supports array content format via JSON parsing fallback
+        String head = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is Java?\"}]}}\n";
+        String result = reader.extractFirstPromptFromHead(head);
+        // Array content is now extracted correctly
+        assertEquals("What is Java?", result);
+    }
+
+    @Test
+    public void extractFirstPromptFromHead_stringContent() {
+        String head = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Hello world\"},\"timestamp\":\"2026-01-01T00:00:00Z\"}\n";
+        String result = reader.extractFirstPromptFromHead(head);
+        assertEquals("Hello world", result);
+    }
+
+    @Test
+    public void extractFirstPromptFromHead_skipsToolResult() {
+        String head = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"tool_result\",\"tool_result\":true}}\n";
+        assertNull(reader.extractFirstPromptFromHead(head));
+    }
+
+    @Test
+    public void extractFirstPromptFromHead_skipsMeta() {
+        String head = "{\"type\":\"user\",\"isMeta\":true,\"message\":{\"role\":\"user\",\"content\":\"meta message\"}}\n";
+        assertNull(reader.extractFirstPromptFromHead(head));
+    }
+
+    @Test
+    public void extractFirstPromptFromHead_truncatesLongContent() {
+        String longContent = "a".repeat(300);
+        String head = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"" + longContent + "\"}}\n";
+        String result = reader.extractFirstPromptFromHead(head);
+        assertNotNull(result);
+        assertTrue(result.length() <= 201); // 200 chars + ellipsis
+        assertTrue(result.endsWith("\u2026"));
+    }
+
+    @Test
+    public void readSessionLite_smallFile() throws IOException {
+        Path tempFile = Files.createTempFile("test-session", ".jsonl");
+        try {
+            String content = "{\"type\":\"user\",\"content\":\"hello\"}\n{\"type\":\"assistant\",\"content\":\"hi\"}\n";
+            Files.writeString(tempFile, content);
+
+            SessionLiteReader.LiteSessionFile lite = reader.readSessionLite(tempFile);
+            assertNotNull(lite);
+            assertTrue(lite.size > 0);
+            // For small files, head should contain all content
+            assertTrue(lite.head.contains("hello"));
+            // For small files, head and tail are the same
+            assertEquals(lite.head, lite.tail);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void readSessionLite_emptyFile() throws IOException {
+        Path tempFile = Files.createTempFile("test-empty", ".jsonl");
+        try {
+            Files.writeString(tempFile, "");
+            assertNull(reader.readSessionLite(tempFile));
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void countMessagesInHead() {
+        String head = "{\"type\":\"user\",\"content\":\"hello\"}\n{\"type\":\"assistant\",\"content\":\"hi\"}\n\n{\"type\":\"user\",\"content\":\"bye\"}\n";
+        assertEquals(3, reader.countMessagesInHead(head));
+    }
+
+    @Test
+    public void countMessagesInHead_skipsSidechain() {
+        String head = "{\"type\":\"user\",\"content\":\"hello\"}\n{\"isSidechain\":true,\"type\":\"assistant\"}\n";
+        assertEquals(1, reader.countMessagesInHead(head));
+    }
+
+    @Test
+    public void countMessagesInHead_empty() {
+        assertEquals(0, reader.countMessagesInHead(null));
+        assertEquals(0, reader.countMessagesInHead(""));
+    }
+}


### PR DESCRIPTION
Implement a lightweight session metadata extraction strategy that reads only the
head (64KB) and tail (64KB) of JSONL files, avoiding full parse for large sessions.
Add mtime-based incremental scanning to detect and refresh changed files.

Core changes:
- Add SessionLiteReader: generic base class for reading only first/last lines
- Add ClaudeSessionLiteReader/CodexSessionLiteReader: provider-specific implementations
- Extract metadata (sessionId, title, messageCount, timestamps, cwd) from partial reads
- Fallback to full parse when lite-read fails to extract essential fields

Index management improvements:
- Bump INDEX_VERSION to 3: forces rebuild of v2 indexes with incompatible metadata semantics
- Add fileLastModified field: track file mtime for incremental change detection
- Add fileRelativePath field: enable sessionId -> file lookup (Codex session_meta.id override)
- mtime-driven incremental scan: re-read files with drifted mtime, restore unchanged from index
- Remove preserveExistingTitles: custom titles handled by HistoryLoadService.enhanceHistoryWithTitles()
- Accept uppercase UUID filenames, normalize to lowercase for consistency

Performance benefits:
- Lite-read avoids parsing entire JSONL for sessions with hundreds of messages
- Incremental scan only re-reads files that actually changed (mtime comparison)
- Index carries mtime from scan phase, avoiding redundant stat calls
- Pagination support: stat-first sorting before batch lite-read

Tests:
- SessionIndexSchemaTest: verify v3 index entry round-trip through Gson
- ClaudeHistoryIndexServiceTest: mtime drift detection, new file pickup, legacy entry refresh
- CodexHistoryIndexServiceTest: relative-path key matching, mtime propagation
- SessionLiteReaderTest/ClaudeSessionLiteReaderTest/CodexSessionLiteReaderTest: lite-read extraction
- PaginatedSessionLoadingTest: pagination with stat-first ordering

Files changed:
- SessionIndexManager: INDEX_VERSION bump, new fields in SessionIndexEntry
- ClaudeHistoryIndexService: ScanResult/ReadResult data classes, mtime-driven incrementalScanLite
- CodexHistoryIndexService: similar changes, removed preserveExistingTitles
- New lite-reader classes for both providers
- 6 new test classes covering core functionality