### PR TITLE
修复 Codex 会话中编辑面板误显示伪文件变更

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -144,6 +144,7 @@ class HistoryMessageInjector {
      * 只统一前端注入协议，不改变 Codex 历史文件格式与标题数据来源。
      */
     static List<JsonObject> convertCodexMessagesToFrontendBatch(JsonArray messages) {
+        CodexMessageConverter.clearSessionState();
         List<JsonObject> frontendMessages = new ArrayList<>();
         for (int i = 0; i < messages.size(); i++) {
             JsonObject msg = messages.get(i).getAsJsonObject();

--- a/webview/src/hooks/useFileChanges.test.ts
+++ b/webview/src/hooks/useFileChanges.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isLikelyFileChangePath } from './useFileChanges';
+
+describe('isLikelyFileChangePath', () => {
+  it('accepts normal relative, absolute, and special file names', () => {
+    expect(isLikelyFileChangePath('webview/src/App.tsx')).toBe(true);
+    expect(isLikelyFileChangePath('D:\\dev\\custom - xt\\TG Tool\\electron\\renderer\\src\\App.tsx')).toBe(true);
+    expect(isLikelyFileChangePath('.gitignore')).toBe(true);
+    expect(isLikelyFileChangePath('Dockerfile')).toBe(true);
+  });
+
+  it('rejects code fragments that should not appear in the edits panel', () => {
+    expect(isLikelyFileChangePath('JSON.parse(task.account_ids_json)')).toBe(false);
+    expect(isLikelyFileChangePath('((await response.json()) as ApiEnvelope<T> | { detail?: string })')).toBe(false);
+    expect(isLikelyFileChangePath('${Math.max(historyMeta.total_pages, 1)} 页`')).toBe(false);
+    expect(isLikelyFileChangePath('n${content.trim()}`')).toBe(false);
+  });
+});

--- a/webview/src/hooks/useFileChanges.ts
+++ b/webview/src/hooks/useFileChanges.ts
@@ -20,6 +20,24 @@ const LCS_MAX_LINES = 100;
 /** Cache for diff calculations to avoid redundant computations */
 const diffCache = new Map<string, { additions: number; deletions: number }>();
 const DIFF_CACHE_MAX_SIZE = 100;
+const KNOWN_EXTENSIONLESS_FILE_NAMES = new Set([
+  'authors',
+  'changelog',
+  'cname',
+  'contributors',
+  'dockerfile',
+  'gemfile',
+  'gradlew',
+  'guardfile',
+  'jenkinsfile',
+  'license',
+  'licence',
+  'makefile',
+  'procfile',
+  'rakefile',
+  'readme',
+  'vagrantfile',
+]);
 
 /**
  * Generate cache key from strings (using hash-like approach for large strings)
@@ -31,6 +49,47 @@ function getDiffCacheKey(oldString: string, newString: string): string {
   }
   // For larger strings, use length + first/last chars as key
   return `${oldString.length}:${newString.length}:${oldString.slice(0, 30)}:${oldString.slice(-20)}:${newString.slice(0, 30)}:${newString.slice(-20)}`;
+}
+
+function stripLineSuffix(filePath: string): string {
+  return filePath.replace(/:\d+(?:-\d+)?$/, '');
+}
+
+/**
+ * Filter out malformed "file paths" that are actually code snippets or
+ * streamed terminal text. This prevents the status panel from showing bogus
+ * edits such as `JSON.parse(...)` or template fragments.
+ */
+export function isLikelyFileChangePath(filePath: string | null | undefined): boolean {
+  if (typeof filePath !== 'string') {
+    return false;
+  }
+
+  const trimmed = filePath.trim();
+  if (!trimmed || /[\r\n\t]/.test(trimmed)) {
+    return false;
+  }
+
+  const normalizedPath = stripLineSuffix(trimmed);
+  const fileName = getFileName(normalizedPath) || normalizedPath;
+  const lowerFileName = fileName.toLowerCase();
+  const hasSeparator = /[\\/]/.test(normalizedPath);
+  const isAbsoluteWindowsPath = /^[A-Za-z]:[\\/]/.test(normalizedPath);
+  const isAbsoluteUnixPath = normalizedPath.startsWith('/');
+  const hasExtension = /\.[A-Za-z0-9][A-Za-z0-9._-]*$/.test(fileName) || fileName.startsWith('.');
+  const isKnownExtensionlessFile = KNOWN_EXTENSIONLESS_FILE_NAMES.has(lowerFileName);
+
+  if (!hasSeparator && !isAbsoluteWindowsPath && !isAbsoluteUnixPath && !hasExtension && !isKnownExtensionlessFile) {
+    return false;
+  }
+
+  // Reject obvious code/template fragments that can leak through malformed
+  // write events when no real path was attached.
+  if (!hasSeparator && !hasExtension && !isKnownExtensionlessFile && /[`$(){}]/.test(normalizedPath)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -232,7 +291,7 @@ export function useFileChanges({
         if (!input) return;
 
         const filePath = extractFilePath(input);
-        if (!filePath) return;
+        if (!filePath || !isLikelyFileChangePath(filePath)) return;
 
         // Check if operation completed successfully
         const result = findToolResult(block.id, messageIndex);


### PR DESCRIPTION
## 修复内容

修复了 Codex 会话中，未实际编辑文件时，右下角“编辑”面板仍出现代码片段、模板字符串等伪文件变更的问题。

## 原因分析

- 前端在提取文件变更时，部分非路径字符串被误识别为文件路径并展示到编辑面板中
- Codex 历史消息转换过程中，会话文件映射状态未及时清理，存在旧会话上下文串入新会话的风险

## 修改说明

- 在前端文件变更提取逻辑中增加伪路径过滤，屏蔽明显不是文件路径的代码片段
- 在 Codex 历史消息批量转换前清理会话文件映射状态
- 补充对应回归测试

## 验证情况

- 已通过 `webview` 前端测试
- 新增伪路径过滤回归测试
<img width="659" height="581" alt="Snipaste_2026-04-22_05-21-38" src="https://github.com/user-attachments/assets/aeda8998-005e-4bab-a14b-66b1ac800fb5" />
