### PR TITLE
fix(claude): drain stale iterator events between turns on persistent …

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -189,6 +189,60 @@ const _sessionCleanupTimer = setInterval(async () => {
 // unref() so the timer does not prevent natural process exit
 _sessionCleanupTimer.unref();
 
+/**
+ * Drain any events still buffered in the SDK iterator from a previous turn.
+ *
+ * When a persistent runtime is reused across turns, the SDK's async iterator
+ * may still hold events emitted after the previous turn's `result` message
+ * (late `content_block_delta`, trailing `assistant` snapshots, stream cleanup
+ * events). Without draining, the first `query.next()` of the NEW turn returns
+ * those stale events — and because `turnState.lastAssistantContent` is reset
+ * to '' at turn start, the full previous-turn text is re-emitted as a delta
+ * for the new turn, producing the "AI answered the previous question" bug.
+ *
+ * Uses Promise.race with a short timeout. Any promise abandoned via the race
+ * would, in the worst case, consume a single future SDK value — but this
+ * function is only called BEFORE the next user message is enqueued, so any
+ * such value is guaranteed to be a previous-turn straggler (nothing new can
+ * be produced by the SDK without new input). Losing it is therefore safe.
+ */
+async function drainPendingEvents(runtime, budgetMs = 50) {
+  if (!runtime || runtime.closed) return 0;
+  const deadline = Date.now() + budgetMs;
+  let drained = 0;
+  const timeoutSentinel = Symbol('drain-timeout');
+
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
+    let timeoutHandle;
+    const timeoutPromise = new Promise((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(timeoutSentinel), remaining);
+    });
+
+    let result;
+    try {
+      result = await Promise.race([runtime.query.next(), timeoutPromise]);
+    } catch (error) {
+      clearTimeout(timeoutHandle);
+      console.warn('[LIFECYCLE] drainPendingEvents encountered error: ' + (error?.message || error));
+      break;
+    }
+    clearTimeout(timeoutHandle);
+
+    if (result === timeoutSentinel) break;
+    if (result?.done) break;
+    drained++;
+    console.log('[LIFECYCLE] Drained stale event type=' + (result?.value?.type || 'unknown'));
+  }
+
+  if (drained > 0) {
+    console.log('[LIFECYCLE] Cleared ' + drained + ' carry-over event(s) before new turn');
+  }
+  return drained;
+}
+
 async function executeTurn(runtime, requestContext, turnMeta) {
   if (!runtime || runtime.closed) {
     const err = new Error('Runtime is closed');
@@ -207,6 +261,14 @@ async function executeTurn(runtime, requestContext, turnMeta) {
 
   try {
     beginRuntimeTurn(runtime);
+
+    // FIX: Clear any leftover events from a previous turn on this runtime
+    // before enqueueing the new user message. Prevents stale previous-turn
+    // content from being misattributed to the new turn.
+    if (runtime.hasCompletedTurn) {
+      await drainPendingEvents(runtime, 50);
+    }
+
     console.log('[MESSAGE_START]');
     runtime.inputStream.enqueue(requestContext.userMessage);
 
@@ -263,6 +325,10 @@ async function executeTurn(runtime, requestContext, turnMeta) {
         if (msg.is_error) {
           throw new Error(msg.result || msg.message || 'API request failed');
         }
+        // FIX: Mark this runtime as having completed a turn so that the NEXT
+        // turn's executeTurn drains any straggling events before enqueueing
+        // its user message.
+        runtime.hasCompletedTurn = true;
         break;
       }
     }
@@ -417,6 +483,9 @@ export const __testing = {
   },
   async executeTurn(runtime, requestContext, turnMeta = null) {
     return executeTurn(runtime, requestContext, turnMeta);
+  },
+  async drainPendingEvents(runtime, budgetMs = 50) {
+    return drainPendingEvents(runtime, budgetMs);
   },
   async cleanupAnonymousRuntimes() {
     return cleanupStaleAnonymousRuntimes({ registerActiveQueryResult, removeSession });

--- a/ai-bridge/services/claude/persistent-query-service.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.test.mjs
@@ -299,6 +299,139 @@ test('executeTurn refreshes lastUsedAt while processing query events', async () 
   assert.ok(runtime.lastUsedAt > 1);
 });
 
+test('drainPendingEvents consumes all buffered events before a timeout', async () => {
+  const calls = [];
+  const runtime = {
+    closed: false,
+    query: {
+      async next() {
+        calls.push(Date.now());
+        if (calls.length <= 3) {
+          return { done: false, value: { type: 'stream_event', event: { type: 'content_block_delta' } } };
+        }
+        // After draining 3 buffered events, simulate no more events by hanging.
+        return new Promise(() => {});
+      }
+    }
+  };
+
+  const drained = await __testing.drainPendingEvents(runtime, 50);
+  assert.equal(drained, 3);
+  assert.ok(calls.length >= 4); // 3 drained + 1 hanging call that triggered the timeout
+});
+
+test('drainPendingEvents returns 0 for a closed runtime', async () => {
+  const runtime = { closed: true, query: { async next() { throw new Error('must not be called'); } } };
+  const drained = await __testing.drainPendingEvents(runtime, 50);
+  assert.equal(drained, 0);
+});
+
+test('drainPendingEvents stops at done:true', async () => {
+  let i = 0;
+  const runtime = {
+    closed: false,
+    query: {
+      async next() {
+        i++;
+        if (i === 1) return { done: false, value: { type: 'assistant' } };
+        return { done: true, value: undefined };
+      }
+    }
+  };
+  const drained = await __testing.drainPendingEvents(runtime, 1000);
+  assert.equal(drained, 1);
+  assert.equal(i, 2);
+});
+
+test('executeTurn drains stale previous-turn events before processing new turn', async () => {
+  // Scenario: previous turn left 2 straggling events in the iterator.
+  // With hasCompletedTurn=true, these must be drained BEFORE the main loop
+  // starts processing the new turn, so they don't pollute turnState.
+  const staleAssistant1 = { type: 'assistant', message: { content: [{ type: 'text', text: 'STALE PREVIOUS ANSWER' }] } };
+  const staleAssistant2 = { type: 'assistant', message: { content: [{ type: 'text', text: 'STALE PREVIOUS ANSWER continued' }] } };
+  const newAssistant = { type: 'assistant', message: { content: [{ type: 'text', text: 'fresh reply' }] } };
+  const resultMsg = { type: 'result', is_error: false };
+
+  // Custom factory: first 2 calls return stale events immediately, call 3
+  // hangs forever (simulating the SDK with no more buffered events — drain
+  // times out here), then calls 4+ return new-turn events to the main loop.
+  let callCount = 0;
+  const queryFn = ({ prompt, options }) => {
+    const q = {
+      prompt,
+      options,
+      closed: false,
+      setPermissionMode: async () => {},
+      setModel: async () => {},
+      setMaxThinkingTokens: async () => {},
+      close() { this.closed = true; },
+      async next() {
+        callCount++;
+        if (callCount === 1) return { done: false, value: staleAssistant1 };
+        if (callCount === 2) return { done: false, value: staleAssistant2 };
+        if (callCount === 3) return new Promise(() => {}); // hangs; drain times out
+        if (callCount === 4) return { done: false, value: newAssistant };
+        return { done: false, value: resultMsg };
+      }
+    };
+    return q;
+  };
+  __testing.setQueryFn(queryFn);
+
+  const context = await __testing.buildRequestContext({
+    sessionId: 'session-drain',
+    runtimeSessionEpoch: 'epoch-drain',
+    cwd: process.cwd(),
+    message: 'new question',
+    streaming: true
+  }, false);
+  const runtime = await __testing.acquireRuntime(context);
+  // Simulate that this runtime has already completed one turn.
+  runtime.hasCompletedTurn = true;
+
+  const turnMeta = { state: null };
+  await __testing.executeTurn(runtime, context, turnMeta);
+
+  // After drain, the main loop should have only seen newAssistant + result.
+  // turnState.lastAssistantContent should contain only 'fresh reply',
+  // never the stale previous-turn text.
+  assert.equal(turnMeta.state.lastAssistantContent, 'fresh reply');
+  assert.ok(!turnMeta.state.lastAssistantContent.includes('STALE'));
+  // Drain took calls 1-3 (3rd hung until timeout), main loop took calls 4-5.
+  assert.equal(callCount, 5);
+});
+
+test('executeTurn skips drain on a first-turn runtime (hasCompletedTurn=false)', async () => {
+  // Scenario: a brand-new runtime has not completed any turn yet.
+  // Drain must NOT run — there's nothing to drain, and calling next()
+  // before enqueueing the user message would hang the iterator.
+  const newAssistant = { type: 'assistant', message: { content: [{ type: 'text', text: 'first reply' }] } };
+  const resultMsg = { type: 'result', is_error: false };
+
+  const factory = createSequencedQueryFactory([
+    { done: false, value: newAssistant },
+    { done: false, value: resultMsg }
+  ]);
+  __testing.setQueryFn(factory.queryFn);
+
+  const context = await __testing.buildRequestContext({
+    sessionId: 'session-first',
+    runtimeSessionEpoch: 'epoch-first',
+    cwd: process.cwd(),
+    message: 'first message',
+    streaming: true
+  }, false);
+  const runtime = await __testing.acquireRuntime(context);
+  assert.equal(runtime.hasCompletedTurn, undefined, 'new runtime should not have hasCompletedTurn set');
+
+  const turnMeta = { state: null };
+  await __testing.executeTurn(runtime, context, turnMeta);
+
+  assert.equal(turnMeta.state.lastAssistantContent, 'first reply');
+  // After a successful turn, runtime should be flagged.
+  assert.equal(runtime.hasCompletedTurn, true);
+});
+
 test('abortCurrentTurn still disposes an active runtime explicitly', async () => {
   const nextDeferred = createDeferred();
   const enteredDeferred = createDeferred();

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -55,6 +55,28 @@ export function processStreamEvent(msg, turnState) {
   }
 }
 
+// FIX (defensive): Flag suspiciously large first-emission deltas in a
+// streaming-enabled turn where no stream_event has arrived yet. In normal
+// streaming this shouldn't happen — content_block_delta events should
+// populate lastAssistantContent incrementally. A large initial jump from ''
+// suggests the iterator leaked a full-text `assistant` message from a
+// previous turn. Only logs; does not alter behavior.
+const SUSPICIOUS_INITIAL_DELTA_CHARS = 2000;
+
+function warnOnSuspiciousInitialDelta(turnState, delta, kind) {
+  if (
+    turnState.streamingEnabled &&
+    !turnState.hasStreamEvents &&
+    delta.length > SUSPICIOUS_INITIAL_DELTA_CHARS &&
+    turnState.lastAssistantContent.length === 0 &&
+    turnState.lastThinkingContent.length === 0
+  ) {
+    console.warn('[DEFENSIVE] Large initial ' + kind + ' delta without prior stream events ('
+      + delta.length + ' chars). Possible stale content leak from previous turn. Preview='
+      + JSON.stringify(delta.slice(0, 120)));
+  }
+}
+
 export function processMessageContent(msg, turnState) {
   if (msg.type !== 'assistant') return;
   const content = msg.message?.content;
@@ -66,6 +88,7 @@ export function processMessageContent(msg, turnState) {
         if (turnState.streamingEnabled && !turnState.hasStreamEvents && currentText.length > turnState.lastAssistantContent.length) {
           const delta = currentText.substring(turnState.lastAssistantContent.length);
           if (delta) {
+            warnOnSuspiciousInitialDelta(turnState, delta, 'text');
             process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastAssistantContent = currentText;
@@ -81,6 +104,7 @@ export function processMessageContent(msg, turnState) {
         if (turnState.streamingEnabled && !turnState.hasStreamEvents && thinkingText.length > turnState.lastThinkingContent.length) {
           const delta = thinkingText.substring(turnState.lastThinkingContent.length);
           if (delta) {
+            warnOnSuspiciousInitialDelta(turnState, delta, 'thinking');
             process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastThinkingContent = thinkingText;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -123,9 +123,31 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     setMessages((prev) => {
       const last = prev[prev.length - 1];
       if (last?.type === 'assistant' && last?.isStreaming) {
+        // FIX: If the last streaming assistant belongs to an OLDER turn,
+        // its onStreamEnd was likely dropped (e.g., JCEF async chain
+        // breakage). Finalize it (isStreaming=false) and start a fresh
+        // assistant for the new turn, so new deltas are not appended
+        // to the previous turn's bubble.
+        const lastTurnId = (last as { __turnId?: number }).__turnId;
+        const currentTurnId = streamingTurnIdRef.current;
+        if (typeof lastTurnId === 'number' && lastTurnId > 0 && lastTurnId < currentTurnId) {
+          const finalized = [...prev];
+          finalized[prev.length - 1] = { ...last, isStreaming: false };
+          streamingMessageIndexRef.current = finalized.length;
+          return [
+            ...finalized,
+            {
+              type: 'assistant',
+              content: '',
+              isStreaming: true,
+              timestamp: new Date().toISOString(),
+              __turnId: currentTurnId,
+            },
+          ];
+        }
         streamingMessageIndexRef.current = prev.length - 1;
         const updated = [...prev];
-        updated[prev.length - 1] = { ...updated[prev.length - 1], __turnId: streamingTurnIdRef.current };
+        updated[prev.length - 1] = { ...updated[prev.length - 1], __turnId: currentTurnId };
         return updated;
       }
       streamingMessageIndexRef.current = prev.length;


### PR DESCRIPTION
…runtime

The persistent Claude runtime reuses the same async iterator across turns. When executeTurn broke on a result message, events still buffered inside the SDK iterator were not drained. The next turn's first query.next() returned those stale events, and because turnState.lastAssistantContent resets to '' at turn start, the previous-turn text was re-emitted as a large CONTENT_DELTA for the new turn — producing the "AI answered the previous question" bug when sending from an idle state.

- Add drainPendingEvents helper (Promise.race with 50ms budget) that clears buffered events before enqueueing the new user message, gated on runtime.hasCompletedTurn to avoid hanging on first-turn runtimes.
- Set runtime.hasCompletedTurn=true on successful result break.
- Add defensive warnOnSuspiciousInitialDelta logging for large first deltas emitted without prior stream events (leak detector).
- Finalize stale previous-turn streaming assistant in onStreamStart (when onStreamEnd was dropped by JCEF) so new deltas land on a fresh bubble rather than appending to the previous turn's message.
- Regression tests covering drain behavior, first-turn gating, and end-to-end executeTurn isolation.